### PR TITLE
Add support for a static bootstrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#832](https://github.com/spegel-org/spegel/pull/832) Add delete hook to cleanup configuration from host when chart is uninstalled.
 - [#846](https://github.com/spegel-org/spegel/pull/846) Build binaries as part of the release process.
+- [#848](https://github.com/spegel-org/spegel/pull/848) Add support for a static bootstrapper.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -40,10 +40,11 @@ type ConfigurationCmd struct {
 }
 
 type BootstrapConfig struct {
-	BootstrapKind      string `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
-	DNSBootstrapDomain string `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
-	HTTPBootstrapAddr  string `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
-	HTTPBootstrapPeer  string `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
+	BootstrapKind        string   `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
+	DNSBootstrapDomain   string   `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
+	HTTPBootstrapAddr    string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
+	HTTPBootstrapPeer    string   `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
+	StaticBootstrapPeers []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
 }
 
 type RegistryCmd struct {
@@ -258,6 +259,8 @@ func getBootstrapper(cfg BootstrapConfig) (routing.Bootstrapper, error) { //noli
 		return routing.NewDNSBootstrapper(cfg.DNSBootstrapDomain, 10), nil
 	case "http":
 		return routing.NewHTTPBootstrapper(cfg.HTTPBootstrapAddr, cfg.HTTPBootstrapPeer), nil
+	case "static":
+		return routing.NewStaticBootstrapperFromStrings(cfg.StaticBootstrapPeers)
 	default:
 		return nil, fmt.Errorf("unknown bootstrap kind %s", cfg.BootstrapKind)
 	}

--- a/pkg/routing/bootstrap.go
+++ b/pkg/routing/bootstrap.go
@@ -35,8 +35,22 @@ type StaticBootstrapper struct {
 	mx    sync.RWMutex
 }
 
-func NewStaticBootstrapper() *StaticBootstrapper {
-	return &StaticBootstrapper{}
+func NewStaticBootstrapperFromStrings(peerStrs []string) (*StaticBootstrapper, error) {
+	peers := []peer.AddrInfo{}
+	for _, peerStr := range peerStrs {
+		peer, err := peer.AddrInfoFromString(peerStr)
+		if err != nil {
+			return nil, err
+		}
+		peers = append(peers, *peer)
+	}
+	return NewStaticBootstrapper(peers), nil
+}
+
+func NewStaticBootstrapper(peers []peer.AddrInfo) *StaticBootstrapper {
+	return &StaticBootstrapper{
+		peers: peers,
+	}
 }
 
 func (b *StaticBootstrapper) Run(ctx context.Context, id string) error {

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -27,8 +27,7 @@ func TestStaticBootstrap(t *testing.T) {
 			Addrs: []ma.Multiaddr{manet.IP6Loopback},
 		},
 	}
-	bs := NewStaticBootstrapper()
-	bs.SetPeers(peers)
+	bs := NewStaticBootstrapper(peers)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	g, gCtx := errgroup.WithContext(ctx)

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -37,7 +37,7 @@ func TestP2PRouter(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 
-	bs := NewStaticBootstrapper()
+	bs := NewStaticBootstrapper(nil)
 	router, err := NewP2PRouter(ctx, "localhost:0", bs, "9090")
 	require.NoError(t, err)
 
@@ -72,7 +72,7 @@ func TestP2PRouter(t *testing.T) {
 func TestReady(t *testing.T) {
 	t.Parallel()
 
-	bs := NewStaticBootstrapper()
+	bs := NewStaticBootstrapper(nil)
 	router, err := NewP2PRouter(t.Context(), "localhost:0", bs, "9090")
 	require.NoError(t, err)
 
@@ -159,8 +159,7 @@ func TestBootstrapFunc(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			bs := NewStaticBootstrapper()
-			bs.SetPeers(tt.peers)
+			bs := NewStaticBootstrapper(tt.peers)
 			f := bootstrapFunc(ctx, bs, mn.Hosts()[0])
 			peers := f()
 


### PR DESCRIPTION
This change exposes the already implemented static bootstrapper to end users. Allowing users running Spegel outside of Kubernetes to assign a static set of peers as the rendezvous point.

Relates to #829 