### PR TITLE
Fix improper image string formatting and expand tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#824](https://github.com/spegel-org/spegel/pull/824) Fix improper image string formatting and expand tests.
+
 ### Security
 
 ## v0.1.1

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -50,7 +50,7 @@ func (i Image) String() string {
 	if i.Digest != "" {
 		digest = "@" + i.Digest.String()
 	}
-	return fmt.Sprintf("%s/%s%s@%s", i.Registry, i.Repository, tag, digest)
+	return fmt.Sprintf("%s/%s%s%s", i.Registry, i.Repository, tag, digest)
 }
 
 func (i Image) TagName() (string, bool) {


### PR DESCRIPTION
During the refactoring of OCI images some error was introduced in the image string formatting. This doesn't have an functional impact as it is only used in errors and logs but still causes confusion.