### PR TITLE
Fix p2p option naming to conform with the standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#824](https://github.com/spegel-org/spegel/pull/824) Fix improper image string formatting and expand tests.
 - [#825](https://github.com/spegel-org/spegel/pull/825) Fix gopls modernize warnings.
 - [#826](https://github.com/spegel-org/spegel/pull/826) Standardize router channel naming.
+- [#844](https://github.com/spegel-org/spegel/pull/844) Fix p2p option naming to conform with the standard.
 
 ### Security
 

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -47,7 +47,7 @@ func (cfg *P2PRouterConfig) Apply(opts ...P2PRouterOption) error {
 
 type P2PRouterOption func(cfg *P2PRouterConfig) error
 
-func LibP2POptions(opts ...libp2p.Option) P2PRouterOption {
+func WithLibP2POptions(opts ...libp2p.Option) P2PRouterOption {
 	return func(cfg *P2PRouterConfig) error {
 		cfg.libp2pOpts = opts
 		return nil

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -24,7 +24,7 @@ func TestP2PRouterOptions(t *testing.T) {
 		libp2p.ListenAddrStrings("foo"),
 	}
 	opts := []P2PRouterOption{
-		LibP2POptions(libp2pOpts...),
+		WithLibP2POptions(libp2pOpts...),
 	}
 	cfg := P2PRouterConfig{}
 	err := cfg.Apply(opts...)


### PR DESCRIPTION
Slight mistake on my part when adding options to the p2p router.