### PR TITLE
Fix topology annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#743](https://github.com/spegel-org/spegel/pull/743) Charts - removed metrics label from bootstrap service
+- [#748](https://github.com/spegel-org/spegel/pull/748) Fix topology annotation.
 
 ### Security
 

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -24,7 +24,7 @@ metadata:
     {{- include "spegel.labels" . | nindent 4 }}
   {{- if .Values.service.registry.topologyAwareHintsEnabled }}
   annotations:
-    service.kubernetes.io/topology-aware-hints: auto
+    service.kubernetes.io/topology-mode: "auto"
   {{- end }}
 spec:
   type: NodePort


### PR DESCRIPTION
Updates the topology annotation from the old `service.kubernetes.io/topology-aware-hints: auto` to the new `service.kubernetes.io/topology-mode: "auto"`.