### PR TITLE
Refactor store advertisement to list content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#871](https://github.com/spegel-org/spegel/pull/871) Implement OCI client and refactor debug web pulling.
 - [#873](https://github.com/spegel-org/spegel/pull/873) Refactor web to use internal mux router.
 - [#875](https://github.com/spegel-org/spegel/pull/875) Change debug unit formatting and add totals.
+- [#880](https://github.com/spegel-org/spegel/pull/880) Refactor store advertisement to list content.
 
 ### Deprecated
 

--- a/pkg/oci/memory.go
+++ b/pkg/oci/memory.go
@@ -58,6 +58,17 @@ func (m *Memory) Resolve(ctx context.Context, ref string) (digest.Digest, error)
 	return dgst, nil
 }
 
+func (m *Memory) ListContents(ctx context.Context) ([]Content, error) {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+
+	contents := []Content{}
+	for k := range m.blobs {
+		contents = append(contents, Content{Digest: k})
+	}
+	return contents, nil
+}
+
 func (m *Memory) Size(ctx context.Context, dgst digest.Digest) (int64, error) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -30,6 +30,11 @@ type ImageEvent struct {
 	Type  EventType
 }
 
+type Content struct {
+	Digest     digest.Digest
+	Registires []string
+}
+
 type Store interface {
 	// Name returns the name of the store implementation.
 	Name() string
@@ -46,6 +51,9 @@ type Store interface {
 	// Resolve returns the digest for the tagged image name reference.
 	// The ref is expected to be in the format `registry/name:tag`.
 	Resolve(ctx context.Context, ref string) (digest.Digest, error)
+
+	// ListContents returns a list of all the contents.
+	ListContents(ctx context.Context) ([]Content, error)
 
 	// Size returns the content byte size for the given digest.
 	// Will return ErrNotFound if the digest cannot be found.


### PR DESCRIPTION
The current implementation of state tracking will list images and then walk the image digests to get all of the digests linked to it. This has worked well for a long time. The solution is overly complicated for the end result that we want to achieve. The walking of all the manifests can be resource consuming and can be error prone as new OCI artifact types emerge.

This new solution instead lists all of the image tags, and then all of the contents in the OCI store, which are then advertised. The solution is a lot more simpler, and does not explicitly require content to be linked to an image.

This work is also required in preparation for the work related to capturing content create events.

Part of #502 