### PR TITLE
Fix e2e test not found image

### DIFF
--- a/test/e2e/test-nginx.yaml
+++ b/test/e2e/test-nginx.yaml
@@ -100,7 +100,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: docker.io/library/nginx:1.24.0-bullseye-perl
+        image: docker.io/library/nginx:1.1.0-bullseye-perl
         imagePullPolicy: Always
         ports:
         - containerPort: 80


### PR DESCRIPTION
E2E tests we built slightly naively that the image `docker.io/library/nginx:1.24.0-bullseye-perl` would not exist. Turns out it now exists. This changes the image to something that will probably never exist.