### PR TITLE
Rename OCI client to store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#852](https://github.com/spegel-org/spegel/pull/852) Remove use of Afero in Containerd config.
 - [#854](https://github.com/spegel-org/spegel/pull/854) Implement unit tests for cleanup logic.
 - [#860](https://github.com/spegel-org/spegel/pull/860) Update Go to 1.24.2.
+- [#864](https://github.com/spegel-org/spegel/pull/864) Rename OCI client to store.
 
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -141,12 +141,12 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		return err
 	}
 
-	// OCI Client
-	ociClient, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, args.MirroredRegistries, oci.WithContentPath(args.ContainerdContentPath))
+	// OCI Store
+	ociStore, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, args.MirroredRegistries, oci.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
 		return err
 	}
-	err = ociClient.Verify(ctx)
+	err = ociStore.Verify(ctx)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 
 	// State tracking
 	g.Go(func() error {
-		err := state.Track(ctx, ociClient, router, args.ResolveLatestTag)
+		err := state.Track(ctx, ociStore, router, args.ResolveLatestTag)
 		if err != nil {
 			return err
 		}
@@ -188,7 +188,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		registry.WithLogger(log),
 		registry.WithBasicAuth(username, password),
 	}
-	reg, err := registry.NewRegistry(ociClient, router, registryOpts...)
+	reg, err := registry.NewRegistry(ociStore, router, registryOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -34,7 +34,7 @@ const (
 	backupDir = "_backup"
 )
 
-var _ Client = &Containerd{}
+var _ Store = &Containerd{}
 
 type Containerd struct {
 	contentPath        string

--- a/pkg/oci/memory.go
+++ b/pkg/oci/memory.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-var _ Client = &Memory{}
+var _ Store = &Memory{}
 
 type Memory struct {
 	blobs  map[digest.Digest][]byte

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -30,8 +30,8 @@ type ImageEvent struct {
 	Type  EventType
 }
 
-type Client interface {
-	// Name returns the name of the Client implementation.
+type Store interface {
+	// Name returns the name of the store implementation.
 	Name() string
 
 	// Verify checks that all expected configuration is set.
@@ -94,10 +94,10 @@ func DetermineMediaType(b []byte) (string, error) {
 	return "", errors.New("not able to determine media type")
 }
 
-func WalkImage(ctx context.Context, client Client, img Image) ([]string, error) {
+func WalkImage(ctx context.Context, store Store, img Image) ([]string, error) {
 	keys := []string{}
 	err := walk(ctx, []digest.Digest{img.Digest}, func(dgst digest.Digest) ([]digest.Digest, error) {
-		b, mt, err := client.GetManifest(ctx, dgst)
+		b, mt, err := store.GetManifest(ctx, dgst)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +110,7 @@ func WalkImage(ctx context.Context, client Client, img Image) ([]string, error) 
 			}
 			manifestDgsts := []digest.Digest{}
 			for _, m := range idx.Manifests {
-				_, err := client.Size(ctx, m.Digest)
+				_, err := store.Size(ctx, m.Digest)
 				if errors.Is(err, ErrNotFound) {
 					continue
 				}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestTrack(t *testing.T) {
 	t.Parallel()
-	ociClient := oci.NewMemory()
+	ociStore := oci.NewMemory()
 
 	imgRefs := []string{
 		"docker.io/library/ubuntu:latest",
@@ -48,10 +48,10 @@ func TestTrack(t *testing.T) {
 		_, err = hash.Write(b)
 		require.NoError(t, err)
 		dgst := digest.NewDigest(digest.SHA256, hash)
-		ociClient.AddBlob(b, dgst)
+		ociStore.AddBlob(b, dgst)
 		img, err := oci.ParseImageRequireDigest(imageStr, dgst)
 		require.NoError(t, err)
-		ociClient.AddImage(img)
+		ociStore.AddImage(img)
 
 		imgs = append(imgs, img)
 	}
@@ -80,7 +80,7 @@ func TestTrack(t *testing.T) {
 			router := routing.NewMemoryRouter(map[string][]netip.AddrPort{}, netip.MustParseAddrPort("127.0.0.1:5000"))
 			g, gCtx := errgroup.WithContext(ctx)
 			g.Go(func() error {
-				return Track(gCtx, ociClient, router, tt.resolveLatestTag)
+				return Track(gCtx, ociStore, router, tt.resolveLatestTag)
 			})
 			time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
I do not know why I called the interface a client. If it confuses me at times it probably confuses others too. This allows us to implement an actual OCI client without having the names collide in the package. Changing the name from client to store is more descriptive for what the interface actually does.