### PR TITLE
Fix helm values naming for additionalMirrorTargets and mirroredRegistries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#785](https://github.com/spegel-org/spegel/pull/785) Fix verification of digests when parsing distribution path.
 - [#798](https://github.com/spegel-org/spegel/pull/798) Restart Spegel if Containerd event subscription is disconnected.
 - [#800](https://github.com/spegel-org/spegel/pull/800) Fix so that host is closed even when a bootstrap error occurs.
+- [#801](https://github.com/spegel-org/spegel/pull/801) Fix helm values naming for additionalMirrorTargets and mirroredRegistries.
 
 ### Security
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -46,7 +46,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | serviceMonitor.metricRelabelings | list | `[]` | List of relabeling rules to apply to the samples before ingestion. |
 | serviceMonitor.relabelings | list | `[]` | List of relabeling rules to apply the target’s metadata labels. |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Prometheus scrape interval timeout. |
-| spegel.additionalMirrorRegistries | list | `[]` | Additional target mirror registries other than Spegel. |
+| spegel.additionalMirrorTargets | list | `[]` | Additional target mirror registries other than Spegel. |
 | spegel.containerdContentPath | string | `"/var/lib/containerd/io.containerd.content.v1.content"` | Path to Containerd content store.. |
 | spegel.containerdMirrorAdd | bool | `true` | If true Spegel will add mirror configuration to the node. |
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           - --mirror-targets
           - http://$(NODE_IP):{{ .Values.service.registry.hostPort }}
           - http://$(NODE_IP):{{ .Values.service.registry.nodePort }}
-          {{- with .Values.spegel.additionalMirrorRegistries }}
+          {{- with .Values.spegel.additionalMirrorTargets }}
           {{- range . }}
           - {{ . | quote }}
           {{- end }}
@@ -87,7 +87,7 @@ spec:
           - --registry-addr=:{{ .Values.service.registry.port }}
           - --router-addr=:{{ .Values.service.router.port }}
           - --metrics-addr=:{{ .Values.service.metrics.port }}
-          {{- with .Values.spegel.registries }}
+          {{- with .Values.spegel.mirroredRegistries }}
           - --mirrored-registries
           {{- range . }}
           - {{ . | quote }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -138,7 +138,7 @@ spegel:
     # - https://docker.io
     # - https://ghcr.io
   # -- Additional target mirror registries other than Spegel.
-  additionalMirrorRegistries: []
+  additionalMirrorTargets: []
   # -- Max amount of mirrors to attempt.
   mirrorResolveRetries: 3
   # -- Max duration spent finding a mirror.


### PR DESCRIPTION
This change does two things. It renames `additionalMirrorRegistries` to `additionalMirrorTargets` so that it aligns better with the name change. It also fixes the name change to `mirroredRegistries` which missed a change in #373.