### PR TITLE
Remove path filters from github actions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,16 +1,8 @@
 name: e2e
 on:
   pull_request:
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - "Dockerfile"
-      - "test/**"
-      - "charts/**"
 jobs:
   test:
-    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,11 +1,6 @@
 name: go
 on:
   pull_request:
-    paths: 
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - ".golangci.yaml"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -22,7 +17,6 @@ jobs:
           version: v1.58.0
           args: --timeout 3m0s
   unit:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,11 +1,8 @@
 name: helm
 on:
   pull_request:
-    paths:
-      - "charts/**"
 jobs:
   docs:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Turns out that it is not possible to configure required workflows while using path filters. For now we will run all workflows as keeping required workflows is more important.