### PR TITLE
Skip status response verification for containerd v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#581](https://github.com/spegel-org/spegel/pull/581) Skip status response verification for containerd v2
+
 ### Security
 
 ## v0.0.24


### PR DESCRIPTION
containerd v2 refactored its config structures/objects and the configuration that spegel is verifying in `verifyStatusResponse` is no longer returned. This patch adds a version check to `Verify` to allow spegel to skip the verification and take it on blind faith that it is configured correctly to work.

Fixes #579