### PR TITLE
Add optional Containerd local content store to increase serve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - [#435](https://github.com/spegel-org/spegel/pull/435) Add pprof endpoints to enable profiling.
+- [#434](https://github.com/spegel-org/spegel/pull/434) Add optional Containerd local content store to increase serve performance.
 
 ### Changed
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -85,6 +85,7 @@ spec:
 | spegel.additionalMirrorRegistries | list | `[]` | Additional target mirror registries other than Spegel. |
 | spegel.appendMirrors | bool | `false` | When true existing mirror configuration will be appended to instead of replaced. |
 | spegel.blobSpeed | string | `""` | Maximum write speed per request when serving blob layers. Should be an integer followed by unit Bps, KBps, MBps, GBps, or TBps. |
+| spegel.containerdContentPath | string | `"/var/lib/containerd/io.containerd.content.v1.content"` | Path to Containerd content store.. |
 | spegel.containerdMirrorAdd | bool | `true` | If true Spegel will add mirror configuration to the node. |
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -96,6 +96,9 @@ spec:
           {{- with .Values.spegel.blobSpeed }}
           - --blob-speed={{ . }}
           {{- end }}
+          {{- with .Values.spegel.containerdContentPath }}
+          - --containerd-content-path={{ . }}
+          {{- end }}
         env:
         - name: NODE_IP
           valueFrom:
@@ -127,12 +130,23 @@ spec:
         volumeMounts:
           - name: containerd-sock
             mountPath: {{ .Values.spegel.containerdSock }}
+          {{- with .Values.spegel.containerdContentPath }}
+          - name: containerd-content
+            mountPath: {{ . }}
+            readOnly: true
+          {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
         - name: containerd-sock
           hostPath:
             path: {{ .Values.spegel.containerdSock }}
+        {{- with .Values.spegel.containerdContentPath }}
+        - name: containerd-content
+          hostPath:
+            path: {{ . }}
+            type: Directory
+        {{- end }}
         {{- if .Values.spegel.containerdMirrorAdd }}
         - name: containerd-config
           hostPath:

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -132,6 +132,8 @@ spegel:
   containerdNamespace: "k8s.io"
   # -- Path to Containerd mirror configuration.
   containerdRegistryConfigPath: "/etc/containerd/certs.d"
+  # -- Path to Containerd content store..
+  containerdContentPath: "/var/lib/containerd/io.containerd.content.v1.content"
   # -- If true Spegel will add mirror configuration to the node.
   containerdMirrorAdd: true
   # -- Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC.

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ type RegistryCmd struct {
 	LocalAddr                    string             `arg:"--local-addr,required,env:LOCAL_ADDR" help:"Address that the local Spegel instance will be reached at."`
 	ContainerdSock               string             `arg:"--containerd-sock,env:CONTAINERD_SOCK" default:"/run/containerd/containerd.sock" help:"Endpoint of containerd service."`
 	ContainerdNamespace          string             `arg:"--containerd-namespace,env:CONTAINERD_NAMESPACE" default:"k8s.io" help:"Containerd namespace to fetch images from."`
+	ContainerdContentPath        string             `arg:"--containerd-content-path,env:CONTAINERD_CONTENT_PATH" default:"/var/lib/containerd/io.containerd.content.v1.content" help:"Path to Containerd content store"`
 	RouterAddr                   string             `arg:"--router-addr,env:ROUTER_ADDR,required" help:"address to serve router."`
 	RegistryAddr                 string             `arg:"--registry-addr,env:REGISTRY_ADDR,required" help:"address to server image registry."`
 	Registries                   []url.URL          `arg:"--registries,env:REGISTRIES,required" help:"registries that are configured to be mirrored."`
@@ -116,7 +117,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	g, ctx := errgroup.WithContext(ctx)
 
 	// OCI Client
-	ociClient, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, args.Registries)
+	ociClient, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, args.Registries, oci.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change would add an optional feature, that would be enabled by default in the Helm chart, that would mount Containerds content directory. By doing this we would be able to read manifests and blobs straight from disk instead of streaming the content over the socket. The major benefit of this is that we would be able to copy content without a buffer which should in theory speed up image pulling, especially for large blobs.

This would resolve https://github.com/containerd/containerd/issues/10034 as we would just use an optional extra content store if the path is set. The content store would only be used for functions where the label store is not required.

We should be able to close #385 if this is merged and the buffer would not be used at all.

Fixes #378 