### PR TITLE
Add retry mirroring to new peer if current peer fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#125](https://github.com/XenitAB/spegel/pull/125) Add retry mirroring to new peer if current peer fails.
+
 ### Changed
 
 - [#107](https://github.com/XenitAB/spegel/pull/107) Refactor image references with generic implementation.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,143 @@
+package registry
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"github.com/xenitab/spegel/internal/routing"
+)
+
+type TestResponseRecorder struct {
+	*httptest.ResponseRecorder
+	closeChannel chan bool
+}
+
+func (r *TestResponseRecorder) CloseNotify() <-chan bool {
+	return r.closeChannel
+}
+
+//nolint:unused // ignore
+func (r *TestResponseRecorder) closeClient() {
+	r.closeChannel <- true
+}
+
+func CreateTestResponseRecorder() *TestResponseRecorder {
+	return &TestResponseRecorder{
+		httptest.NewRecorder(),
+		make(chan bool, 1),
+	}
+}
+
+func TestMirrorHandler(t *testing.T) {
+	badSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("foo", "bar")
+		if r.Method == http.MethodGet {
+			//nolint:errcheck // ignore
+			w.Write([]byte("hello world"))
+		}
+	}))
+	defer badSvr.Close()
+	goodSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("foo", "bar")
+		if r.Method == http.MethodGet {
+			//nolint:errcheck // ignore
+			w.Write([]byte("hello world"))
+		}
+	}))
+	defer goodSvr.Close()
+
+	resolver := map[string][]string{
+		"no-working-peers":  {badSvr.URL, "foo", badSvr.URL},
+		"first-peer":        {goodSvr.URL, badSvr.URL, badSvr.URL},
+		"first-peer-error":  {"foo", goodSvr.URL},
+		"last-peer-working": {badSvr.URL, badSvr.URL, goodSvr.URL},
+	}
+	router := routing.NewMockRouter(resolver)
+	handler := RegistryHandler{
+		log:           logr.Discard(),
+		router:        router,
+		mirrorRetries: 3,
+	}
+
+	tests := []struct {
+		name            string
+		key             string
+		expectedStatus  int
+		expectedBody    string
+		expectedHeaders map[string][]string
+	}{
+		{
+			name:            "request should timeout when no peers exists",
+			key:             "no-peers",
+			expectedStatus:  http.StatusNotFound,
+			expectedBody:    "",
+			expectedHeaders: nil,
+		},
+		{
+			name:            "request should not timeout and give 500 if all peers fail",
+			key:             "no-working-peers",
+			expectedStatus:  http.StatusInternalServerError,
+			expectedBody:    "",
+			expectedHeaders: nil,
+		},
+		{
+			name:            "request should work when first peer responds",
+			key:             "first-peer",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "hello world",
+			expectedHeaders: map[string][]string{"foo": {"bar"}},
+		},
+		{
+			name:            "second peer should respond when first gives error",
+			key:             "first-peer-error",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "hello world",
+			expectedHeaders: map[string][]string{"foo": {"bar"}},
+		},
+		{
+			name:            "last peer should respond when two first fail",
+			key:             "last-peer-working",
+			expectedStatus:  http.StatusOK,
+			expectedBody:    "hello world",
+			expectedHeaders: map[string][]string{"foo": {"bar"}},
+		},
+	}
+	for _, tt := range tests {
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			t.Run(tt.name, func(t *testing.T) {
+				rw := CreateTestResponseRecorder()
+				c, _ := gin.CreateTestContext(rw)
+				target := fmt.Sprintf("http://example.com/%s", tt.key)
+				c.Request = httptest.NewRequest(method, target, nil)
+				handler.handleMirror(c, tt.key)
+
+				resp := rw.Result()
+				defer resp.Body.Close()
+				b, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+				if method == http.MethodGet {
+					require.Equal(t, tt.expectedBody, string(b))
+				}
+				if method == http.MethodHead {
+					require.Equal(t, "", string(b))
+				}
+
+				if tt.expectedHeaders == nil {
+					require.Len(t, resp.Header, 0)
+				}
+				for k, v := range tt.expectedHeaders {
+					require.Equal(t, v, resp.Header.Values(k))
+				}
+			})
+		}
+	}
+}

--- a/internal/routing/mock.go
+++ b/internal/routing/mock.go
@@ -1,0 +1,39 @@
+package routing
+
+import (
+	"context"
+)
+
+type MockRouter struct {
+	resolver map[string][]string
+}
+
+func NewMockRouter(resolver map[string][]string) *MockRouter {
+	return &MockRouter{
+		resolver: resolver,
+	}
+}
+
+func (m *MockRouter) Close() error {
+	return nil
+}
+
+func (m *MockRouter) Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan string, error) {
+	peerCh := make(chan string, count)
+	peers, ok := m.resolver[key]
+	// Not found will look forever until timeout.
+	if !ok {
+		return peerCh, nil
+	}
+	go func() {
+		for _, peer := range peers {
+			peerCh <- peer
+		}
+		close(peerCh)
+	}()
+	return peerCh, nil
+}
+
+func (m *MockRouter) Advertise(ctx context.Context, keys []string) error {
+	return nil
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,0 +1,14 @@
+package routing
+
+import (
+	"context"
+	"time"
+)
+
+const KeyTTL = 10 * time.Minute
+
+type Router interface {
+	Close() error
+	Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan string, error)
+	Advertise(ctx context.Context, keys []string) error
+}


### PR DESCRIPTION
Currently Spegel will only try to mirror a request once. There are several reasons a request may fail to a peer, ideally it should try the next peer. This change implements a retry logic which tries three different peers before returning an error, on the condition that the peer is returned either before the request times out or the resolve timeout is hit.

Fixes #1 