### PR TITLE
Add metrics to measure duration to resolve peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#421](https://github.com/spegel-org/spegel/pull/421) Add conformance tests to e2e test.
 - [#424](https://github.com/spegel-org/spegel/pull/424) Add option to append mirror configuration instead of overwriting.
+- [#429](https://github.com/spegel-org/spegel/pull/429) Add metrics to measure duration to resolve peers.
 
 ### Changed
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -3,6 +3,7 @@
 | Name| Type | Labels |
 | ---------- | ----------- | ----------- |
 | spegel_advertised_images | Gauge | `registry` |
+| spegel_resolve_duration_seconds | Histogram | `router` |
 | spegel_advertised_keys | Gauge | `registry` |
 | spegel_advertised_image_tags | Gauge | `registry` |
 | spegel_advertised_image_digests | Gauge | `registry` |

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,6 +19,10 @@ var (
 		Name: "spegel_mirror_requests_total",
 		Help: "Total number of mirror requests.",
 	}, []string{"registry", "cache", "source"})
+	ResolveDurHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "spegel_resolve_duration_seconds",
+		Help: "The duration for router to resolve a peer.",
+	}, []string{"router"})
 	AdvertisedImages = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "spegel_advertised_images",
 		Help: "Number of images advertised to be available.",
@@ -54,6 +58,7 @@ var (
 
 func Register() {
 	DefaultRegisterer.MustRegister(MirrorRequestsTotal)
+	DefaultRegisterer.MustRegister(ResolveDurHistogram)
 	DefaultRegisterer.MustRegister(AdvertisedImages)
 	DefaultRegisterer.MustRegister(AdvertisedImageTags)
 	DefaultRegisterer.MustRegister(AdvertisedImageDigests)

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -21,6 +21,7 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 	mc "github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/spegel-org/spegel/pkg/metrics"
 )
@@ -163,7 +164,9 @@ func (r *P2PRouter) Resolve(ctx context.Context, key string, allowSelf bool, cou
 	addrCh := r.rd.FindProvidersAsync(ctx, c, count)
 	peerCh := make(chan netip.AddrPort, peerBufferSize)
 	go func() {
+		resolveTimer := prometheus.NewTimer(metrics.ResolveDurHistogram.WithLabelValues("libp2p"))
 		for info := range addrCh {
+			resolveTimer.ObserveDuration()
 			if !allowSelf && info.ID == r.host.ID() {
 				continue
 			}


### PR DESCRIPTION
This will help adjusting the default resolve timeout which is currently absurdly high.