### PR TITLE
Add basic authentication support

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -9,6 +9,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for pod assignment. |
+| basicAuthSecretName | string | `""` | Name of secret containing basic authentication credentials for registry. |
 | clusterDomain | string | `"cluster.local."` | Domain configured for service domain names. |
 | commonLabels | object | `{}` | Common labels to apply to all rendered resources. |
 | fullnameOverride | string | `""` | Overrides the full name of the chart. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -67,6 +67,11 @@ spec:
         volumeMounts:
           - name: containerd-config
             mountPath: {{ .Values.spegel.containerdRegistryConfigPath }}
+          {{- if .Values.basicAuthSecretName }}
+          - name: basic-auth
+            mountPath: "/etc/secrets/basic-auth"
+            readOnly: true
+          {{- end }}
       {{- end }}
       containers:
       - name: registry
@@ -139,6 +144,11 @@ spec:
             path: /healthz
             port: registry
         volumeMounts:
+          {{- if .Values.basicAuthSecretName }}
+          - name: basic-auth
+            mountPath: "/etc/secrets/basic-auth"
+            readOnly: true
+          {{- end }}
           - name: containerd-sock
             mountPath: {{ .Values.spegel.containerdSock }}
           {{- with .Values.spegel.containerdContentPath }}
@@ -149,6 +159,11 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
+        {{- with .Values.basicAuthSecretName }}
+        - name: basic-auth
+          secret:
+            secretName: {{ . }}
+        {{- end }}
         - name: containerd-sock
           hostPath:
             path: {{ .Values.spegel.containerdSock }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -133,6 +133,9 @@ grafanaDashboard:
 # -- Priority class name to use for the pod.
 priorityClassName: system-node-critical
 
+# -- Name of secret containing basic authentication credentials for registry.
+basicAuthSecretName: ""
+
 spegel:
   # -- Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR.
   logLevel: "INFO"


### PR DESCRIPTION
This change adds support for basic auth to Spegel. It works by allowing the user to specify a secret name which is expected to be of the type `kubernetes.io/basic-auth`, which will be mounted on the pod. The configuration init container will write the username and password as a basic auth header. While the registry container will use the secret to validate incoming requests. 

Updating the secret will require a restart of all of the pods so that the new secret can be written to the configuration. During this time some outage may occur as some instances will have the new secret configured while others have the old one.

It is worth noting that this is not a perfect solution as the basic auth is stored in plain text on the host configuration. It is however a easy addition for those who wish to have some sort of authentication.

Fixes #732 