### PR TITLE
Allow bootstrappers to return multiaddress only containing IP

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,6 +68,8 @@ linters-settings:
         alias: cid
       - pkg: github.com/libp2p/go-libp2p-kad-dht
         alias: dht
+      - pkg: github.com/libp2p/go-libp2p/p2p/net/mock
+        alias: mocknet
       - pkg: go.etcd.io/bbolt
         alias: bolt
       - pkg: k8s.io/cri-api/pkg/apis/runtime/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#683](https://github.com/spegel-org/spegel/pull/683) Change bootstrapper to allow returning multiple peers.
+- [#684](https://github.com/spegel-org/spegel/pull/684) Allow bootstrappers to return multiaddress only containing IP.
 
 ### Deprecated
 

--- a/pkg/routing/bootstrap.go
+++ b/pkg/routing/bootstrap.go
@@ -16,12 +16,35 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
-// Bootstrapper resolves peers to bootstrap with.
+// Bootstrapper resolves peers to bootstrap with for the P2P router.
 type Bootstrapper interface {
 	// Run starts the bootstrap process. Should be blocking even if not needed.
 	Run(ctx context.Context, id string) error
 	// Get returns a list of peers that should be used as bootstrap nodes.
+	// If the peer ID is empty it will be resolved.
+	// If the address is missing a port the P2P router port will be used.
 	Get(ctx context.Context) ([]peer.AddrInfo, error)
+}
+
+var _ Bootstrapper = &StaticBootstrapper{}
+
+type StaticBootstrapper struct {
+	peers []peer.AddrInfo
+}
+
+func NewStaticBootstrapper(peers []peer.AddrInfo) *StaticBootstrapper {
+	return &StaticBootstrapper{
+		peers: peers,
+	}
+}
+
+func (b *StaticBootstrapper) Run(ctx context.Context, id string) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (b *StaticBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
+	return b.peers, nil
 }
 
 var _ Bootstrapper = &KubernetesBootstrapper{}

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -1,12 +1,87 @@
 package routing
 
 import (
+	"context"
+	"fmt"
 	"net/netip"
 	"testing"
 
+	"github.com/go-logr/logr"
+	tlog "github.com/go-logr/logr/testing"
+	"github.com/libp2p/go-libp2p/core/peer"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBootstrapFunc(t *testing.T) {
+	t.Parallel()
+
+	log := tlog.NewTestLogger(t)
+	ctx := logr.NewContext(context.Background(), log)
+
+	mn, err := mocknet.WithNPeers(2)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		peers    []peer.AddrInfo
+		expected []string
+	}{
+		{
+			name:     "no peers",
+			peers:    []peer.AddrInfo{},
+			expected: []string{},
+		},
+		{
+			name: "nothing missing",
+			peers: []peer.AddrInfo{
+				{
+					ID:    "foo",
+					Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1/tcp/8080")},
+				},
+			},
+			expected: []string{"/ip4/192.168.1.1/tcp/8080/p2p/foo"},
+		},
+		{
+			name: "only self",
+			peers: []peer.AddrInfo{
+				{
+					ID:    mn.Hosts()[0].ID(),
+					Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1/tcp/8080")},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "missing port",
+			peers: []peer.AddrInfo{
+				{
+					ID:    "foo",
+					Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
+				},
+			},
+			expected: []string{"/ip4/192.168.1.1/tcp/4242/p2p/foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := NewStaticBootstrapper(tt.peers)
+			f := bootstrapFunc(ctx, b, mn.Hosts()[0])
+			peers := f()
+
+			peerStrs := []string{}
+			for _, p := range peers {
+				id, err := p.ID.Marshal()
+				require.NoError(t, err)
+				peerStrs = append(peerStrs, fmt.Sprintf("%s/p2p/%s", p.Addrs[0].String(), string(id)))
+			}
+			require.ElementsMatch(t, tt.expected, peerStrs)
+		})
+	}
+}
 
 func TestListenMultiaddrs(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This change adds logic to set a default port and resolve peer ID if they have been omitted. This feature is added as there are bootstrap implementations that cannot share the peer ID in a reasonable way.

Relates to #682 