### PR TITLE
Default to using bash in all GitHub workflows

### DIFF
--- a/.github/workflows/artifacthub.yaml
+++ b/.github/workflows/artifacthub.yaml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
   packages: write
+defaults:
+  run:
+    shell: bash
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,9 @@
 name: e2e
 on:
   pull_request:
+defaults:
+  run:
+    shell: bash
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,6 +1,9 @@
 name: go
 on:
   pull_request:
+defaults:
+  run:
+    shell: bash   
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,6 +1,9 @@
 name: helm
 on:
   pull_request:
+defaults:
+  run:
+    shell: bash   
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ permissions:
   contents: read
   packages: write
   id-token: write
+defaults:
+  run:
+    shell: bash
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Seeing some unexpected behavior during e2e tests. Being explicit with the shell used should factor that out from being the source.