### PR TITLE
Fix http-bootstrap-addr env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#460](https://github.com/spegel-org/spegel/pull/460) Fix environment variable for http-bootstrap-addr flag.
+
 ### Security
 
 ## v0.0.22

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ type ConfigurationCmd struct {
 
 type BootstrapConfig struct {
 	BootstrapKind           string `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
-	HTTPBootstrapAddr       string `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_KIND" help:"Address to serve for HTTP bootstrap."`
+	HTTPBootstrapAddr       string `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
 	HTTPBootstrapPeer       string `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
 	KubeconfigPath          string `arg:"--kubeconfig-path,env:KUBECONFIG_PATH" help:"Path to the kubeconfig file."`
 	LeaderElectionName      string `arg:"--leader-election-name,env:LEADER_ELECTION_NAME" default:"spegel-leader-election" help:"Name of leader election."`


### PR DESCRIPTION
PR fixes the env variable for `HTTPBootstrapAddr` / `--http-bootstrap-addr` flag from `HTTP_BOOTSTRAP_KIND` to `HTTP_BOOTSTRAP_ADDR`. This matches the convention for the other env var options in the file.

While this is a breaking change, I would be surprised if anyone is using the HTTP bootstrap feature yet.

Let me know your thoughts.