### PR TITLE
Make cluster domain configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#689](https://github.com/spegel-org/spegel/pull/689) Make cluster domain configurable.
+
 ### Security
 
 ## v0.0.29

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -9,6 +9,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for pod assignment. |
+| clusterDomain | string | `"cluster.local."` | Domain configured for service domain names. |
 | commonLabels | object | `{}` | Common labels to apply to all rendered resources. |
 | fullnameOverride | string | `""` | Overrides the full name of the chart. |
 | grafanaDashboard.annotations | object | `{}` | Annotations that ConfigMaps can have to get configured in Grafana, See: sidecar.dashboards.folderAnnotation for specifying the dashboard folder. https://github.com/grafana/helm-charts/tree/main/charts/grafana |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -89,7 +89,7 @@ spec:
           - --containerd-namespace={{ .Values.spegel.containerdNamespace }}
           - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
           - --bootstrap-kind=dns
-          - --dns-bootstrap-domain={{ include "spegel.fullname" . }}-bootstrap.{{ include "spegel.namespace" . }}.svc.cluster.local.
+          - --dns-bootstrap-domain={{ include "spegel.fullname" . }}-bootstrap.{{ include "spegel.namespace" . }}.svc.{{ .Values.clusterDomain }}
           - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
           - --local-addr=$(NODE_IP):{{ .Values.service.registry.hostPort }}
           {{- with .Values.spegel.containerdContentPath }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -101,6 +101,9 @@ affinity: {}
 # -- Common labels to apply to all rendered resources.
 commonLabels: {}
 
+# -- Domain configured for service domain names.
+clusterDomain: cluster.local.
+
 serviceMonitor:
   # -- If true creates a Prometheus Service Monitor.
   enabled: false


### PR DESCRIPTION
This change makes the cluster domain configurable for those that are using custom domain names. The change in #688 suggested removing it but I would prefer it to default as `cluster.local.` and then have users with custom domains change this.

Fixes #687