### PR TITLE
Remove use of Afero in Containerd config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#852](https://github.com/spegel-org/spegel/pull/852) Remove use of Afero in Containerd config.
+
 ### Deprecated
 
 ### Removed

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.63.0
-	github.com/spf13/afero v1.14.0
 	github.com/stretchr/testify v1.10.0
 	go.etcd.io/bbolt v1.4.0
 	golang.org/x/sync v0.13.0
@@ -162,6 +161,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/alexflint/go-arg"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
 
@@ -126,8 +125,7 @@ func configurationCommand(ctx context.Context, args *ConfigurationCmd) error {
 	if err != nil {
 		return err
 	}
-	fs := afero.NewOsFs()
-	err = oci.AddMirrorConfiguration(ctx, fs, args.ContainerdRegistryConfigPath, args.MirroredRegistries, args.MirrorTargets, args.ResolveTags, args.PrependExisting, username, password)
+	err = oci.AddMirrorConfiguration(ctx, args.ContainerdRegistryConfigPath, args.MirroredRegistries, args.MirrorTargets, args.ResolveTags, args.PrependExisting, username, password)
 	if err != nil {
 		return err
 	}
@@ -286,8 +284,7 @@ func loadBasicAuth() (string, string, error) {
 func cleanupCommand(ctx context.Context, args *CleanupCmd) error {
 	log := logr.FromContextOrDiscard(ctx)
 
-	fs := afero.NewOsFs()
-	err := oci.CleanupMirrorConfiguration(ctx, fs, args.ContainerdRegistryConfigPath)
+	err := oci.CleanupMirrorConfiguration(ctx, args.ContainerdRegistryConfigPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I initially used Afero because I thought it would make testing easier. After some time now it has mostly made things more difficult and Afero was never used in the rest of the codebase. For this reason it is better to remove Afero completely to align with the rest of the project.