### PR TITLE
Fix append to backup always happening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#603](https://github.com/spegel-org/spegel/pull/603) Fix append to backup always happening.
+
 ### Security
 
 ## v0.0.26


### PR DESCRIPTION
The change in #601 fixed mirror ordering but introduced a bug which caused the mirror configuration to always append on the backup. This change fixes the regression and adds a test to verify configuration is only appended when enabled.