### PR TITLE
Set default workflow permissions where it was missing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,8 @@
 name: e2e
 on:
   pull_request:
+permissions:
+  contents: read
 defaults:
   run:
     shell: bash

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,6 +1,8 @@
 name: go
 on:
   pull_request:
+permissions:
+  contents: read
 defaults:
   run:
     shell: bash   

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,6 +1,8 @@
 name: helm
 on:
   pull_request:
+permissions:
+  contents: read
 defaults:
   run:
     shell: bash   


### PR DESCRIPTION
This change is to address warnings given from CodeQL.