### PR TITLE
Update org imports from xenitab to spegel-org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#376](https://github.com/spegel-org/spegel/pull/376) Change go directive to 1.21.
 - [#383](https://github.com/spegel-org/spegel/pull/383) Bump libp2p to v0.33.0, replace deprecated Pretty function
 - [#397](https://github.com/spegel-org/spegel/pull/397) Replace CopyLayer with GetBlob.
+- [#400](https://github.com/spegel-org/spegel/pull/400) Update org imports from xenitab to spegel-org.
 
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xenitab/spegel
+module github.com/spegel-org/spegel
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -22,12 +22,12 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
 
-	"github.com/xenitab/spegel/pkg/metrics"
-	"github.com/xenitab/spegel/pkg/oci"
-	"github.com/xenitab/spegel/pkg/registry"
-	"github.com/xenitab/spegel/pkg/routing"
-	"github.com/xenitab/spegel/pkg/state"
-	"github.com/xenitab/spegel/pkg/throttle"
+	"github.com/spegel-org/spegel/pkg/metrics"
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/registry"
+	"github.com/spegel-org/spegel/pkg/routing"
+	"github.com/spegel-org/spegel/pkg/state"
+	"github.com/spegel-org/spegel/pkg/throttle"
 )
 
 type ConfigurationCmd struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -18,10 +18,10 @@ import (
 	"github.com/opencontainers/go-digest"
 	pkggin "github.com/xenitab/pkg/gin"
 
-	"github.com/xenitab/spegel/pkg/metrics"
-	"github.com/xenitab/spegel/pkg/oci"
-	"github.com/xenitab/spegel/pkg/routing"
-	"github.com/xenitab/spegel/pkg/throttle"
+	"github.com/spegel-org/spegel/pkg/metrics"
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/routing"
+	"github.com/spegel-org/spegel/pkg/throttle"
 )
 
 const (

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 
-	"github.com/xenitab/spegel/pkg/routing"
+	"github.com/spegel-org/spegel/pkg/routing"
 )
 
 type TestResponseRecorder struct {

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -22,7 +22,7 @@ import (
 	mc "github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
 
-	"github.com/xenitab/spegel/pkg/metrics"
+	"github.com/spegel-org/spegel/pkg/metrics"
 )
 
 const KeyTTL = 10 * time.Minute

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -9,9 +9,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/xenitab/pkg/channels"
 
-	"github.com/xenitab/spegel/pkg/metrics"
-	"github.com/xenitab/spegel/pkg/oci"
-	"github.com/xenitab/spegel/pkg/routing"
+	"github.com/spegel-org/spegel/pkg/metrics"
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/routing"
 )
 
 func Track(ctx context.Context, ociClient oci.Client, router routing.Router, resolveLatestTag bool) error {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/xenitab/spegel/pkg/oci"
-	"github.com/xenitab/spegel/pkg/routing"
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/routing"
 )
 
 func TestBasic(t *testing.T) {

--- a/test/benchmark/go.mod
+++ b/test/benchmark/go.mod
@@ -1,4 +1,4 @@
-module github.com/xenitab/spegel/test/benchmark
+module github.com/spegel-org/spegel/test/benchmark
 
 go 1.21.3
 


### PR DESCRIPTION
Updates the org for all local imports.

Part of #374 