### PR TITLE
Change default resolve timeout to 20ms

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -97,7 +97,7 @@ spec:
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
-| spegel.mirrorResolveTimeout | string | `"5s"` | Max duration spent finding a mirror. |
+| spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |
 | spegel.registries | list | `["https://cgr.dev","https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io","https://lscr.io"]` | Registries for which mirror configuration will be created. |
 | spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | spegel.resolveTags | bool | `true` | When true Spegel will resolve tags to digests. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -139,7 +139,7 @@ spegel:
   # -- Max ammount of mirrors to attempt.
   mirrorResolveRetries: 3
   # -- Max duration spent finding a mirror.
-  mirrorResolveTimeout: "5s"
+  mirrorResolveTimeout: "20ms"
   # -- Path to Containerd socket.
   containerdSock: "/run/containerd/containerd.sock"
   # -- Containerd namespace where images are stored.

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ type RegistryCmd struct {
 	RouterAddr                   string             `arg:"--router-addr,env:ROUTER_ADDR,required" help:"address to serve router."`
 	RegistryAddr                 string             `arg:"--registry-addr,env:REGISTRY_ADDR,required" help:"address to server image registry."`
 	Registries                   []url.URL          `arg:"--registries,env:REGISTRIES,required" help:"registries that are configured to be mirrored."`
-	MirrorResolveTimeout         time.Duration      `arg:"--mirror-resolve-timeout,env:MIRROR_RESOLVE_TIMEOUT" default:"5s" help:"Max duration spent finding a mirror."`
+	MirrorResolveTimeout         time.Duration      `arg:"--mirror-resolve-timeout,env:MIRROR_RESOLVE_TIMEOUT" default:"20ms" help:"Max duration spent finding a mirror."`
 	MirrorResolveRetries         int                `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
 	ResolveLatestTag             bool               `arg:"--resolve-latest-tag,env:RESOLVE_LATEST_TAG" default:"true" help:"When true latest tags will be resolved to digests."`
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -88,7 +88,7 @@ func NewRegistry(ociClient oci.Client, router routing.Router, opts ...Option) *R
 		ociClient:        ociClient,
 		router:           router,
 		resolveRetries:   3,
-		resolveTimeout:   1 * time.Second,
+		resolveTimeout:   20 * time.Millisecond,
 		resolveLatestTag: true,
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
This change will adjust the default resolve timeout from 5s to 20ms. This will improve pull performance when the image is not present in the cluster. I set this to a high value on purpose a year ago when I knew much less about resolving keys. After creating the benchmarks I realized that the default timeout had a large impact on initial performance.

The new default value comes from tests that I have run with the benchmark on an AKS cluster with 50 nodes. These tests showed that the average resolve time was somewhere between 1ms-2ms with no real extreme values. Setting the default value to 20ms will give some buffer.

Fixes #472 