### PR TITLE
fix(metrics): use appropriate buckets for response size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#747](https://github.com/spegel-org/spegel/pull/747) Update Go to 1.23.6.
 - [#750](https://github.com/spegel-org/spegel/pull/750) Rename append mirrors to prepend existing.
 - [#373](https://github.com/spegel-org/spegel/pull/373) Apply mirror configuration on all registires by default.
+- [#762](https://github.com/spegel-org/spegel/pull/762) Set appropriate buckets for response size
 
 ### Deprecated
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,6 +48,8 @@ var (
 		Subsystem: "http",
 		Name:      "response_size_bytes",
 		Help:      "The size of the HTTP responses.",
+		// 1kB up to 2GB
+		Buckets: prometheus.ExponentialBuckets(1024, 5, 10),
 	}, []string{"handler", "method", "code"})
 	HttpRequestsInflight = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: "http",


### PR DESCRIPTION
Default prometheus bucket are not covering the real response sizes, buckets less then 1.0 doesn't make sense.

Scaled to more reasonable scale 1kB to 50MB, up to discussion. 
