### PR TITLE
Create empty backup directory when mirror directory is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#603](https://github.com/spegel-org/spegel/pull/603) Fix append to backup always happening.
+- [#604](https://github.com/spegel-org/spegel/pull/604) Create empty backup directory when mirror directory is empty.
 
 ### Security
 

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -410,19 +410,16 @@ func validateRegistries(urls []url.URL) error {
 
 func backupConfig(log logr.Logger, fs afero.Fs, configPath string) error {
 	backupDirPath := path.Join(configPath, backupDir)
-	_, err := fs.Stat(backupDirPath)
-	if err != nil && !os.IsNotExist(err) {
+	ok, err := afero.DirExists(fs, backupDirPath)
+	if err != nil {
 		return err
 	}
-	if err == nil {
+	if ok {
 		return nil
 	}
 	files, err := afero.ReadDir(fs, configPath)
 	if err != nil {
 		return err
-	}
-	if len(files) == 0 {
-		return nil
 	}
 	err = fs.MkdirAll(backupDirPath, 0o755)
 	if err != nil {


### PR DESCRIPTION
This change makes sure that mirror configuration created by Spegel is not backed up after a restart when the mirror configuration is empty. We use the presence of a backup directory  as a way to indicate that the backup as been done. If we don't create it on the first run, when Spegel restarts it is then assumed that backup has not been done before.