### PR TITLE
fix grafana dashboard

### DIFF
--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -1175,6 +1175,13 @@
   "templating": {
     "list": [
       {
+        "hide": 2,
+        "name": "DS_PROMETHEUS",
+        "query": "Prometheus",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
         "current": {
           "selected": false,
           "text": "Prometheus",


### PR DESCRIPTION
Hi,
when you load the dashboad in the UI, the __input makes grafana asks for the datasource and the dashboard works. When you load the dashboard from grafana' sidecar, it doesn't work because DS_PROMETHEUS is not inizialized properly, so I added the variable 

I installed the chart and the dashboard worked flawlessy

regards