### PR TITLE
Update to Go 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#488](https://github.com/XenitAB/spegel/pull/488) Update existing registry errors and add more detail.
 - [#490](https://github.com/XenitAB/spegel/pull/490) Close immediate channel after writing to it to close wait group in merge logic.
 - [#495](https://github.com/XenitAB/spegel/pull/495) Modify e2e tests to allow reusing the same kind cluster.
+- [#498](https://github.com/spegel-org/spegel/pull/498) Update to Go 1.22.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.9@sha256:81811f8a883e238666dbadee6928ae2902243a3cd3f3e860f21c102543c6b5a7 as builder
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as builder
 RUN mkdir /build
 WORKDIR /build
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spegel-org/spegel
 
-go 1.21.9
+go 1.22.3
 
 require (
 	github.com/alexflint/go-arg v1.5.0


### PR DESCRIPTION
K3s and RKE2 are both using Go 1.22 so should not break any downstream dependents. 