### PR TITLE
Fix handler key in request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#460](https://github.com/spegel-org/spegel/pull/460) Fix environment variable for http-bootstrap-addr flag.
+- [#471](https://github.com/spegel-org/spegel/pull/471) Fix handler key in request logging.
 
 ### Security
 


### PR DESCRIPTION
During the removal of Gin in #395 I accidentally removed the handler key from the request logs. This key turned out to be very useful for understanding request flows. This change fixes the behavior to work as it did before.