### PR TITLE
Move resolving ref to digest to manifest handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#475](https://github.com/XenitAB/spegel/pull/475) Move resolving ref to digest to manifest handler.
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
Ref resolving should only be done for manifests to it does not make sense to do it for all requests to the registry.