### PR TITLE
Remove local address check when resolving peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#831](https://github.com/spegel-org/spegel/pull/831) Remove local address check when resolving peers.
+
 ### Fixed
 
 - [#824](https://github.com/spegel-org/spegel/pull/824) Fix improper image string formatting and expand tests.

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -99,7 +99,6 @@ spec:
           - --bootstrap-kind=dns
           - --dns-bootstrap-domain={{ include "spegel.fullname" . }}-bootstrap.{{ include "spegel.namespace" . }}.svc.{{ .Values.clusterDomain }}
           - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
-          - --local-addr=$(NODE_IP):{{ .Values.service.registry.hostPort }}
           {{- with .Values.spegel.containerdContentPath }}
           - --containerd-content-path={{ . }}
           {{- end }}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -134,7 +134,7 @@ func (w *Web) measure(req *http.Request) (string, any, error) {
 
 	// Resolve peers for the given image.
 	resolveStart := time.Now()
-	peerCh, err := w.router.Resolve(req.Context(), imgName, false, 0)
+	peerCh, err := w.router.Resolve(req.Context(), imgName, 0)
 	if err != nil {
 		return "", nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ type RegistryCmd struct {
 	BootstrapConfig
 	ContainerdRegistryConfigPath string        `arg:"--containerd-registry-config-path,env:CONTAINERD_REGISTRY_CONFIG_PATH" default:"/etc/containerd/certs.d" help:"Directory where mirror configuration is written."`
 	MetricsAddr                  string        `arg:"--metrics-addr,required,env:METRICS_ADDR" help:"address to serve metrics."`
-	LocalAddr                    string        `arg:"--local-addr,required,env:LOCAL_ADDR" help:"Address that the local Spegel instance will be reached at."`
 	ContainerdSock               string        `arg:"--containerd-sock,env:CONTAINERD_SOCK" default:"/run/containerd/containerd.sock" help:"Endpoint of containerd service."`
 	ContainerdNamespace          string        `arg:"--containerd-namespace,env:CONTAINERD_NAMESPACE" default:"k8s.io" help:"Containerd namespace to fetch images from."`
 	ContainerdContentPath        string        `arg:"--containerd-content-path,env:CONTAINERD_CONTENT_PATH" default:"/var/lib/containerd/io.containerd.content.v1.content" help:"Path to Containerd content store"`
@@ -165,7 +164,6 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		registry.WithResolveLatestTag(args.ResolveLatestTag),
 		registry.WithResolveRetries(args.MirrorResolveRetries),
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
-		registry.WithLocalAddress(args.LocalAddr),
 		registry.WithLogger(log),
 		registry.WithBasicAuth(username, password),
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,7 +18,7 @@ var (
 	MirrorRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "spegel_mirror_requests_total",
 		Help: "Total number of mirror requests.",
-	}, []string{"registry", "cache", "source"})
+	}, []string{"registry", "cache"})
 	ResolveDurHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "spegel_resolve_duration_seconds",
 		Help: "The duration for router to resolve a peer.",

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spegel-org/spegel/internal/mux"
+	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
 )
 
@@ -128,7 +129,7 @@ func TestMirrorHandler(t *testing.T) {
 		"sha256:11242d2a347bf8ab30b9f92d5ca219bbbedf95df5a8b74631194561497c1fae8": {badAddrPort, badAddrPort, goodAddrPort},
 	}
 	router := routing.NewMemoryRouter(resolver, netip.AddrPort{})
-	reg := NewRegistry(nil, router)
+	reg := NewRegistry(oci.NewMemory(), router)
 
 	tests := []struct {
 		expectedHeaders map[string][]string

--- a/pkg/routing/memory.go
+++ b/pkg/routing/memory.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 )
 
