### PR TITLE
Add debug view to help validating Spegel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#717](https://github.com/spegel-org/spegel/pull/717) Extend tests for distribution.
 - [#753](https://github.com/spegel-org/spegel/pull/753) Set GOMAXPROCS and GOMEMLIMIT when limits are set.
 - [#792](https://github.com/spegel-org/spegel/pull/792) Add dev deploy recipe to simplify local development.
+- [#791](https://github.com/spegel-org/spegel/pull/791) Add debug view to help validating Spegel.
 
 ### Changed
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -52,6 +52,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
+| spegel.debugWebEnabled | bool | `false` | When true enables debug web page. |
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
 | spegel.mirrorResolveRetries | int | `3` | Max amount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -103,6 +103,7 @@ spec:
           {{- with .Values.spegel.containerdContentPath }}
           - --containerd-content-path={{ . }}
           {{- end }}
+          - --debug-web-enabled={{ .Values.spegel.debugWebEnabled }}
         env:
         {{- if ((.Values.resources).limits).cpu }}
         - name: GOMAXPROCS

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -165,6 +165,8 @@ spegel:
   resolveLatestTag: true
   # -- When true existing mirror configuration will be kept and Spegel will prepend it's configuration.
   prependExisting: false
+  # -- When true enables debug web page.
+  debugWebEnabled: false
 
 verticalPodAutoscaler:
   # -- If true creates a Vertical Pod Autoscaler.

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/prometheus/client_golang v1.21.1
+	github.com/prometheus/common v0.62.0
 	github.com/spf13/afero v1.14.0
 	github.com/stretchr/testify v1.10.0
 	go.etcd.io/bbolt v1.4.0
@@ -168,7 +169,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.50.0 // indirect

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Spegel Debug</title>
+	<link rel="icon" href="https://spegel.dev/favicon.svg" type="image/svg+xml">
+	<script src="https://unpkg.com/htmx.org@2.0.4"></script>
+
+	<style>
+		body {
+			margin: 0;
+			padding: 0;
+			font-family: ui-sans-serif, system-ui, sans-serif, "apple color emoji", "segoe ui emoji", "segoe ui symbol", "noto color emoji";
+			font-size: 16px;
+		}
+
+		.container {
+			max-width: 1366px;
+			width: 100%;
+			margin: 0 auto;
+			padding: 0 20px;
+		}
+
+		.table-container {
+			max-width: 100%;
+			overflow-x: auto;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			text-align: left;
+			padding: 8px;
+			border: 1px solid #ddd;
+		}
+
+		th {
+			background-color: #f4f4f4;
+			font-weight: bold;
+		}
+
+		.stat-container {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+			gap: 16px;
+			width: 100%;
+			margin-bottom: 16px;
+		}
+
+		.stat-box {
+			padding: 16px;
+			border-radius: 8px;
+			box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+			text-align: center;
+		}
+
+		.stat-title {
+			font-size: 14px;
+			color: #555;
+		}
+
+		.stat-value {
+			font-size: 24px;
+			font-weight: bold;
+			margin-top: 8px;
+		}
+
+		.measure-container {
+			padding: 16px;
+			border-radius: 8px;
+			box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+		}
+
+		input[type="text"],
+		button {
+			font-size: 16px;
+			height: 2em;
+			padding: 0 8px;
+			border: 1px solid #ccc;
+		}
+
+		input[type="text"] {
+			width: 100%;
+			max-width: 450px;
+		}
+
+		button {
+			background-color: #1d5a9a;
+			color: white;
+			border: none;
+			cursor: pointer;
+			padding: 0 12px;
+		}
+
+		button:hover {
+			background-color: #164577;
+		}
+	</style>
+</head>
+
+<body>
+	<div class="container">
+		<h1>Spegel</h1>
+
+		<div hx-get="/debug/web/stats" hx-trigger="load, every 2s"></div>
+
+		<div class="measure-container">
+			<h2>Measure Image Pull</h2>
+			<form hx-get="/debug/web/measure" hx-target="#measure-result">
+				<input type="text" name="image" placeholder="ghcr.io/spegel-org/spegel:v0.30.0" />
+				<button>Pull</button>
+			</form>
+			<div id="measure-result"></div>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/internal/web/templates/measure.html
+++ b/internal/web/templates/measure.html
@@ -1,0 +1,40 @@
+{{ if .PeerResults }}
+<h3>Resolved Peers</h3>
+<div class="table-container">
+  <table>
+    <tr>
+      <th style="width: 50%;">Peer</th>
+      <th style="width: 50%;">Duration</th>
+    </tr>
+
+    {{ range .PeerResults }}
+    <tr>
+      <td>{{ .Peer.Addr }}</td>
+      <td>{{ .Duration }}</td>
+    </tr>
+    {{ end }}
+  </table>
+</div>
+
+<h3>Result</h3>
+<div class="table-container">
+  <table>
+    <tr>
+      <th>Identifier</th>
+      <th>Type</th>
+      <th>Size</th>
+      <th>Duration</th>
+    </tr>
+    {{ range .PullResults }}
+    <tr>
+      <td>{{ .Identifier }}</td>
+      <td>{{ .ContentType }}</td>
+      <td>{{ .ContentLength }}</td>
+      <td>{{ .Duration }}</td>
+    </tr>
+    {{ end }}
+  </table>
+</div>
+{{ else }}
+<p>No peers found for image</p>
+{{ end }}

--- a/internal/web/templates/stats.html
+++ b/internal/web/templates/stats.html
@@ -1,0 +1,12 @@
+<div>
+  <div class="stat-container">
+    <div class="stat-box">
+      <div class="stat-title">Images</div>
+      <div class="stat-value">{{ .ImageCount }}</div>
+    </div>
+    <div class="stat-box">
+      <div class="stat-title">Layers</div>
+      <div class="stat-value">{{ .LayerCount }}</div>
+    </div>
+  </div>
+</div>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -1,0 +1,296 @@
+package web
+
+import (
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/go-logr/logr"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/routing"
+)
+
+//go:embed templates/*
+var templatesFS embed.FS
+
+type Web struct {
+	router routing.Router
+	client *http.Client
+	tmpls  *template.Template
+}
+
+func NewWeb(router routing.Router) (*Web, error) {
+	tmpls, err := template.New("").ParseFS(templatesFS, "templates/*")
+	if err != nil {
+		return nil, err
+	}
+	return &Web{
+		router: router,
+		client: &http.Client{},
+		tmpls:  tmpls,
+	}, nil
+}
+
+func (w *Web) Handler(log logr.Logger) http.Handler {
+	log = log.WithName("web")
+	handlers := map[string]func(*http.Request) (string, any, error){
+		"/debug/web/": func(r *http.Request) (string, any, error) {
+			return "index", nil, nil
+		},
+		"/debug/web/stats":   w.stats,
+		"/debug/web/measure": w.measure,
+	}
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h, ok := handlers[req.URL.Path]
+		if !ok {
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+		t, data, err := h(req)
+		if err != nil {
+			log.Error(err, "error when running handler", "path", req.URL.Path)
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		err = w.tmpls.ExecuteTemplate(rw, t+".html", data)
+		if err != nil {
+			log.Error(err, "error rendering page", "path", req.URL.Path)
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+}
+
+func (w *Web) stats(req *http.Request) (string, any, error) {
+	//nolint: errcheck // Ignore error.
+	srvAddr := req.Context().Value(http.LocalAddrContextKey).(net.Addr)
+	resp, err := http.Get(fmt.Sprintf("http://%s/metrics", srvAddr.String()))
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+	parser := expfmt.TextParser{}
+	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
+	if err != nil {
+		return "", nil, err
+	}
+
+	data := struct {
+		ImageCount int64
+		LayerCount int64
+	}{}
+	for _, metric := range metricFamilies["spegel_advertised_images"].Metric {
+		data.ImageCount += int64(*metric.Gauge.Value)
+	}
+	for _, metric := range metricFamilies["spegel_advertised_keys"].Metric {
+		data.LayerCount += int64(*metric.Gauge.Value)
+	}
+	return "stats", data, nil
+}
+
+type measureResult struct {
+	PeerResults []peerResult
+	PullResults []pullResult
+}
+
+type peerResult struct {
+	Peer     netip.AddrPort
+	Duration time.Duration
+}
+
+type pullResult struct {
+	Identifier    string
+	ContentType   string
+	ContentLength string
+	Duration      time.Duration
+}
+
+func (w *Web) measure(req *http.Request) (string, any, error) {
+	// Parse image name.
+	imgName := req.URL.Query().Get("image")
+	if imgName == "" {
+		return "", nil, errors.New("image name cannot be empty")
+	}
+	img, err := oci.ParseImage(imgName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	res := measureResult{}
+
+	// Resolve peers for the given image.
+	resolveStart := time.Now()
+	peerCh, err := w.router.Resolve(req.Context(), imgName, false, 0)
+	if err != nil {
+		return "", nil, err
+	}
+	for peer := range peerCh {
+		res.PeerResults = append(res.PeerResults, peerResult{
+			Peer:     peer,
+			Duration: time.Since(resolveStart),
+		})
+	}
+	if len(res.PeerResults) == 0 {
+		return "measure", res, nil
+	}
+
+	// Pull the image and measure performance.
+	pullResults, err := measureImagePull(w.client, "http://localhost:5000", img)
+	if err != nil {
+		return "", nil, err
+	}
+	res.PullResults = pullResults
+
+	return "measure", res, nil
+}
+
+func measureImagePull(client *http.Client, regURL string, img oci.Image) ([]pullResult, error) {
+	pullResults := []pullResult{}
+	queue := []oci.DistributionPath{
+		{
+			Kind:     oci.DistributionKindManifest,
+			Name:     img.Repository,
+			Digest:   img.Digest,
+			Tag:      img.Tag,
+			Registry: img.Registry,
+		},
+	}
+	for {
+		if len(queue) == 0 {
+			break
+		}
+		pr, dists, err := fetchDistributionPath(client, regURL, queue[0])
+		if err != nil {
+			return nil, err
+		}
+		queue = queue[1:]
+		queue = append(queue, dists...)
+		pullResults = append(pullResults, pr)
+	}
+	return pullResults, nil
+}
+
+func fetchDistributionPath(client *http.Client, regURL string, dist oci.DistributionPath) (pullResult, []oci.DistributionPath, error) {
+	regU, err := url.Parse(regURL)
+	if err != nil {
+		return pullResult{}, nil, err
+	}
+	u := dist.URL()
+	u.Scheme = regU.Scheme
+	u.Host = regU.Host
+
+	pullStart := time.Now()
+	pullReq, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return pullResult{}, nil, err
+	}
+	pullResp, err := client.Do(pullReq)
+	if err != nil {
+		return pullResult{}, nil, err
+	}
+	defer pullResp.Body.Close()
+	if pullResp.StatusCode != http.StatusOK {
+		_, err = io.Copy(io.Discard, pullResp.Body)
+		if err != nil {
+			return pullResult{}, nil, err
+		}
+		return pullResult{}, nil, fmt.Errorf("request returned unexpected status code %s", pullResp.Status)
+	}
+
+	queue := []oci.DistributionPath{}
+	ct := pullResp.Header.Get("Content-Type")
+	switch dist.Kind {
+	case oci.DistributionKindBlob:
+		_, err = io.Copy(io.Discard, pullResp.Body)
+		if err != nil {
+			return pullResult{}, nil, err
+		}
+		ct = "Layer"
+	case oci.DistributionKindManifest:
+		b, err := io.ReadAll(pullResp.Body)
+		if err != nil {
+			return pullResult{}, nil, err
+		}
+		switch ct {
+		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+			var idx ocispec.Index
+			if err := json.Unmarshal(b, &idx); err != nil {
+				return pullResult{}, nil, err
+			}
+			for _, m := range idx.Manifests {
+				if !(m.Platform.OS == runtime.GOOS && m.Platform.Architecture == runtime.GOARCH) {
+					continue
+				}
+				queue = append(queue, oci.DistributionPath{
+					Kind:     oci.DistributionKindManifest,
+					Name:     dist.Name,
+					Digest:   m.Digest,
+					Registry: dist.Registry,
+				})
+			}
+			ct = "Index"
+		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+			var manifest ocispec.Manifest
+			err := json.Unmarshal(b, &manifest)
+			if err != nil {
+				return pullResult{}, nil, err
+			}
+			queue = append(queue, oci.DistributionPath{
+				Kind:     oci.DistributionKindManifest,
+				Name:     dist.Name,
+				Digest:   manifest.Config.Digest,
+				Registry: dist.Registry,
+			})
+			for _, layer := range manifest.Layers {
+				queue = append(queue, oci.DistributionPath{
+					Kind:     oci.DistributionKindBlob,
+					Name:     dist.Name,
+					Digest:   layer.Digest,
+					Registry: dist.Registry,
+				})
+			}
+			ct = "Manifest"
+		case ocispec.MediaTypeImageConfig:
+			ct = "Config"
+		}
+	}
+	pullResp.Body.Close()
+
+	i, err := strconv.ParseInt(pullResp.Header.Get("Content-Length"), 10, 0)
+	if err != nil {
+		return pullResult{}, nil, err
+	}
+	return pullResult{
+		Identifier:    dist.Reference(),
+		ContentType:   ct,
+		ContentLength: formatByteSize(i),
+		Duration:      time.Since(pullStart),
+	}, queue, nil
+}
+
+func formatByteSize(size int64) string {
+	const unit = 1000
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+	div, exp := int64(unit), 0
+	for n := size / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(size)/float64(div), "kMGTPE"[exp])
+}

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -1,0 +1,124 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spegel-org/spegel/pkg/oci"
+)
+
+func TestMeasureImagePull(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v2/test/image/manifests/index":
+			rw.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
+			idx := ocispec.Index{
+				Manifests: []ocispec.Descriptor{
+					{
+						Digest: digest.Digest("manifest"),
+						Platform: &ocispec.Platform{
+							OS:           runtime.GOOS,
+							Architecture: runtime.GOARCH,
+						},
+					},
+				},
+			}
+			b, err := json.Marshal(&idx)
+			if err != nil {
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			//nolint: errcheck // Ignore error.
+			rw.Write(b)
+		case "/v2/test/image/manifests/manifest":
+			rw.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+			manifest := ocispec.Manifest{
+				Config: ocispec.Descriptor{
+					Digest: digest.Digest("config"),
+				},
+				Layers: []ocispec.Descriptor{
+					{
+						Digest: digest.Digest("layer"),
+					},
+				},
+			}
+			b, err := json.Marshal(&manifest)
+			if err != nil {
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			//nolint: errcheck // Ignore error.
+			rw.Write(b)
+		case "/v2/test/image/manifests/config":
+			rw.Header().Set("Content-Type", ocispec.MediaTypeImageConfig)
+			config := ocispec.ImageConfig{
+				User: "root",
+			}
+			b, err := json.Marshal(&config)
+			if err != nil {
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			//nolint: errcheck // Ignore error.
+			rw.Write(b)
+		case "/v2/test/image/blobs/layer":
+			//nolint: errcheck // Ignore error.
+			rw.Write([]byte("Hello World"))
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(func() {
+		srv.Close()
+	})
+
+	img := oci.Image{
+		Repository: "test/image",
+		Digest:     digest.Digest("index"),
+		Registry:   "example.com",
+	}
+	pullResults, err := measureImagePull(srv.Client(), srv.URL, img)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, pullResults)
+}
+
+func TestFormatByteSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expected string
+		size     int64
+	}{
+		{
+			size:     1,
+			expected: "1 B",
+		},
+		{
+			size:     18954,
+			expected: "19.0 kB",
+		},
+		{
+			size:     1000000000,
+			expected: "1.0 GB",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(strconv.FormatInt(tt.size, 10), func(t *testing.T) {
+			t.Parallel()
+
+			result := formatByteSize(tt.size)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This change adds a debug web view to Spegel which allow users to see some quick stats and also test pull images from within the network to verify functionality. This feature is kept small for now but is a spring board for future features that could be implemented based on user feedback.

![image](https://github.com/user-attachments/assets/e341f486-bc17-4516-89cd-127602b3915f)

Fixes #715 
