### PR TITLE
Fix so that resolve timeout does not cancel mirroring attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#460](https://github.com/spegel-org/spegel/pull/460) Fix environment variable for http-bootstrap-addr flag.
 - [#471](https://github.com/spegel-org/spegel/pull/471) Fix handler key in request logging.
+- [#491](https://github.com/spegel-org/spegel/pull/491) Fix so that resolve timeout does not cancel mirroring attempts.
 
 ### Security
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -246,8 +246,7 @@ func (r *Registry) handleMirror(rw mux.ResponseWriter, req *http.Request, ref re
 	mirrorAttempts := 0
 	for {
 		select {
-		// TODO: Refactor context cancel and mirror channel closing
-		case <-resolveCtx.Done():
+		case <-req.Context().Done():
 			// Request has been closed by server or client. No use continuing.
 			rw.WriteError(http.StatusNotFound, fmt.Errorf("mirroring for image component %s has been cancelled: %w", key, resolveCtx.Err()))
 			return

--- a/pkg/routing/mock.go
+++ b/pkg/routing/mock.go
@@ -28,8 +28,9 @@ func (m *MockRouter) Ready() (bool, error) {
 func (m *MockRouter) Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan netip.AddrPort, error) {
 	peerCh := make(chan netip.AddrPort, count)
 	peers, ok := m.resolver[key]
-	// Not found will look forever until timeout.
+	// If not peers exist close the channel to stop any consumer.
 	if !ok {
+		close(peerCh)
 		return peerCh, nil
 	}
 	go func() {


### PR DESCRIPTION
Using the resolve context as a method of cancelling proxying requests turned out to not be the right answer. When evaluating how to change the default resolve timeout i realized my error that a low enough resolve timeout would cancel any mirror retry even if multiple mirrors has been found. If the resolve timeout was 20ms it would mean that any retry would have to occur before that. In reality it is a lot better to limit the resolve time and populate the peer channel buffer. Then to attempt all peers found in the buffer as long as the client does not timeout.

Part of #472 