+var _ Router = &MemoryRouter{}
+
 type MemoryRouter struct {
 	resolver map[string][]netip.AddrPort
 	self     netip.AddrPort
@@ -27,7 +29,7 @@ func (m *MemoryRouter) Ready(ctx context.Context) (bool, error) {
 	return len(m.resolver) > 0, nil
 }
 
-func (m *MemoryRouter) Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan netip.AddrPort, error) {
+func (m *MemoryRouter) Resolve(ctx context.Context, key string, count int) (<-chan netip.AddrPort, error) {
 	m.mx.RLock()
 	peers, ok := m.resolver[key]
 	m.mx.RUnlock()

--- a/pkg/routing/memory_test.go
+++ b/pkg/routing/memory_test.go
@@ -23,7 +23,7 @@ func TestMemoryRouter(t *testing.T) {
 	require.True(t, isReady)
 
 	r.Add("foo", netip.MustParseAddrPort("127.0.0.1:9090"))
-	peerCh, err := r.Resolve(t.Context(), "foo", true, 2)
+	peerCh, err := r.Resolve(t.Context(), "foo", 2)
 	require.NoError(t, err)
 	peers := []netip.AddrPort{}
 	for peer := range peerCh {
@@ -34,7 +34,7 @@ func TestMemoryRouter(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, peers, 2)
 
-	peerCh, err = r.Resolve(t.Context(), "bar", false, 1)
+	peerCh, err = r.Resolve(t.Context(), "bar", 1)
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 	select {

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -54,6 +54,8 @@ func LibP2POptions(opts ...libp2p.Option) P2PRouterOption {
 	}
 }
 
+var _ Router = &P2PRouter{}
+
 type P2PRouter struct {
 	bootstrapper Bootstrapper
 	host         host.Host
@@ -184,7 +186,7 @@ func (r *P2PRouter) Ready(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (r *P2PRouter) Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan netip.AddrPort, error) {
+func (r *P2PRouter) Resolve(ctx context.Context, key string, count int) (<-chan netip.AddrPort, error) {
 	log := logr.FromContextOrDiscard(ctx).WithValues("host", r.host.ID().String(), "key", key)
 	c, err := createCid(key)
 	if err != nil {
@@ -202,9 +204,6 @@ func (r *P2PRouter) Resolve(ctx context.Context, key string, allowSelf bool, cou
 		resolveTimer := prometheus.NewTimer(metrics.ResolveDurHistogram.WithLabelValues("libp2p"))
 		for addrInfo := range addrInfoCh {
 			resolveTimer.ObserveDuration()
-			if !allowSelf && addrInfo.ID == r.host.ID() {
-				continue
-			}
 			if len(addrInfo.Addrs) != 1 {
 				addrs := []string{}
 				for _, addr := range addrInfo.Addrs {

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -52,14 +52,14 @@ func TestP2PRouter(t *testing.T) {
 
 	err = router.Advertise(ctx, nil)
 	require.NoError(t, err)
-	peerCh, err := router.Resolve(ctx, "foo", true, 1)
+	peerCh, err := router.Resolve(ctx, "foo", 1)
 	require.NoError(t, err)
 	peer := <-peerCh
 	require.False(t, peer.IsValid())
 
 	err = router.Advertise(ctx, []string{"foo"})
 	require.NoError(t, err)
-	peerCh, err = router.Resolve(ctx, "foo", true, 1)
+	peerCh, err = router.Resolve(ctx, "foo", 1)
 	require.NoError(t, err)
 	peer = <-peerCh
 	require.True(t, peer.IsValid())

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -10,7 +10,7 @@ type Router interface {
 	// Ready returns true when the router is ready.
 	Ready(ctx context.Context) (bool, error)
 	// Resolve asynchronously discovers addresses that can serve the content defined by the give key.
-	Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan netip.AddrPort, error)
+	Resolve(ctx context.Context, key string, count int) (<-chan netip.AddrPort, error)
 	// Advertise broadcasts that the current router can serve the content.
 	Advertise(ctx context.Context, keys []string) error
 }


### PR DESCRIPTION
Early on I had this idea that I should not route to self if the request comes from the node Spegel is running on. I think the idea behind it was that content would somehow be different on other nodes. This is partially true if you are reusing tags and changing their digests but not otherwise. Any client requesting data should be served that data with as few hops as possible. We have already documented how to deal with the side effects of Spegel and tag reuse so this should not be a problem anymore.

Another challenge that I was not aware of when implementing this feature originally is that the reported IP in the request varies based on the CNI used. Which in turn made the IP detection logic flaky and sometimes always report requests as coming from an external source. As there does not seem to be any standard to do this it is just easier to remove the feature all together.

This changes so that the content requested will be checked for locally first, and if it exists locally the content will be served immediately without any proxy forwarding.

This should also remove some complexity when implementing #823.