### PR TITLE
chore(helm): allow relabeling rules for service monitor

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -85,6 +85,8 @@ spec:
 | serviceMonitor.enabled | bool | `false` | If true creates a Prometheus Service Monitor. |
 | serviceMonitor.interval | string | `"60s"` | Prometheus scrape interval. |
 | serviceMonitor.labels | object | `{}` | Service monitor specific labels for prometheus to discover servicemonitor. |
+| serviceMonitor.metricRelabelings | list | `[]` | List of relabeling rules to apply to the samples before ingestion. |
+| serviceMonitor.relabelings | list | `[]` | List of relabeling rules to apply the target’s metadata labels. |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Prometheus scrape interval timeout. |
 | spegel.additionalMirrorRegistries | list | `[]` | Additional target mirror registries other than Spegel. |
 | spegel.appendMirrors | bool | `false` | When true existing mirror configuration will be appended to instead of replaced. |

--- a/charts/spegel/templates/servicemonitor.yaml
+++ b/charts/spegel/templates/servicemonitor.yaml
@@ -18,4 +18,12 @@ spec:
     - port: metrics
       interval: {{ .Values.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -103,6 +103,10 @@ serviceMonitor:
   scrapeTimeout: 30s
   # -- Service monitor specific labels for prometheus to discover servicemonitor.
   labels: {}
+  # -- List of relabeling rules to apply the target’s metadata labels.
+  relabelings: []
+  # -- List of relabeling rules to apply to the samples before ingestion.
+  metricRelabelings: []
 
 grafanaDashboard:
   # -- If true creates a Grafana dashboard.


### PR DESCRIPTION
Hello, a small contrib for the helm chart 🙂

## Description
This PR allow a user to provide relabeling rules for the service monitor to inject custom labels, rename or drop others.

~Additional change for `appVersion` to match current latest image version, don't have strong opinion here, feel free to refuse this change if the rest looks good to you.~

## How has this been tested ?
Deployed on our clusters successfully.

## Breaking changes ?
No breaking changes.

