### PR TITLE
Add artifacthub-repo.yml to verify repository

### DIFF
--- a/.github/workflows/artifacthub.yaml
+++ b/.github/workflows/artifacthub.yaml
@@ -1,0 +1,29 @@
+name: artifacthub
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["charts/spegel/artifacthub-repo.yml"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+        with:        
+          submodules: true
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@v1
+      - name: Push Artifact Hub metadata
+        run: oras push ghcr.io/spegel-org/helm-charts/spegel:artifacthub.io --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml charts/spegel/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,7 @@ jobs:
       - name: Publish Helm chart to GHCR
         id: helm
         run: |
+          rm charts/spegel/artifacthub-repo.yml
           yq -i '.image.digest = "${{ steps.build.outputs.DIGEST }}"' charts/spegel/values.yaml
           helm package --app-version ${{ steps.prep.outputs.VERSION }} --version ${{ steps.prep.outputs.VERSION }} charts/spegel
           helm push spegel-${{ steps.prep.outputs.VERSION }}.tgz oci://ghcr.io/spegel-org/helm-charts 2> .digest

--- a/charts/spegel/artifacthub-repo.yml
+++ b/charts/spegel/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: 8122016b-c465-4eaf-be87-f51423aa76f1
+owners:
+  - name: Philip Laine
+    email: philip.laine@gmail.com


### PR DESCRIPTION
Adds Artifact Hub metadata layer to the Helm Chart according to the docs.

https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support

This will allow the repository to be verified.