### PR TITLE
Upload code coverage result to Codecov

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,4 +23,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run tests
-        run: make test
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Adds Codecov in the hopes that this will help discover untested code.