### PR TITLE
Enable Spegel scaling during GitHub container registry outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#68](https://github.com/XenitAB/spegel/pull/68) Enable Spegel scaling during GitHub container registry outage. 
+
 ### Changed
 
 - [#82](https://github.com/XenitAB/spegel/pull/82) Filter out localhost from advertised IPs.

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -74,6 +74,7 @@ spec:
 | service.registry.port | int | `5000` | Port to expose the registry via the service. |
 | service.registry.topologyAwareHintsEnabled | bool | `true` | If true adds topology aware hints annotation to node port service. |
 | service.router.port | int | `5001` | Port to expose the router via the service. |
+| service.webhook.port | int | `443` | Port to expose the mutating webhook. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | serviceMonitor.enabled | bool | `false` | If true creates a Prometheus Service Monitor. |
@@ -85,4 +86,6 @@ spec:
 | spegel.imageFilter | string | `""` | Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel. |
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io"]` | Registries for which mirror configuration will be created. |
+| spegel.selfBootstrap | bool | `true` | If true Spegel will mutate it's init containers image registry to pull from self. selfBootstrap: true |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |
+| webhook.timeoutSeconds | int | `5` | Timeout for mutating webhook. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -64,22 +64,27 @@ spec:
           - --registry-addr=:{{ .Values.service.registry.port }}
           - --router-addr=:{{ .Values.service.router.port }}
           - --metrics-addr=:{{ .Values.service.metrics.port }}
+          - --containerd-sock={{ .Values.spegel.containerdSock }}
+          - --containerd-namespace={{ .Values.spegel.containerdNamespace }}
+          - --leader-election-namespace={{ .Release.Namespace }}
+          - --leader-election-name={{ .Release.Namespace }}-leader-election
           {{- with .Values.spegel.registries }}
           - --registries
           {{- range . }}
           - {{ . | quote }}
           {{- end }}
           {{- end }}
-          - --containerd-sock={{ .Values.spegel.containerdSock }}
-          - --containerd-namespace={{ .Values.spegel.containerdNamespace }}
           {{- with .Values.spegel.kubeconfigPath }}
           - --kubeconfig-path={{ . }}
           {{- end }}
-          - --leader-election-namespace={{ .Release.Namespace }}
-          - --leader-election-name={{ .Release.Namespace }}-leader-election
           {{- with .Values.spegel.imageFilter }}
           - --image-filter
           - {{ . | quote }}
+          {{- end }}
+          {{- if .Values.spegel.selfBootstrap }}
+          - --self-bootstrap-enabled=true
+          - --webhook-addr=:{{ .Values.service.webhook.port }}
+          - --self-bootstrap-addr=127.0.0.1:{{ .Values.service.registry.nodePort }}          
           {{- end }}
         ports:
           - name: registry
@@ -93,6 +98,11 @@ spec:
           - name: metrics
             containerPort: {{ .Values.service.metrics.port }}
             protocol: TCP
+          {{- if .Values.spegel.selfBootstrap }}
+          - name: webhook
+            containerPort: {{ .Values.service.webhook.port }}
+            protocol: TCP
+          {{- end }}
         # Startup may take a bit longer on bootsrap as Pods need to find each other.
         # This is why the startup proben is a bit more forgiving, while hitting the endpoint more often.
         startupProbe:
@@ -108,6 +118,11 @@ spec:
         volumeMounts:
           - name: containerd-sock
             mountPath: {{ .Values.spegel.containerdSock }}
+        {{- if .Values.spegel.selfBootstrap }}
+          - name: tls
+            mountPath: "/etc/admission-webhook/tls"
+            readOnly: true
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
@@ -119,6 +134,11 @@ spec:
           hostPath:
             path: {{ .Values.spegel.containerdRegistryConfigPath }}
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if .Values.spegel.selfBootstrap }}
+        - name: tls
+          secret:
+            secretName: {{ include "spegel.fullname" . }}-tls
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/spegel/templates/mutating-webhook-configuration.yaml
+++ b/charts/spegel/templates/mutating-webhook-configuration.yaml
@@ -1,0 +1,56 @@
+{{- $ca := genCA "spegel-ca" 3650 -}}
+{{- $cn := printf "%s.%s.svc" ( include "spegel.fullname" . ) .Release.Namespace -}}
+{{- $san := list ( printf "%s" ( include "spegel.fullname" . ) ) ( printf "%s.%s" ( include "spegel.fullname" . ) .Release.Namespace ) ( printf "%s.%s.svc" ( include "spegel.fullname" . ) .Release.Namespace ) -}}
+{{- $cert := genSignedCert $cn nil $san 3650 $ca -}}
+{{- if .Values.spegel.selfBootstrap }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "spegel.fullname" . }}
+  labels:
+    {{- include "spegel.labels" . | nindent 4 }}
+webhooks:
+  - name: "deployment-mutation.production.svc"
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: 
+            - {{ .Release.Namespace }}
+    objectSelector:
+      matchLabels:
+        {{- include "spegel.selectorLabels" . | nindent 8 }}
+    rules:
+      - operations: 
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods
+        scope: "Namespaced"
+    clientConfig:
+      caBundle: {{ $ca.Cert | b64enc | quote }}
+      service:
+        name: {{ include "spegel.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+        path: "/v1/mutate"
+    admissionReviewVersions: ["v1"]
+    matchPolicy: Exact
+    sideEffects: None
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spegel.fullname" . }}-tls
+  labels:
+    {{- include "spegel.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -12,6 +12,12 @@ spec:
       port: {{ .Values.service.metrics.port }}
       targetPort: metrics
       protocol: TCP
+    {{- if .Values.spegel.selfBootstrap }}
+    - name: webhook
+      port: 443
+      targetPort: webhook
+      protocol: TCP
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -37,6 +37,9 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  webhook:
+    # -- Port to expose the mutating webhook.
+    port: 8443
   registry:
     # -- Port to expose the registry via the service.
     port: 5000
@@ -90,6 +93,10 @@ serviceMonitor:
 # -- Priority class name to use for the pod.
 priorityClassName: system-node-critical
 
+webhook:
+  # -- Timeout for mutating webhook.
+  timeoutSeconds: 5
+
 spegel:
   # -- Registries for which mirror configuration will be created.
   registries:
@@ -105,13 +112,16 @@ spegel:
   extraMirrorRegistries: []
   # -- Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel.
   imageFilter: ""
+  # -- If true Spegel will add mirror configuration to the node.
+  containerdMirrorAdd: true
+  # -- If true Spegel will mutate it's init containers image registry to pull from self.
+  # selfBootstrap: true
+  selfBootstrap: true
   # -- Path to Containerd socket.
   containerdSock: "/run/containerd/containerd.sock"
   # -- Containerd namespace where images are stored.
   containerdNamespace: "k8s.io"
   # -- Path to Containerd mirror configuration.
   containerdRegistryConfigPath: "/etc/containerd/certs.d"
-  # -- If true Spegel will add mirror configuration to the node.
-  containerdMirrorAdd: true
   # -- Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC.
   kubeconfigPath: ""

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/xenitab/pkg/kubernetes v0.0.3
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.1.0
+	k8s.io/api v0.26.3
 	k8s.io/client-go v0.26.3
 )
 
@@ -199,7 +200,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.3 // indirect
 	k8s.io/apimachinery v0.26.3 // indirect
 	k8s.io/helm v2.17.0+incompatible // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,124 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd/reference"
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/go-logr/logr"
+	pkggin "github.com/xenitab/pkg/gin"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/xenitab/spegel/internal/routing"
+)
+
+type Webhook struct {
+	srv *http.Server
+}
+
+func NewWebhook(ctx context.Context, addr string, selfBootstrapAddr string, router routing.Router) (*Webhook, error) {
+	log := logr.FromContextOrDiscard(ctx).WithName("webhook")
+	webhookHandler := &WebhookHandler{
+		selfBootstrapAddr: selfBootstrapAddr,
+		router:            router,
+	}
+	cfg := pkggin.Config{
+		LogConfig: pkggin.LogConfig{
+			Logger:          log,
+			IncludeLatency:  true,
+			IncludeClientIP: true,
+			IncludeKeys:     []string{"handler"},
+		},
+		MetricsConfig: pkggin.MetricsConfig{
+			Service: "webhook",
+		},
+	}
+	engine := pkggin.NewEngine(cfg)
+	engine.POST("/v1/mutate", webhookHandler.mutateHandler)
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: engine,
+	}
+	return &Webhook{
+		srv: srv,
+	}, nil
+}
+
+func (w *Webhook) ListenAndServe(ctx context.Context) error {
+	if err := w.srv.ListenAndServeTLS("/etc/admission-webhook/tls/tls.crt", "/etc/admission-webhook/tls/tls.key"); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func (w *Webhook) Shutdown() error {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return w.srv.Shutdown(shutdownCtx)
+}
+
+type WebhookHandler struct {
+	selfBootstrapAddr string
+	router            routing.Router
+}
+
+func (w *WebhookHandler) mutateHandler(ctx *gin.Context) {
+	requestReview := &admissionv1.AdmissionReview{}
+	ctx.MustBindWith(requestReview, binding.JSON)
+	if requestReview.Request == nil {
+		ctx.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+	pod := &corev1.Pod{}
+	err := json.Unmarshal(requestReview.Request.Object.Raw, pod)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	responseReview := admissionv1.AdmissionReview{
+		TypeMeta: requestReview.TypeMeta,
+		Response: &admissionv1.AdmissionResponse{
+			UID:     requestReview.Request.UID,
+			Allowed: true,
+		},
+	}
+
+	if len(pod.Spec.InitContainers) != 1 {
+		ctx.JSON(http.StatusOK, responseReview)
+		return
+	}
+	c := pod.Spec.InitContainers[0]
+	ref, err := reference.Parse(c.Image)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	_, ok, err := w.router.Resolve(ctx, ref, true)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	if !ok {
+		ctx.JSON(http.StatusOK, responseReview)
+		return
+	}
+	localImage := fmt.Sprintf("%s%s", w.selfBootstrapAddr, trimHostname(ref))
+	patch := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/initContainers/0/image", "value": "%s" }]`, localImage)
+	responseReview.Response.Patch = []byte(patch)
+	pt := admissionv1.PatchTypeJSONPatch
+	responseReview.Response.PatchType = &pt
+	ctx.JSON(http.StatusOK, responseReview)
+}
+
+func trimHostname(ref reference.Spec) string {
+	return strings.TrimPrefix(ref.String(), ref.Hostname())
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,63 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/reference"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestShouldPatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected bool
+	}{
+		{
+			name:     "identical image",
+			image:    "ghcr.io/xenitab/spegel:v0.0.5",
+			expected: true,
+		},
+		{
+			name:     "different registry",
+			image:    "docker.io/xenitab/spegel:v0.0.5",
+			expected: true,
+		},
+		{
+			name:     "wrong version",
+			image:    "ghcr.io/xenitab/spegel:v0.0.4",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := reference.Parse("ghcr.io/xenitab/spegel:v0.0.5")
+			require.NoError(t, err)
+			pod := corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Image: tt.image,
+						},
+					},
+				},
+			}
+			ok := shouldPatch(&pod, ref)
+			require.Equal(t, tt.expected, ok)
+		})
+	}
+}
+
+func TestShouldPatchTooManyContainers(t *testing.T) {
+	pod := corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{},
+				{},
+			},
+		},
+	}
+	ok := shouldPatch(&pod, reference.Spec{})
+	require.False(t, ok)
+}


### PR DESCRIPTION
This change introduces a mutating webhook in Spegel. The purpose of this webhook is to change the registry of the Spegel image in the init container from `ghcr.io` to `localhost:30021`. When this is done the Spegel image will be pulled from locally within the cluster, instead of from GHCR. 

When Spegel is first installed there will be no instance to mutate any Spegel Pod. This is by design as there is no Spegel instance to serve the image on `localhost:30021`. When Spegel is up an running the mutation will kick in, if there is a Spegel instance that can mutate the image there will be a Spegel image that can be served.

Fixes #2 