### PR TITLE
fix: Correct Max Request Duration in Grafana

### DIFF
--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -407,7 +407,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(rate(http_request_duration_seconds_bucket{job=\"spegel\"})) [$__interval]",
+          "expr": "max(rate(http_request_duration_seconds_bucket{job=\"spegel\"}[$__interval]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",


### PR DESCRIPTION
Closes #588 

<img width="270" alt="image" src="https://github.com/user-attachments/assets/a9ea8c85-6e3a-439a-b160-00892e3695e2">
