### PR TITLE
Set blob content type to disable detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#519](https://github.com/spegel-org/spegel/pull/519) Extend tests for containerd.
 - [#520](https://github.com/spegel-org/spegel/pull/520) Add tests for metrics.
 - [#536](https://github.com/spegel-org/spegel/pull/536) Update Go version to 1.22.5.
+- [#547](https://github.com/spegel-org/spegel/pull/547) Set blob content type to disable detection.
 
 ### Deprecated
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -334,6 +334,7 @@ func (r *Registry) handleBlob(rw mux.ResponseWriter, req *http.Request, ref refe
 		rw.WriteError(http.StatusInternalServerError, fmt.Errorf("could not determine size of blob with digest %s: %w", ref.dgst.String(), err))
 		return
 	}
+	rw.Header().Set("Content-Type", "application/octet-stream")
 	rw.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	rw.Header().Set("Docker-Content-Digest", ref.dgst.String())
 	if req.Method == http.MethodHead {


### PR DESCRIPTION
The default behavior in Golang is to try to detect the content type is no header is set. This adds a small bit of over head. For manifests we return the correct content type in the header as it is required by the distribution spec. The spec does not however mention any guidelines for what to do for setting the blobs content type.

https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-blobs

For this reason we will just set the header to a generic `application/octet-stream` which is what is already being set today.