### PR TITLE
Fix Containerd subscribe returning on any error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#452](https://github.com/spegel-org/spegel/pull/452) Fix Containerd Subscribe returning on any error.
+
 ### Security
 
 - [#451](https://github.com/spegel-org/spegel/pull/451) Bump golang.org/x/net from 0.21.0 to 0.23.0.

--- a/pkg/oci/mock.go
+++ b/pkg/oci/mock.go
@@ -27,8 +27,8 @@ func (m *MockClient) Verify(ctx context.Context) error {
 	return nil
 }
 
-func (m *MockClient) Subscribe(ctx context.Context) (<-chan ImageEvent, <-chan error) {
-	return nil, nil
+func (m *MockClient) Subscribe(ctx context.Context) (<-chan ImageEvent, <-chan error, error) {
+	return nil, nil, nil
 }
 
 func (m *MockClient) ListImages(ctx context.Context) ([]Image, error) {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -14,7 +14,7 @@ type UnknownDocument struct {
 type Client interface {
 	Name() string
 	Verify(ctx context.Context) error
-	Subscribe(ctx context.Context) (<-chan ImageEvent, <-chan error)
+	Subscribe(ctx context.Context) (<-chan ImageEvent, <-chan error, error)
 	ListImages(ctx context.Context) ([]Image, error)
 	AllIdentifiers(ctx context.Context, img Image) ([]string, error)
 	Resolve(ctx context.Context, ref string) (digest.Digest, error)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -16,7 +16,10 @@ import (
 
 func Track(ctx context.Context, ociClient oci.Client, router routing.Router, resolveLatestTag bool) error {
 	log := logr.FromContextOrDiscard(ctx)
-	eventCh, errCh := ociClient.Subscribe(ctx)
+	eventCh, errCh, err := ociClient.Subscribe(ctx)
+	if err != nil {
+		return err
+	}
 	immediate := make(chan time.Time, 1)
 	immediate <- time.Now()
 	expirationTicker := time.NewTicker(routing.KeyTTL - time.Minute)


### PR DESCRIPTION
The code was copied from a function which kept the return during errors. This was wrong as it would cancel any future event mapping. This change refactors the Subscribe function and resolves the issue. It makes sure to close the channels when the go routine returns to make sure that future errors will bubble up.