### PR TITLE
Switch to using headless service for bootstrapping

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -51,7 +51,6 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
-| spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -88,12 +88,8 @@ spec:
           - --containerd-sock={{ .Values.spegel.containerdSock }}
           - --containerd-namespace={{ .Values.spegel.containerdNamespace }}
           - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
-          - --bootstrap-kind=kubernetes
-          {{- with .Values.spegel.kubeconfigPath }}
-          - --kubeconfig-path={{ . }}
-          {{- end }}
-          - --leader-election-namespace={{ include "spegel.namespace" . }}
-          - --leader-election-name={{ .Release.Name }}-leader-election
+          - --bootstrap-kind=dns
+          - --dns-bootstrap-domain={{ include "spegel.fullname" . }}-bootstrap.{{ include "spegel.namespace" . }}.svc.cluster.local.
           - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
           - --local-addr=$(NODE_IP):{{ .Values.service.registry.hostPort }}
           {{- with .Values.spegel.containerdContentPath }}

--- a/charts/spegel/templates/rbac.yaml
+++ b/charts/spegel/templates/rbac.yaml
@@ -9,31 +9,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "spegel.fullname" . }}
-  namespace: {{ include "spegel.namespace" . }}
-  labels:
-    {{- include "spegel.labels" . | nindent 4 }}
-rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "spegel.fullname" . }}
-  namespace: {{ include "spegel.namespace" . }}
-  labels:
-    {{- include "spegel.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "spegel.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "spegel.serviceAccountName" . }}
-    namespace: {{ include "spegel.namespace" . }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -36,3 +36,21 @@ spec:
       targetPort: registry
       nodePort: {{ .Values.service.registry.nodePort }}
       protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spegel.fullname" . }}-bootstrap
+  namespace: {{ include "spegel.namespace" . }}
+  labels:
+    app.kubernetes.io/component: metrics
+    {{- include "spegel.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "spegel.selectorLabels" . | nindent 4 }}
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: router
+      port: {{ .Values.service.router.port }}
+      protocol: TCP

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -8,7 +8,6 @@ image:
   # -- Image digest.
   digest: ""
 
-
 # -- Image Pull Secrets
 imagePullSecrets: []
 # -- Overrides the name of the chart.
@@ -162,8 +161,6 @@ spegel:
   containerdContentPath: "/var/lib/containerd/io.containerd.content.v1.content"
   # -- If true Spegel will add mirror configuration to the node.
   containerdMirrorAdd: true
-  # -- Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC.
-  kubeconfigPath: ""
   # -- When true Spegel will resolve tags to digests.
   resolveTags: true
   # -- When true latest tags will be resolved to digests.

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -45,7 +45,7 @@ func TestStaticBootstrap(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestKubernetesBootstra(t *testing.T) {
+func TestKubernetesBootstrap(t *testing.T) {
 	t.Parallel()
 
 	addr := "/ip4/10.244.1.2/tcp/5001"

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -129,10 +129,8 @@ func (r *P2PRouter) Ready(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, addrInfo := range addrInfos {
-		if addrInfo.ID == r.host.ID() {
-			return true, nil
-		}
+	if len(addrInfos) == 0 {
+		return true, nil
 	}
 	if r.kdht.RoutingTable().Size() == 0 {
 		err := r.kdht.Bootstrap(ctx)


### PR DESCRIPTION
This change replaces the Kubernetes leader election with a DNS based bootstrapper to fix scaling issues.

Fixes #682 
Fixes #663 