### PR TITLE
Set default memory request and limit in Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#778](https://github.com/spegel-org/spegel/pull/778) Replace interface{} with any alias.
 - [#784](https://github.com/spegel-org/spegel/pull/784) Refactor distribution and move to OCI package.
 - [#787](https://github.com/spegel-org/spegel/pull/787) Refactor OCI image to allow parsing without digest.
+- [#794](https://github.com/spegel-org/spegel/pull/794) Set default memory request and limit in Helm chart.
 
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -28,7 +28,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | podAnnotations | object | `{}` | Annotations to add to the pod. |
 | podSecurityContext | object | `{}` | Security context for the pod. |
 | priorityClassName | string | `"system-node-critical"` | Priority class name to use for the pod. |
-| resources | object | `{}` | Resource requests and limits for the Spegel container. |
+| resources | object | `{"limits":{"memory":"128Mi"},"requests":{"memory":"128Mi"}}` | Resource requests and limits for the Spegel container. |
 | revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | securityContext | object | `{}` | Security context for the Spegel container. |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -63,17 +63,11 @@ service:
     port: 9090
 
 # -- Resource requests and limits for the Spegel container.
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  requests:
+    memory: 128Mi
+  limits:
+    memory: 128Mi
 
 # -- Node selector for pod assignment.
 nodeSelector:


### PR DESCRIPTION
This change sets a default value for memory requests and limits. This is to make sure that the container memory usage does not continually increase due to the VFS cache.

Fixes #718 