### PR TITLE
Fix e2e tests for Kind v0.27.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,5 +23,10 @@ jobs:
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version-file: go.mod
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 #v1.12.0
+        with:
+          version: v0.27.0
+          install_only: true
       - name: Run e2e
         run: make test-e2e E2E_PROXY_MODE=${{ matrix.proxy-mode }} E2E_IP_FAMILY=${{ matrix.ip-family }}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -74,8 +74,10 @@ func TestE2E(t *testing.T) {
 	// Deploy Spegel.
 	t.Log("Deploying Spegel")
 	command(ctx, t, fmt.Sprintf("kind load docker-image --name %s %s", kindName, imageRef))
-	imageDigest := command(ctx, t, fmt.Sprintf("docker exec %s-worker crictl inspecti -o 'go-template' --template '{{ index .status.repoDigests 0 }}' %s", kindName, imageRef))
-	imageDigest = strings.Split(imageDigest, "@")[1]
+	imagesOutput := command(ctx, t, fmt.Sprintf("docker exec %s-worker ctr -n k8s.io images ls name==%s", kindName, imageRef))
+	_, imagesOutput, ok := strings.Cut(imagesOutput, "\n")
+	require.True(t, ok)
+	imageDigest := strings.Split(imagesOutput, " ")[2]
 	nodes := []string{
 		"control-plane",
 		"worker",


### PR DESCRIPTION
This change fixes broken e2e tests with Kind v0.27.0 due to them upgrading to Containerd v2. The change also pins the e2e tests to use a specific version of Kind.