### PR TITLE
Update tests to use spegel-org instead of xenitab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#383](https://github.com/spegel-org/spegel/pull/383) Bump libp2p to v0.33.0, replace deprecated Pretty function
 - [#397](https://github.com/spegel-org/spegel/pull/397) Replace CopyLayer with GetBlob.
 - [#400](https://github.com/spegel-org/spegel/pull/400) Update org imports from xenitab to spegel-org.
+- [#402](https://github.com/spegel-org/spegel/pull/402) Update tests to use spegel-org instead of xenitab.
 
 ### Deprecated
 

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -78,6 +78,6 @@ func TestParseImageDigestDoesNotMatch(t *testing.T) {
 }
 
 func TestParseImageNoTagOrDigest(t *testing.T) {
-	_, err := Parse("ghcr.io/xenitab/spegel", digest.Digest(""))
+	_, err := Parse("ghcr.io/spegel-org/spegel", digest.Digest(""))
 	require.EqualError(t, err, "image needs to contain a digest")
 }

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -149,7 +149,7 @@ func TestOCIClient(t *testing.T) {
 				expectedKeys []string
 			}{
 				{
-					imageName:   "ghcr.io/xenitab/spegel:v0.0.8-with-media-type",
+					imageName:   "ghcr.io/spegel-org/spegel:v0.0.8-with-media-type",
 					imageDigest: "sha256:9506c8e7a2d0a098d43cadfd7ecdc3c91697e8188d3a1245943b669f717747b4",
 					expectedKeys: []string{
 						"sha256:9506c8e7a2d0a098d43cadfd7ecdc3c91697e8188d3a1245943b669f717747b4",
@@ -195,7 +195,7 @@ func TestOCIClient(t *testing.T) {
 					},
 				},
 				{
-					imageName:   "ghcr.io/xenitab/spegel:v0.0.8-without-media-type",
+					imageName:   "ghcr.io/spegel-org/spegel:v0.0.8-without-media-type",
 					imageDigest: "sha256:d8df04365d06181f037251de953aca85cc16457581a8fc168f4957c978e1008b",
 					expectedKeys: []string{
 						"sha256:d8df04365d06181f037251de953aca85cc16457581a8fc168f4957c978e1008b",

--- a/pkg/oci/testdata/images.json
+++ b/pkg/oci/testdata/images.json
@@ -5,17 +5,17 @@
     "digest": "sha256:9430beb291fa7b96997711fc486bc46133c719631aefdbeebe58dd3489217bfe"
   },
   {
-    "name": "ghcr.io/xenitab/spegel:v0.0.8",
+    "name": "ghcr.io/spegel-org/spegel:v0.0.8",
     "mediaType": "application/vnd.oci.image.index.v1+json",
     "digest": "sha256:9506c8e7a2d0a098d43cadfd7ecdc3c91697e8188d3a1245943b669f717747b4"
   },
   {
-    "name": "ghcr.io/xenitab/spegel:v0.0.8-with-media-type",
+    "name": "ghcr.io/spegel-org/spegel:v0.0.8-with-media-type",
     "mediaType": "application/vnd.oci.image.index.v1+json",
     "digest": "sha256:9506c8e7a2d0a098d43cadfd7ecdc3c91697e8188d3a1245943b669f717747b4"
   },
   {
-    "name": "ghcr.io/xenitab/spegel:v0.0.8-without-media-type",
+    "name": "ghcr.io/spegel-org/spegel:v0.0.8-without-media-type",
     "mediaType": "application/vnd.oci.image.index.v1+json",
     "digest": "sha256:d8df04365d06181f037251de953aca85cc16457581a8fc168f4957c978e1008b"
   },

--- a/pkg/registry/distribution_test.go
+++ b/pkg/registry/distribution_test.go
@@ -45,11 +45,11 @@ func TestParsePathComponents(t *testing.T) {
 }
 
 func TestParsePathComponentsInvalidPath(t *testing.T) {
-	_, _, _, err := parsePathComponents("example.com", "/v2/xenitab/spegel/v0.0.1")
+	_, _, _, err := parsePathComponents("example.com", "/v2/spegel-org/spegel/v0.0.1")
 	require.EqualError(t, err, "distribution path could not be parsed")
 }
 
 func TestParsePathComponentsMissingRegistry(t *testing.T) {
-	_, _, _, err := parsePathComponents("", "/v2/xenitab/spegel/manifests/v0.0.1")
+	_, _, _, err := parsePathComponents("", "/v2/spegel-org/spegel/manifests/v0.0.1")
 	require.EqualError(t, err, "registry parameter needs to be set for tag references")
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -29,7 +29,7 @@ func TestBasic(t *testing.T) {
 
 	imgRefs := []string{
 		"docker.io/library/ubuntu:latest@sha256:b060fffe8e1561c9c3e6dea6db487b900100fc26830b9ea2ec966c151ab4c020",
-		"ghcr.io/xenitab/spegel:v0.0.9@sha256:fa32bd3bcd49a45a62cfc1b0fed6a0b63bf8af95db5bad7ec22865aee0a4b795",
+		"ghcr.io/spegel-org/spegel:v0.0.9@sha256:fa32bd3bcd49a45a62cfc1b0fed6a0b63bf8af95db5bad7ec22865aee0a4b795",
 		"docker.io/library/alpine@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70",
 	}
 


### PR DESCRIPTION
Part of #374 