### PR TITLE
Use buffer pool for proxy copying data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#538](https://github.com/spegel-org/spegel/pull/538) Replace mock OCI client with in memory client.
 - [#552](https://github.com/spegel-org/spegel/pull/552) Add support for VerticalPodAutoscaler in the Helm chart.
 - [#556](https://github.com/spegel-org/spegel/pull/556) Add configuration for revisionHistoryLimit in the Helm Chart.
+- [#573](https://github.com/spegel-org/spegel/pull/573) Use buffer pool for proxy copying data.
 
 ### Changed
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -1,0 +1,26 @@
+package buffer
+
+import "sync"
+
+type BufferPool struct {
+	pool sync.Pool
+}
+
+func NewBufferPool() *BufferPool {
+	return &BufferPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, 32*1024)
+			},
+		},
+	}
+}
+
+func (p *BufferPool) Get() []byte {
+	return p.pool.Get().([]byte)
+}
+
+func (p *BufferPool) Put(b []byte) {
+	//nolint: staticcheck // false positive
+	p.pool.Put(b)
+}

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -1,0 +1,16 @@
+package buffer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferPool(t *testing.T) {
+	t.Parallel()
+
+	bufferPool := NewBufferPool()
+	b := bufferPool.Get()
+	require.Len(t, b, 32*1024)
+	bufferPool.Put(b)
+}


### PR DESCRIPTION
This change makes the HTTP proxy use a buffer pool when copying data between a response and request. It does not change the buffer size which still is what it was before. Future work could be done to test if changing the buffer size would improve performance.

Relates to #546 