### PR TITLE
Fix Containerd CRI config verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#651](https://github.com/spegel-org/spegel/pull/651) Fix Containerd CRI config verification.
+
 ### Security
 
 ## v0.0.27


### PR DESCRIPTION
Either the configuration format has changed or I implemented it incorrectly from the beginning. This change fixes the parsing of the CRI config JSON to actually check discard unpacked layers. It also adds a check to make sure the field is present.

Relates to #634