### PR TITLE
Rename append mirrors to prepend existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#747](https://github.com/spegel-org/spegel/pull/747) Update Go to 1.23.6.
+- [#750](https://github.com/spegel-org/spegel/pull/750) Rename append mirrors to prepend existing.
 
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -46,7 +46,6 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | serviceMonitor.relabelings | list | `[]` | List of relabeling rules to apply the target’s metadata labels. |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Prometheus scrape interval timeout. |
 | spegel.additionalMirrorRegistries | list | `[]` | Additional target mirror registries other than Spegel. |
-| spegel.appendMirrors | bool | `false` | When true existing mirror configuration will be appended to instead of replaced. |
 | spegel.containerdContentPath | string | `"/var/lib/containerd/io.containerd.content.v1.content"` | Path to Containerd content store.. |
 | spegel.containerdMirrorAdd | bool | `true` | If true Spegel will add mirror configuration to the node. |
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
@@ -55,6 +54,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |
+| spegel.prependExisting | bool | `false` | When true existing mirror configuration will be kept and Spegel will prepend it's configuration. |
 | spegel.registries | list | `["https://cgr.dev","https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io","https://lscr.io"]` | Registries for which mirror configuration will be created. |
 | spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | spegel.resolveTags | bool | `true` | When true Spegel will resolve tags to digests. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           {{- end }}
           {{- end }}
           - --resolve-tags={{ .Values.spegel.resolveTags }}
-          - --append-mirrors={{ .Values.spegel.appendMirrors }}
+          - --prepend-existing={{ .Values.spegel.prependExisting }}
         env:
         - name: NODE_IP
         {{- include "networking.nodeIp" . | nindent 10 }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -168,8 +168,8 @@ spegel:
   resolveTags: true
   # -- When true latest tags will be resolved to digests.
   resolveLatestTag: true
-  # -- When true existing mirror configuration will be appended to instead of replaced.
-  appendMirrors: false
+  # -- When true existing mirror configuration will be kept and Spegel will prepend it's configuration.
+  prependExisting: false
 
 verticalPodAutoscaler:
   # -- If true creates a Vertical Pod Autoscaler.

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ type ConfigurationCmd struct {
 	Registries                   []url.URL `arg:"--registries,required,env:REGISTRIES" help:"registries that are configured to be mirrored."`
 	MirrorRegistries             []url.URL `arg:"--mirror-registries,env:MIRROR_REGISTRIES,required" help:"registries that are configured to act as mirrors."`
 	ResolveTags                  bool      `arg:"--resolve-tags,env:RESOLVE_TAGS" default:"true" help:"When true Spegel will resolve tags to digests."`
-	AppendMirrors                bool      `arg:"--append-mirrors,env:APPEND_MIRRORS" default:"false" help:"When true existing mirror configuration will be appended to instead of replaced."`
+	PrependExisting              bool      `arg:"--prepend-existing,env:PREPEND_EXISTING" default:"false" help:"When true existing mirror configuration will be kept and Spegel will prepend it's configuration."`
 }
 
 type BootstrapConfig struct {
@@ -105,7 +105,7 @@ func run(ctx context.Context, args *Arguments) error {
 
 func configurationCommand(ctx context.Context, args *ConfigurationCmd) error {
 	fs := afero.NewOsFs()
-	err := oci.AddMirrorConfiguration(ctx, fs, args.ContainerdRegistryConfigPath, args.Registries, args.MirrorRegistries, args.ResolveTags, args.AppendMirrors)
+	err := oci.AddMirrorConfiguration(ctx, fs, args.ContainerdRegistryConfigPath, args.Registries, args.MirrorRegistries, args.ResolveTags, args.PrependExisting)
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -345,7 +345,7 @@ func createFilters(registries []url.URL) (string, string) {
 // Refer to containerd registry configuration documentation for more information about required configuration.
 // https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 // https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples
-func AddMirrorConfiguration(ctx context.Context, fs afero.Fs, configPath string, registryURLs, mirrorURLs []url.URL, resolveTags, appendToBackup bool) error {
+func AddMirrorConfiguration(ctx context.Context, fs afero.Fs, configPath string, registryURLs, mirrorURLs []url.URL, resolveTags, prependExisting bool) error {
 	log := logr.FromContextOrDiscard(ctx)
 	err := validateRegistries(registryURLs)
 	if err != nil {
@@ -374,7 +374,7 @@ func AddMirrorConfiguration(ctx context.Context, fs afero.Fs, configPath string,
 		if err != nil {
 			return err
 		}
-		if appendToBackup {
+		if prependExisting {
 			existingHosts, err := existingHosts(fs, configPath, registryURL)
 			if err != nil {
 				return err
@@ -382,7 +382,7 @@ func AddMirrorConfiguration(ctx context.Context, fs afero.Fs, configPath string,
 			if existingHosts != "" {
 				templatedHosts = templatedHosts + "\n\n" + existingHosts
 			}
-			log.Info("appending to existing Containerd mirror configuration", "registry", registryURL.String())
+			log.Info("prepending to existing Containerd mirror configuration", "registry", registryURL.String())
 		}
 		fp := path.Join(configPath, registryURL.Host, "hosts.toml")
 		err = fs.MkdirAll(path.Dir(fp), 0o755)


### PR DESCRIPTION
This change renames append mirrors to prepend existing. The new name makes it more clear what the setting actually does also removes a flag with the word mirrors, as there are a lot of them.

Fixes #617 