### PR TITLE
Switch to using new test context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#812](https://github.com/spegel-org/spegel/pull/812) Upgrade to Go 1.24.1 and switch to use go tool for helm docs.
 - [#725](https://github.com/spegel-org/spegel/pull/725) Remove use of httputil reverse proxy.
+- [#820](https://github.com/spegel-org/spegel/pull/820) Switch to using new test context.
 
 ### Deprecated
 

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -1,7 +1,6 @@
 package oci
 
 import (
-	"context"
 	"fmt"
 	iofs "io/fs"
 	"maps"
@@ -602,7 +601,7 @@ Authorization = 'Basic aGVsbG86d29ybGQ='`,
 				err := afero.WriteFile(fs, k, []byte(v), 0o644)
 				require.NoError(t, err)
 			}
-			err := AddMirrorConfiguration(context.TODO(), fs, registryConfigPath, tt.registries, tt.mirrors, tt.resolveTags, tt.prependExisting, tt.username, tt.password)
+			err := AddMirrorConfiguration(t.Context(), fs, registryConfigPath, tt.registries, tt.mirrors, tt.resolveTags, tt.prependExisting, tt.username, tt.password)
 			require.NoError(t, err)
 			ok, err := afero.DirExists(fs, "/etc/containerd/certs.d/_backup")
 			require.NoError(t, err)
@@ -633,19 +632,19 @@ func TestMirrorConfigurationInvalidMirrorURL(t *testing.T) {
 	mirrors := stringListToUrlList(t, []string{"http://127.0.0.1:5000"})
 
 	registries := stringListToUrlList(t, []string{"ftp://docker.io"})
-	err := AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
+	err := AddMirrorConfiguration(t.Context(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
 	require.EqualError(t, err, "invalid registry url scheme must be http or https: ftp://docker.io")
 
 	registries = stringListToUrlList(t, []string{"https://docker.io/foo/bar"})
-	err = AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
+	err = AddMirrorConfiguration(t.Context(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
 	require.EqualError(t, err, "invalid registry url path has to be empty: https://docker.io/foo/bar")
 
 	registries = stringListToUrlList(t, []string{"https://docker.io?foo=bar"})
-	err = AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
+	err = AddMirrorConfiguration(t.Context(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
 	require.EqualError(t, err, "invalid registry url query has to be empty: https://docker.io?foo=bar")
 
 	registries = stringListToUrlList(t, []string{"https://foo@docker.io"})
-	err = AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
+	err = AddMirrorConfiguration(t.Context(), fs, "/etc/containerd/certs.d", registries, mirrors, true, false, "", "")
 	require.EqualError(t, err, "invalid registry url user has to be empty: https://foo@docker.io")
 }
 

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -1,7 +1,6 @@
 package oci
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -51,7 +50,7 @@ func TestOCIClient(t *testing.T) {
 	require.NoError(t, err)
 	db := metadata.NewDB(boltDB, contentStore, nil)
 	imageStore := metadata.NewImageStore(db)
-	ctx := namespaces.WithNamespace(context.TODO(), "k8s.io")
+	ctx := namespaces.WithNamespace(t.Context(), "k8s.io")
 	for _, img := range imgs {
 		dgst, err := digest.Parse(img["digest"])
 		require.NoError(t, err)

--- a/pkg/routing/memory_test.go
+++ b/pkg/routing/memory_test.go
@@ -1,7 +1,6 @@
 package routing
 
 import (
-	"context"
 	"net/netip"
 	"testing"
 	"time"
@@ -12,20 +11,19 @@ import (
 func TestMemoryRouter(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	r := NewMemoryRouter(map[string][]netip.AddrPort{}, netip.AddrPort{})
 
-	isReady, err := r.Ready(ctx)
+	isReady, err := r.Ready(t.Context())
 	require.NoError(t, err)
 	require.False(t, isReady)
-	err = r.Advertise(ctx, []string{"foo"})
+	err = r.Advertise(t.Context(), []string{"foo"})
 	require.NoError(t, err)
-	isReady, err = r.Ready(ctx)
+	isReady, err = r.Ready(t.Context())
 	require.NoError(t, err)
 	require.True(t, isReady)
 
 	r.Add("foo", netip.MustParseAddrPort("127.0.0.1:9090"))
-	peerCh, err := r.Resolve(ctx, "foo", true, 2)
+	peerCh, err := r.Resolve(t.Context(), "foo", true, 2)
 	require.NoError(t, err)
 	peers := []netip.AddrPort{}
 	for peer := range peerCh {
@@ -36,7 +34,7 @@ func TestMemoryRouter(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, peers, 2)
 
-	peerCh, err = r.Resolve(ctx, "bar", false, 1)
+	peerCh, err = r.Resolve(t.Context(), "bar", false, 1)
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 	select {

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -19,10 +19,10 @@ import (
 func TestP2PRouter(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	bs := NewStaticBootstrapper()
-	router, err := NewP2PRouter(context.TODO(), "localhost:0", bs, "9090")
+	router, err := NewP2PRouter(ctx, "localhost:0", bs, "9090")
 	require.NoError(t, err)
 
 	g, gCtx := errgroup.WithContext(ctx)
@@ -57,23 +57,23 @@ func TestReady(t *testing.T) {
 	t.Parallel()
 
 	bs := NewStaticBootstrapper()
-	router, err := NewP2PRouter(context.TODO(), "localhost:0", bs, "9090")
+	router, err := NewP2PRouter(t.Context(), "localhost:0", bs, "9090")
 	require.NoError(t, err)
 
 	// Should not be ready if no peers are found.
-	isReady, err := router.Ready(context.TODO())
+	isReady, err := router.Ready(t.Context())
 	require.NoError(t, err)
 	require.False(t, isReady)
 
 	// Should be ready if only peer is host.
 	bs.SetPeers([]peer.AddrInfo{*host.InfoFromHost(router.host)})
-	isReady, err = router.Ready(context.TODO())
+	isReady, err = router.Ready(t.Context())
 	require.NoError(t, err)
 	require.True(t, isReady)
 
 	// Shouldd be not ready with multiple peers but empty routing table.
 	bs.SetPeers([]peer.AddrInfo{{}, {}})
-	isReady, err = router.Ready(context.TODO())
+	isReady, err = router.Ready(t.Context())
 	require.NoError(t, err)
 	require.False(t, isReady)
 
@@ -84,7 +84,7 @@ func TestReady(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	bs.SetPeers([]peer.AddrInfo{{}, {}})
-	isReady, err = router.Ready(context.TODO())
+	isReady, err = router.Ready(t.Context())
 	require.NoError(t, err)
 	require.True(t, isReady)
 }
@@ -93,7 +93,7 @@ func TestBootstrapFunc(t *testing.T) {
 	t.Parallel()
 
 	log := tlog.NewTestLogger(t)
-	ctx := logr.NewContext(context.Background(), log)
+	ctx := logr.NewContext(t.Context(), log)
 
 	mn, err := mocknet.WithNPeers(2)
 	require.NoError(t, err)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -74,7 +74,7 @@ func TestTrack(t *testing.T) {
 			t.Parallel()
 
 			log := tlog.NewTestLogger(t)
-			ctx := logr.NewContext(context.Background(), log)
+			ctx := logr.NewContext(t.Context(), log)
 			ctx, cancel := context.WithCancel(ctx)
 
 			router := routing.NewMemoryRouter(map[string][]netip.AddrPort{}, netip.MustParseAddrPort("127.0.0.1:5000"))


### PR DESCRIPTION
This change makes use of the new `t.Context()` in tests, which makes sure contexts will cancel when tests cancel.