### PR TITLE
Update Go version and fix toolchain version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#439](https://github.com/spegel-org/spegel/pull/439) Update Go version and fix toolchain version.
+
 ### Deprecated
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.7@sha256:549dd88a1a53715f177b41ab5fee25f7a376a6bb5322ac7abe263480d9554021 as builder
+FROM golang:1.21.9@sha256:81811f8a883e238666dbadee6928ae2902243a3cd3f3e860f21c102543c6b5a7 as builder
 RUN mkdir /build
 WORKDIR /build
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spegel-org/spegel
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/alexflint/go-arg v1.4.3


### PR DESCRIPTION
CodeQL warned about the go toolchain version needing to include the patch in the version. This change remediates this warning.

https://github.com/spegel-org/spegel/actions/runs/8689519404/job/23827360001#step:7:314