### PR TITLE
Build binaries as part of the release process

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
         with:
           go-version-file: go.mod
+      - name: Setup GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
       - name: Setup Kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 #v1.12.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,10 @@
 name: release
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 permissions:
-  contents: read
+  contents: write
   packages: write
   id-token: write
 defaults:
@@ -20,9 +21,7 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 #v4.3.0
         with:
-          version: v3.12.1
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+          version: v3.17.3
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3.10.0
@@ -34,19 +33,26 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare
+      - name: Prepare version
         id: prep
         run: |
           VERSION=sha-${GITHUB_SHA::8}
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF/refs\/tags\//}
           fi
+          echo "Refer to the [Changelog](https://github.com/spegel-org/spegel/blob/main/CHANGELOG.md#${VERSION//.}) for list of changes." > ${{ runner.temp }}/NOTES.txt
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean --release-notes ${{ runner.temp }}/NOTES.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate images meta
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
         with:
-          images: ghcr.io/spegel-org/spegel
+          images: ghcr.io/${{ github.repository_owner }}/spegel
           tags: type=raw,value=${{ steps.prep.outputs.VERSION }}
       - name: Publish multi-arch image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
@@ -57,11 +63,11 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          tags: ghcr.io/spegel-org/spegel:${{ steps.prep.outputs.VERSION }}
+          tags: ghcr.io/${{ github.repository_owner }}/spegel:${{ steps.prep.outputs.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Sign the image with Cosign
         run: |
-          cosign sign --yes ghcr.io/spegel-org/spegel@${{ steps.build.outputs.DIGEST }}
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/spegel@${{ steps.build.outputs.DIGEST }}
       - name: Publish Helm chart to GHCR
         id: helm
         run: |
@@ -70,9 +76,9 @@ jobs:
           rm charts/spegel/artifacthub-repo.yml
           yq -i '.image.digest = "${{ steps.build.outputs.DIGEST }}"' charts/spegel/values.yaml
           helm package --app-version ${{ steps.prep.outputs.VERSION }} --version ${HELM_VERSION} charts/spegel
-          helm push spegel-${HELM_VERSION}.tgz oci://ghcr.io/spegel-org/helm-charts 2> .digest
+          helm push spegel-${HELM_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2> .digest
           DIGEST=$(cat .digest | awk -F "[, ]+" '/Digest/{print $NF}')
           echo "DIGEST=${DIGEST}" >> $GITHUB_OUTPUT
       - name: Sign the Helm chart with Cosign
         run: |
-          cosign sign --yes ghcr.io/spegel-org/helm-charts/spegel@${{ steps.helm.outputs.DIGEST }}
+          cosign sign --yes ghcr.io/${{ github.repository_owner }}/helm-charts/spegel@${{ steps.helm.outputs.DIGEST }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,26 @@
+version: 2
+project_name: spegel
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -a
+    no_unique_dist_dir: true
+    binary: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}/{{ .ProjectName }}"
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - none*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#832](https://github.com/spegel-org/spegel/pull/832) Add delete hook to cleanup configuration from host when chart is uninstalled.
+- [#846](https://github.com/spegel-org/spegel/pull/846) Build binaries as part of the release process.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,12 @@ Thank you for considering contributing to Spegel, hopefully this document will m
 The following tools are required to run the tests properly.
 
 * go
-* golangci-lint
-* kind
+* [golangci-lint](https://github.com/golangci/golangci-lint)
+* [kind](https://github.com/kubernetes-sigs/kind)
+* [goreleaser](https://github.com/goreleaser/goreleaser)
+* [docker](https://docs.docker.com/get-started/get-docker/)
+* [helm](https://github.com/helm/helm)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
 Run the linter and the unit tests to quickly validate changes.
 
@@ -33,33 +37,32 @@ make test-e2e E2E_CNI=ipvs
 Build the Docker image locally.
 
 ```shell
-make docker-build
+make build-image
 ```
 
 It is possible to specify a different image name and tag.
 
 ```shell
-make docker-build IMG=example.com/spegel TAG=feature
+make build-image IMG=example.com/spegel TAG=feature
 ```
 
-### Local testing
+### Local debugging
 
-In order to manually test or debug Spegel, you will need the following tools.
-
-* kind
-* docker
-* helm
-* kubectl
-
-First run dev deploy which will create a Kind cluster with the proper configuration and deploy Spegel into it. If you run this command a second time the cluster will be kept but Spegel will be updated.
+Run the `dev-deploy` recipe which will create a Kind cluster with the proper configuration and deploy Spegel into it. If you run this command a second time the cluster will be kept but Spegel will be updated.
 
 ```shell
 make dev-deploy
 ```
 
-After the command has run a Kind cluster named `spegel-dev` should be created. 
+After the command has run you can get a kubeconfig file to access the cluster and do any debugging.
 
-## Generating documentation
+```shell
+kind get kubeconfig --name spegel-dev > kubeconfig
+export KUBECOONFIG=$(pwd)/kubeconfig
+kubectl -n spegel get pods
+```
+
+## Generate Helm documentation
 
 Changes to the Helm chart values will require the documentation to be regenerated.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
-FROM golang:1.24.1@sha256:52ff1b35ff8de185bf9fd26c70077190cd0bed1e9f16a2d498ce907e5c421268 AS builder
-RUN mkdir /build
-WORKDIR /build
-COPY go.mod go.mod
-COPY go.sum go.sum
-RUN go mod download
-COPY main.go main.go
-COPY internal/ internal/
-COPY pkg/ pkg/
-RUN CGO_ENABLED=0 go build -installsuffix 'static' -o spegel .
-
 FROM gcr.io/distroless/static:nonroot
-COPY --from=builder /build/spegel /app/
-WORKDIR /app
+ARG TARGETOS
+ARG TARGETARCH
+COPY ./dist/spegel_${TARGETOS}_${TARGETARCH}/spegel /
 USER root:root
-ENTRYPOINT ["./spegel"]
+ENTRYPOINT ["/spegel"]

--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,22 @@ E2E_IP_FAMILY ?= ipv4
 lint:
 	golangci-lint run ./...
 
-docker-build:
+build:
+	goreleaser build --snapshot --clean --single-target --skip before
+
+build-image: build
 	docker build -t ${IMG_REF} .
 
 test-unit:
 	go test ./...
 
-test-e2e: docker-build
+test-e2e: build-image
 	IMG_REF=${IMG_REF} \
 	E2E_PROXY_MODE=${E2E_PROXY_MODE} \
 	E2E_IP_FAMILY=${E2E_IP_FAMILY} \
 	go test ./test/e2e -v -timeout 200s -tags e2e -count 1 -run TestE2E
 
-dev-deploy: docker-build
+dev-deploy: build-image
 	IMG_REF=${IMG_REF} go test ./test/e2e -v -timeout 200s -tags e2e -count 1 -run TestDevDeploy
 
 tools:


### PR DESCRIPTION
This change will build binaries as part of the release process. This is useful for users who want to run Spegel on the host instead of in a container.

The change also changes some of the build process. Now Goreleaser is used exclusively to build the binaries, and they are copied into the docker image. Doing it this way makes the image build process a lot faster during release.

Fixes #830 