### PR TITLE
Add conformance tests to e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#421](https://github.com/spegel-org/spegel/pull/421) Add conformance tests to e2e test.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -226,9 +226,8 @@ func (r *Registry) handleMirror(c *gin.Context, key string) {
 		case ipAddr, ok := <-peerCh:
 			// Channel closed means no more mirrors will be received and max retries has been reached.
 			if !ok {
-				// TODO: Change to a 404 instead
 				//nolint:errcheck // ignore
-				c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("mirror resolve retries exhausted for key: %s", key))
+				c.AbortWithError(http.StatusNotFound, fmt.Errorf("mirror resolve retries exhausted for key: %s", key))
 				return
 			}
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -81,9 +81,9 @@ func TestMirrorHandler(t *testing.T) {
 			expectedHeaders: nil,
 		},
 		{
-			name:            "request should not timeout and give 500 if all peers fail",
+			name:            "request should not timeout and give 404 if all peers fail",
 			key:             "no-working-peers",
-			expectedStatus:  http.StatusInternalServerError,
+			expectedStatus:  http.StatusNotFound,
 			expectedBody:    "",
 			expectedHeaders: nil,
 		},
@@ -111,7 +111,7 @@ func TestMirrorHandler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		for _, method := range []string{http.MethodGet, http.MethodHead} {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s-%s", method, tt.name), func(t *testing.T) {
 				rw := CreateTestResponseRecorder()
 				c, _ := gin.CreateTestContext(rw)
 				target := fmt.Sprintf("http://example.com/%s", tt.key)

--- a/test/e2e/conformance-job.yaml
+++ b/test/e2e/conformance-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: conformance
+  namespace: default
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: conformance
+        image: ghcr.io/spegel-org/conformance:75d2816
+        env:
+        - name: OCI_TEST_PULL
+          value: "1"
+        - name: "OCI_ROOT_URL"
+          value: "http://spegel-registry.spegel.svc.cluster.local.:5000"
+        - name: "OCI_MIRROR_URL"
+          value: "docker.io"
+        - name: "OCI_NAMESPACE"
+          value: "library/nginx"
+        - name: "OCI_TAG_NAME"
+          value: "1.23.0"
+        - name: "OCI_MANIFEST_DIGEST"
+          value: "sha256:db345982a2f2a4257c6f699a499feb1d79451a1305e8022f16456ddc3ad6b94c"
+        - name: "OCI_BLOB_DIGEST"
+          value: "sha256:461246efe0a75316d99afdbf348f7063b57b0caeee8daab775f1f08152ea36f4"


### PR DESCRIPTION
This change adds conformance tests to the e2e tests. This is a step towards adding support for new OCI 1.1 features. Additionally it will verify that changes made when removing Gin. From now on all changes will have to comply with the conformance tests.

Fixes #304 