### PR TITLE
Allow returning libp2p crypto priv key in linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -76,6 +76,13 @@ linters:
       strconcat: false
     testifylint:
       enable-all: true
+    ireturn:
+      allow:
+        - anon
+        - error
+        - empty
+        - stdlib
+        - github.com/libp2p/go-libp2p/core/crypto.PrivKey
   exclusions:
     generated: lax
     presets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#869](https://github.com/spegel-org/spegel/pull/869) Fix request logging for redirects and not found pages.
+- [#872](https://github.com/spegel-org/spegel/pull/872) Allow returning libp2p crypto priv key in linter.
 
 ### Security
 

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -432,7 +432,7 @@ func hostMatches(host, addrInfo peer.AddrInfo) (bool, error) {
 	return false, nil
 }
 
-func loadOrCreatePrivateKey(ctx context.Context, dataDir string) (crypto.PrivKey, error) { //nolint: ireturn // LibP2P returns interfaces so we also have to.
+func loadOrCreatePrivateKey(ctx context.Context, dataDir string) (crypto.PrivKey, error) {
 	keyPath := filepath.Join(dataDir, "private.key")
 	log := logr.FromContextOrDiscard(ctx).WithValues("path", keyPath)
 	err := os.MkdirAll(dataDir, 0o755)


### PR DESCRIPTION
We wont be able to change the fact that it returns an interface anyway, so it is better to globally allow it.