### PR TITLE
Fix p2p router close panic and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#689](https://github.com/spegel-org/spegel/pull/689) Make cluster domain configurable.
 - [#696](https://github.com/spegel-org/spegel/pull/696) Fix DNS bootstrap self check.
 - [#702](https://github.com/spegel-org/spegel/pull/702) Refactor and add tests for p2p ready.
+- [#703](https://github.com/spegel-org/spegel/pull/703) Fix p2p router close panic and add tests.
 
 ### Security
 

--- a/main.go
+++ b/main.go
@@ -173,10 +173,6 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	g.Go(func() error {
 		return router.Run(ctx)
 	})
-	g.Go(func() error {
-		<-ctx.Done()
-		return router.Close()
-	})
 
 	// State tracking
 	g.Go(func() error {

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -116,11 +116,11 @@ func (r *P2PRouter) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	err = r.host.Close()
+	if err != nil {
+		return err
+	}
 	return nil
-}
-
-func (r *P2PRouter) Close() error {
-	return r.host.Close()
 }
 
 func (r *P2PRouter) Ready(ctx context.Context) (bool, error) {
@@ -223,8 +223,13 @@ func bootstrapFunc(ctx context.Context, bootstrapper Bootstrapper, h host.Host) 
 		bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer bootstrapCancel()
 
+		// TODO (phillebaba): Consider if we should do a best effor bootstrap without host address.
+		hostAddrs := h.Addrs()
+		if len(hostAddrs) == 0 {
+			return nil
+		}
 		var hostPort ma.Component
-		ma.ForEach(h.Addrs()[0], func(c ma.Component) bool {
+		ma.ForEach(hostAddrs[0], func(c ma.Component) bool {
 			if c.Protocol().Code == ma.P_TCP {
 				hostPort = c
 				return false

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -5,8 +5,12 @@ import (
 	"net/netip"
 )
 
+// Router implements the discovery of content.
 type Router interface {
+	// Ready returns true when the router is ready.
 	Ready(ctx context.Context) (bool, error)
+	// Resolve asynchronously discovers addresses that can serve the content defined by the give key.
 	Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan netip.AddrPort, error)
+	// Advertise broadcasts that the current router can serve the content.
 	Advertise(ctx context.Context, keys []string) error
 }


### PR DESCRIPTION
Graceful shutdown was not working due to a index out of bound panic when bootstrap was run during shutdown. This fixes the issue and adds tests for the p2p shutdown.