### PR TITLE
Persist libp2p key to disk when data directory is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#832](https://github.com/spegel-org/spegel/pull/832) Add delete hook to cleanup configuration from host when chart is uninstalled.
 - [#846](https://github.com/spegel-org/spegel/pull/846) Build binaries as part of the release process.
 - [#848](https://github.com/spegel-org/spegel/pull/848) Add support for a static bootstrapper.
+- [#850](https://github.com/spegel-org/spegel/pull/850) Perist libp2p key to disk when data directory is set.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type RegistryCmd struct {
 	ContainerdSock               string        `arg:"--containerd-sock,env:CONTAINERD_SOCK" default:"/run/containerd/containerd.sock" help:"Endpoint of containerd service."`
 	ContainerdNamespace          string        `arg:"--containerd-namespace,env:CONTAINERD_NAMESPACE" default:"k8s.io" help:"Containerd namespace to fetch images from."`
 	ContainerdContentPath        string        `arg:"--containerd-content-path,env:CONTAINERD_CONTENT_PATH" default:"/var/lib/containerd/io.containerd.content.v1.content" help:"Path to Containerd content store"`
+	DataDir                      string        `arg:"--data-dir,env:DATA_DIR" default:"/var/lib/spegel" help:"Directory where Spegel persists data."`
 	RouterAddr                   string        `arg:"--router-addr,env:ROUTER_ADDR" default:":5001" help:"address to serve router."`
 	RegistryAddr                 string        `arg:"--registry-addr,env:REGISTRY_ADDR" default:":5000" help:"address to server image registry."`
 	MirroredRegistries           []url.URL     `arg:"--mirrored-registries,env:MIRRORED_REGISTRIES" help:"Registries that are configured to be mirrored, if slice is empty all registires are mirrored."`
@@ -161,7 +162,10 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	if err != nil {
 		return err
 	}
-	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper, registryPort)
+	routerOpts := []routing.P2PRouterOption{
+		routing.WithDataDir(args.DataDir),
+	}
+	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper, registryPort, routerOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This feature is useful for when running Spegel on the host with a static bootstrapper. If the key was not persisted the ID would be different after every restart, making the process really annoying. For now keys will not be persisted between restarts when running Spegel in Kubernetes but that may become an option in the future.

Relates to #829 