### PR TITLE
Add dial timeout configuration in Containerd mirror configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#877](https://github.com/spegel-org/spegel/pull/877) Add support for www authenticate header.
+- [#878](https://github.com/spegel-org/spegel/pull/878) Add dial timeout configuration in Containerd mirror configuration.
 
 ### Changed
 

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -555,6 +555,7 @@ func templateHosts(mirroredRegistry url.URL, mirrorTargets []url.URL, capabiliti
 {{ range .MirrorTargets }}
 [host.'{{ .String }}']
 capabilities = {{ $.Capabilities }}
+dial_timeout = '200ms'
 {{- if $authorization }}
 [host.'{{ .String }}'.header]
 Authorization = '{{ $authorization }}'

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -333,12 +333,15 @@ func TestMirrorConfiguration(t *testing.T) {
 
 [host.'http://127.0.0.1:5000']
 capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
 
 [host.'http://127.0.0.2:5000']
 capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
 
 [host.'http://127.0.0.1:5001']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -349,7 +352,8 @@ capabilities = ['pull', 'resolve']`,
 			prependExisting: false,
 			expectedFiles: map[string]string{
 				"_default/hosts.toml": `[host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -362,11 +366,13 @@ capabilities = ['pull', 'resolve']`,
 				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull']`,
+capabilities = ['pull']
+dial_timeout = '200ms'`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull']`,
+capabilities = ['pull']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -380,11 +386,13 @@ capabilities = ['pull']`,
 				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -398,11 +406,13 @@ capabilities = ['pull', 'resolve']`,
 				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -422,11 +432,13 @@ capabilities = ['pull', 'resolve']`,
 				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -448,11 +460,13 @@ capabilities = ['pull', 'resolve']`,
 				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -495,6 +509,7 @@ client = ['/etc/certs/xxx/client.cert', '/etc/certs/xxx/client.key']`,
 
 [host.'http://127.0.0.1:5000']
 capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
 
 [host.'http://example.com:30020']
 capabilities = ['pull', 'resolve']
@@ -510,7 +525,8 @@ client = ['/etc/certs/xxx/client.cert', '/etc/certs/xxx/client.key']`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -552,11 +568,13 @@ client = ['/etc/certs/xxx/client.cert', '/etc/certs/xxx/client.key']`,
 				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
 [host.'http://127.0.0.1:5000']
-capabilities = ['pull', 'resolve']`,
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'`,
 			},
 		},
 		{
@@ -572,11 +590,13 @@ capabilities = ['pull', 'resolve']`,
 
 [host.'http://127.0.0.1:5000']
 capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
 [host.'http://127.0.0.1:5000'.header]
 Authorization = 'Basic aGVsbG86d29ybGQ='
 
 [host.'http://127.0.0.1:5001']
 capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
 [host.'http://127.0.0.1:5001'.header]
 Authorization = 'Basic aGVsbG86d29ybGQ='`,
 			},


### PR DESCRIPTION
This change sets the dial timeout for Spegel at 200ms. The value is currently set as a static value for simplicity. This is not a timeout for the HTTP request but for how long Containerd should wait for a TCP connection. We can expect the dial time to be low as the networking is local. Setting this value helps reduce issues when Spegel is not running on a node which may cause a pull to get stuck indefinably. 

This feature was added in https://github.com/containerd/containerd/pull/11106 which means that Containerd version 2.1.0 or later has to be used for this configuration to have any effect. 

Fixes #739 