### PR TITLE
Implement support to disable registry filtering in Containerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#747](https://github.com/spegel-org/spegel/pull/747) Update Go to 1.23.6.
 - [#750](https://github.com/spegel-org/spegel/pull/750) Rename append mirrors to prepend existing.
+- [#373](https://github.com/spegel-org/spegel/pull/373) Apply mirror configuration on all registires by default.
 
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -52,10 +52,10 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
-| spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
+| spegel.mirrorResolveRetries | int | `3` | Max amount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |
+| spegel.mirroredRegistries | list | `[]` | Registries for which mirror configuration will be created. Empty means all registires will be mirrored. |
 | spegel.prependExisting | bool | `false` | When true existing mirror configuration will be kept and Spegel will prepend it's configuration. |
-| spegel.registries | list | `["https://cgr.dev","https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io","https://lscr.io"]` | Registries for which mirror configuration will be created. |
 | spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | spegel.resolveTags | bool | `true` | When true Spegel will resolve tags to digests. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -43,13 +43,13 @@ spec:
           - configuration
           - --log-level={{ .Values.spegel.logLevel }}
           - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
-          {{- with .Values.spegel.registries }}
-          - --registries
+          {{- with .Values.spegel.mirroredRegistries }}
+          - --mirrored-registries
           {{- range . }}
           - {{ . | quote }}
           {{- end }}
           {{- end }}
-          - --mirror-registries
+          - --mirror-targets
           - http://$(NODE_IP):{{ .Values.service.registry.hostPort }}
           - http://$(NODE_IP):{{ .Values.service.registry.nodePort }}
           {{- with .Values.spegel.additionalMirrorRegistries }}
@@ -83,7 +83,7 @@ spec:
           - --router-addr=:{{ .Values.service.router.port }}
           - --metrics-addr=:{{ .Values.service.metrics.port }}
           {{- with .Values.spegel.registries }}
-          - --registries
+          - --mirrored-registries
           {{- range . }}
           - {{ . | quote }}
           {{- end }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -136,21 +136,13 @@ priorityClassName: system-node-critical
 spegel:
   # -- Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR.
   logLevel: "INFO"
-  # -- Registries for which mirror configuration will be created.
-  registries:
-    - https://cgr.dev
-    - https://docker.io
-    - https://ghcr.io
-    - https://quay.io
-    - https://mcr.microsoft.com
-    - https://public.ecr.aws
-    - https://gcr.io
-    - https://registry.k8s.io
-    - https://k8s.gcr.io
-    - https://lscr.io
+  # -- Registries for which mirror configuration will be created. Empty means all registires will be mirrored.
+  mirroredRegistries: []
+    # - https://docker.io
+    # - https://ghcr.io
   # -- Additional target mirror registries other than Spegel.
   additionalMirrorRegistries: []
-  # -- Max ammount of mirrors to attempt.
+  # -- Max amount of mirrors to attempt.
   mirrorResolveRetries: 3
   # -- Max duration spent finding a mirror.
   mirrorResolveTimeout: "20ms"


### PR DESCRIPTION
Some users may want to mirror all images without specifying a registry. This change modifies the filtering regex to allow for an empty filter registries list. Images will still be filtered however to contain a registry in the reference.

This change would resolve a k3s specific use case for now, but should be supported as an option in Spegel also.
https://github.com/k3s-io/k3s/issues/9590