### PR TITLE
feat: allow mounting containerd socket as a directory

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -52,6 +52,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
+| spegel.containerdSockDirMount | bool | `false` | Whether to mount the Containerd socket as directory (true) or as a single socket file (false). Directory mounts are able to survive Containerd restarts, but might raise security concerns depending on your environment. |
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -126,7 +126,7 @@ spec:
             port: registry
         volumeMounts:
           - name: containerd-sock
-            mountPath: {{ .Values.spegel.containerdSock }}
+            mountPath: {{ .Values.spegel.containerdSockDirMount | ternary (.Values.spegel.containerdSock | dir) .Values.spegel.containerdSock }}
           {{- with .Values.spegel.containerdContentPath }}
           - name: containerd-content
             mountPath: {{ . }}
@@ -137,8 +137,8 @@ spec:
       volumes:
         - name: containerd-sock
           hostPath:
-            path: {{ .Values.spegel.containerdSock }}
-            type: Socket
+            path: {{ .Values.spegel.containerdSockDirMount | ternary (.Values.spegel.containerdSock | dir) .Values.spegel.containerdSock }}
+            type: {{ .Values.spegel.containerdSockDirMount | ternary "Directory" "Socket" }}
         {{- with .Values.spegel.containerdContentPath }}
         - name: containerd-content
           hostPath:

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -156,6 +156,9 @@ spegel:
   mirrorResolveTimeout: "20ms"
   # -- Path to Containerd socket.
   containerdSock: "/run/containerd/containerd.sock"
+  # -- Whether to mount the Containerd socket as directory (true) or as a single socket file (false).
+  # Directory mounts are able to survive Containerd restarts, but might raise security concerns depending on your environment.
+  containerdSockDirMount: false
   # -- Containerd namespace where images are stored.
   containerdNamespace: "k8s.io"
   # -- Path to Containerd mirror configuration.


### PR DESCRIPTION
In our testing we learned that spegel is not able to continue functioning after containerd on a node was restarted, while the rest of the node continues functioning fine. This can be seen by it generating a lot of "connection refused" messages in the logs. containerd restarts are of course not a common occurrence, but they can happen (and in our case we intentionally trigger them sometimes). This PR adds an option to make spegel compatible with restarts.

The reason why the current chart configuration is unable to deal with this is that it mounts the socket file directly, which will cause containerd to mount the socket as a pointer to the underlying inode. When containerd is restarted that socket file is removed and re-created, giving it a new inode. So at this point, the mounted socket is pointing to an inode that is not in use anymore, leading to the broken connection. Instead, we can mount the socket parent directory, as this one is not re-created. The socket within then gets updated in the mount as well, which in turn allows the containerd library used by spegel to re-connect.

I added this as an option that will lead to no templated differences for people using the defaults, so that there are no unexpected consequences for those that upgrade their spegel charts from previous versions. Directory mounts have some additional security concerns that people might want to check before they start using them, as this will give the container access to more files than it had before.