### PR TITLE
Fix Containerd host mirror ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#601](https://github.com/spegel-org/spegel/pull/601) Fix Containerd host mirror ordering.
+
 ### Security
 
 ## v0.0.25

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.etcd.io/bbolt v1.3.11
 	golang.org/x/sync v0.8.0
-	golang.org/x/time v0.7.0
 	k8s.io/client-go v0.31.1
 	k8s.io/cri-api v0.31.1
 	k8s.io/klog/v2 v2.130.1
@@ -199,6 +198,7 @@ require (
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	gonum.org/v1/gonum v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 // indirect


### PR DESCRIPTION
This change replaces the use of toml un-marshalling with Go templating which was previously used a year ago. This is to make sure the the order the mirrors passed to Spegel are preserved in the toml file.

This change is heavily based on @vflaux work in both #550 and #557. Thank you for doing the research to figure out a path forward in solving this! 

Fixes #549 