### PR TITLE
Fix verification of Containerd configuration with suffixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,8 @@ linters:
           alias: digest
         - pkg: github.com/opencontainers/image-spec/specs-go/v1
           alias: ocispec
+        - pkg: k8s.io/apimachinery/pkg/util/version
+          alias: utilversion
       no-extra-aliases: true
     nolintlint:
       require-explanation: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#807](https://github.com/spegel-org/spegel/pull/807) Update golangci lint and fix new issues.
 - [#810](https://github.com/spegel-org/spegel/pull/810) Increase timeout to avoid flakiness in conformance tests.
+- [#806](https://github.com/spegel-org/spegel/pull/806) Fix verification of Containerd configuration with suffixes.
 
 ### Security
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.6
 toolchain go1.24.1
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/alexflint/go-arg v1.5.1
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/containerd/v2 v2.0.4
@@ -29,6 +28,7 @@ require (
 	go.etcd.io/bbolt v1.4.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.71.0
+	k8s.io/apimachinery v0.32.3
 	k8s.io/cri-api v0.32.3
 	k8s.io/klog/v2 v2.130.1
 )
@@ -37,6 +37,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -793,6 +793,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+k8s.io/apimachinery v0.32.3 h1:JmDuDarhDmA/Li7j3aPrwhpNBA94Nvk5zLeOge9HH1U=
+k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
 k8s.io/cri-api v0.32.3 h1:E8VXbXNn4yAgmuKTeNzg0C1MFSxzTdlHSwUvjuYlPTY=
 k8s.io/cri-api v0.32.3/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -31,6 +31,47 @@ func TestNewContainerd(t *testing.T) {
 	require.Equal(t, "local", c.contentPath)
 }
 
+func TestCanVerifyContainerdConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{
+			version:  "v2.0.2",
+			expected: false,
+		},
+		{
+			version:  "2.1.4",
+			expected: false,
+		},
+		{
+			version:  "v1.7.27",
+			expected: true,
+		},
+		{
+			version:  "1.6.0",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		// Testing with a suffix is important as some Linux distributions will modify the version
+		// with a non Semver compliant modification. Even if the version is supposed to comply with
+		// semver that may not always be the case.
+		for _, suffix := range []string{"", "~ds1"} {
+			version := tt.version + suffix
+			t.Run(version, func(t *testing.T) {
+				t.Parallel()
+
+				ok, err := canVerifyContainerdConfiguration(tt.version)
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, ok)
+			})
+		}
+	}
+}
+
 func TestVerifyStatusResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This changes the how we parse Containerd versions when attempting to check Containerd configuration. Some Linux distributions will add  a suffix to the version of Containerd as part of the release process when the dependency is built. So in Debian for example the version would be `1.6.20~ds1 ` instead of `1.6.20`. Before this change we would error because the reported version is not Semver compliant. Kubernetes already deals with this in their method of parsing Semver, most likely for the same issues that we are facing. So switching to their dependency will make sure that at least we are able to parse the same versions that Kubernetes can.

Fixes #729 