### PR TITLE
Add delete hook to cleanup configuration from host when chart is uninstalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#832](https://github.com/spegel-org/spegel/pull/832) Add delete hook to cleanup configuration from host when chart is uninstalled.
+
 ### Changed
 
 - [#812](https://github.com/spegel-org/spegel/pull/812) Upgrade to Go 1.24.1 and switch to use go tool for helm docs.

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -31,6 +31,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | resources | object | `{"limits":{"memory":"128Mi"},"requests":{"memory":"128Mi"}}` | Resource requests and limits for the Spegel container. |
 | revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
 | securityContext | object | `{}` | Security context for the Spegel container. |
+| service.cleanup.port | int | `8080` | Port to expose cleanup probe on. |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |
 | service.registry.hostPort | int | `30020` | Local host port to expose the registry. |
 | service.registry.nodeIp | string | `""` | Override the NODE_ID environment variable. It defaults to the field status.hostIP |

--- a/charts/spegel/templates/post-delete-hook.yaml
+++ b/charts/spegel/templates/post-delete-hook.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.spegel.containerdMirrorAdd }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "spegel.fullname" . }}-cleanup
+  namespace: {{ include "spegel.namespace" . }}
+  labels:
+    app.kubernetes.io/component: cleanup
+    {{- include "spegel.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "post-delete"
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
+    helm.sh/hook-weight: "0"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: cleanup
+      {{- include "spegel.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cleanup
+        {{- include "spegel.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      containers:
+      - name: cleanup
+        image: "{{ include "spegel.image" . }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - cleanup
+          - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
+          - --addr=:{{ .Values.service.cleanup.port }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: readiness
+        ports:
+          - name: readiness
+            containerPort: {{ .Values.service.cleanup.port }}
+            protocol: TCP
+        volumeMounts:
+          - name: containerd-config
+            mountPath: {{ .Values.spegel.containerdRegistryConfigPath }}
+      volumes:
+        - name: containerd-config
+          hostPath:
+            path: {{ .Values.spegel.containerdRegistryConfigPath }}
+            type: DirectoryOrCreate
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spegel.fullname" . }}-cleanup
+  namespace: {{ include "spegel.namespace" . }}
+  labels:
+    app.kubernetes.io/component: cleanup
+    {{- include "spegel.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "post-delete"
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
+    helm.sh/hook-weight: "0"
+spec:
+  selector:
+    app.kubernetes.io/component: cleanup
+    {{- include "spegel.selectorLabels" . | nindent 4 }}
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: readiness
+      port: {{ .Values.service.cleanup.port }}
+      protocol: TCP
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "spegel.fullname" . }}-cleanup-wait
+  namespace: {{ include "spegel.namespace" . }}
+  labels:
+    app.kubernetes.io/component: cleanup-wait
+    {{- include "spegel.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "post-delete"
+    helm.sh/hook-delete-policy: "before-hook-creation, hook-succeeded"
+    helm.sh/hook-weight: "1"
+spec:
+  containers:
+    - name: cleanup-wait
+      image: "{{ include "spegel.image" . }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      args:
+        - cleanup-wait
+        - --probe-endpoint={{ include "spegel.fullname" . }}-cleanup.{{ include "spegel.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.cleanup.port }}
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+{{- end }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -61,6 +61,9 @@ service:
   metrics:
     # -- Port to expose the metrics via the service.
     port: 9090
+  cleanup:
+    # -- Port to expose cleanup probe on.
+    port: 8080
 
 # -- Resource requests and limits for the Spegel container.
 resources:


### PR DESCRIPTION
This only took me two years but finally was able to come up with a solution that I don't hate. Its also a solution that has been right in front of me the whole time.

The cleanup solution uses Helm delete hooks to create a DaemonSet when the chart is uninstalled. These pods run the cleanup command which will clear the Containerd mirror configuration directory and restore any files from the backup directory. The solution would have ended there if Helm supported health checking DaemonSets as part as hooks, but it doesn't.

To enable Helm to remove the DaemonSet when the cleanup succeeds we need to create a waiting Pod. Without this Pod Helm would remove the DaemonSet as soon as it was created. With the Pod Helm will wait for the Pod to successfully complete running. Nothing will be deleted until that happens. We use this to our benefit, by having the wait Pod poll the cleanup readiness probe of all the cleanup pods. This probe is only running once the cleanup has succeeded. When the probes from all of the Pods are successful the wait Pod will exit successfully which in turn triggers Helm to remove all of the hook resources.

Fixes #67 