### PR TITLE
Add support for OCI Distribution Specification 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - [#421](https://github.com/spegel-org/spegel/pull/421) Add conformance tests to e2e test.
+- [#422](https://github.com/spegel-org/spegel/pull/422) Add support for OCI Distribution Specification 1.1.
 
 ### Changed
 

--- a/test/e2e/conformance-job.yaml
+++ b/test/e2e/conformance-job.yaml
@@ -12,7 +12,9 @@ spec:
       - name: conformance
         image: ghcr.io/spegel-org/conformance:75d2816
         env:
-        - name: OCI_TEST_PULL
+        - name: "OCI_TEST_PULL"
+          value: "1"
+        - name: "OCI_TEST_CONTENT_DISCOVERY"
           value: "1"
         - name: "OCI_ROOT_URL"
           value: "http://spegel-registry.spegel.svc.cluster.local.:5000"
@@ -26,3 +28,5 @@ spec:
           value: "sha256:db345982a2f2a4257c6f699a499feb1d79451a1305e8022f16456ddc3ad6b94c"
         - name: "OCI_BLOB_DIGEST"
           value: "sha256:461246efe0a75316d99afdbf348f7063b57b0caeee8daab775f1f08152ea36f4"
+        - name: "OCI_TAG_LIST"
+          value: "1.22.0,1.23.0"

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -17,6 +17,7 @@ docker exec kind-worker2 bash -c "mkdir -p /etc/containerd/certs.d/docker.io; ec
 
 # Pull images onto single node which will never run workload.
 docker exec kind-worker ctr -n k8s.io image pull ghcr.io/spegel-org/conformance:75d2816
+docker exec kind-worker ctr -n k8s.io image pull docker.io/library/nginx:1.22.0
 docker exec kind-worker ctr -n k8s.io image pull docker.io/library/nginx:1.23.0
 docker exec kind-worker ctr -n k8s.io image pull docker.io/library/nginx@sha256:b3a676a9145dc005062d5e79b92d90574fb3bf2396f4913dc1732f9065f55c4b
 docker exec kind-worker ctr -n k8s.io image pull mcr.microsoft.com/containernetworking/azure-cns@sha256:7944413c630746a35d5596f56093706e8d6a3db0569bec0c8e58323f965f7416


### PR DESCRIPTION
Adds support for refers which will enable efficient use of remote snapshoters in the future. 

Fixes #289 