### PR TITLE
Add topology aware routing

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ type RegistryCmd struct {
 	ContainerdContentPath        string        `arg:"--containerd-content-path,env:CONTAINERD_CONTENT_PATH" default:"/var/lib/containerd/io.containerd.content.v1.content" help:"Path to Containerd content store"`
 	RouterAddr                   string        `arg:"--router-addr,env:ROUTER_ADDR,required" help:"address to serve router."`
 	RegistryAddr                 string        `arg:"--registry-addr,env:REGISTRY_ADDR,required" help:"address to server image registry."`
+	Zone                         string        `arg:"--zone,env:ZONE" help:"If set the router will prioritize peers within the same zone."`
 	MirroredRegistries           []url.URL     `arg:"--mirrored-registries,env:MIRRORED_REGISTRIES" help:"Registries that are configured to be mirrored, if slice is empty all registires are mirrored."`
 	MirrorResolveTimeout         time.Duration `arg:"--mirror-resolve-timeout,env:MIRROR_RESOLVE_TIMEOUT" default:"20ms" help:"Max duration spent finding a mirror."`
 	MirrorResolveRetries         int           `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
@@ -143,7 +144,11 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	if err != nil {
 		return err
 	}
-	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper, registryPort)
+
+	p2pOpts := []routing.P2PRouterOption{
+		routing.Zone(args.Zone),
+	}
+	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper, registryPort, p2pOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -23,13 +23,16 @@ func TestP2PRouterOptions(t *testing.T) {
 	libp2pOpts := []libp2p.Option{
 		libp2p.ListenAddrStrings("foo"),
 	}
+	zone := "west-1-a"
 	opts := []P2PRouterOption{
 		LibP2POptions(libp2pOpts...),
+		Zone(zone),
 	}
 	cfg := P2PRouterConfig{}
 	err := cfg.Apply(opts...)
 	require.NoError(t, err)
-	require.Equal(t, libp2pOpts, cfg.libp2pOpts)
+	require.Equal(t, libp2pOpts, cfg.Libp2pOpts)
+	require.Equal(t, zone, cfg.Zone)
 }
 
 func TestP2PRouter(t *testing.T) {


### PR DESCRIPTION
This change will add network topology aware routing. When enabled, peers in the same zone will be tried first before other peers. This will hopefully reduce cost and increase performance. This implementation is most likely not the most efficient implementation but is hopefully better than nothing. Until we can verify that there are no negative effects at scale it will be marked as experimental.

The feature works by exposing a endpoint within the p2p network which allows sharing of its zone. As peers are discovered the zone is checked and compared. If the zone is the same the peer will be immediately added to the channel. If the zones are different of if the zone could not be determined the peer will be added to a buffer list. This buffer list will only be written from if the desired peers within the same zone has not been found. Such an implementation means that peers in the same zone will always be attempted first.

There are two main downsides of this implementation. The first being that when content only exists in peers within different zones, the minimum latency until the peer is returned is the same as the maximum lookup latency, which by default is 20ms. The other downside is that more peers need to be discovered due to the nature of Kademlia. As Kademlia does random lookups and there are three different zones there is a 33% chance that a peer is within the same zone. If we want to return 3 peers at most we will need to have to discover more than 3 peers to overcome the probability that only one of them is in the same zone.

In the future this feature may be revised based on future discovery. It will have minimal impact on end users as the API exposed to configure the feature will not need to change. All end users need to worry about is that the zone name is passed to Spegel on startup.

Fixes #669 