### PR TITLE
fix(charts): remove metrics label from bootstrap svc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#743](https://github.com/spegel-org/spegel/pull/743) Charts - removed metrics label from bootstrap service
+
 ### Security
 
 ## v0.0.30

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -43,7 +43,6 @@ metadata:
   name: {{ include "spegel.fullname" . }}-bootstrap
   namespace: {{ include "spegel.namespace" . }}
   labels:
-    app.kubernetes.io/component: metrics
     {{- include "spegel.labels" . | nindent 4 }}
 spec:
   selector:


### PR DESCRIPTION
Currently, bootstrap service has `app.kubernetes.io/component: metrics` label, which wrongly leads to selecting the service (e.g. from ServiceMonitor).

This PR drops the wrongly placed label.


