### PR TITLE
fix(dashboard): add Variable for job name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#889](https://github.com/spegel-org/spegel/pull/889) Add support for content create events.
 
 ### Changed
-
+- [#881](https://github.com/spegel-org/spegel/pull/881) Add Variable for job name in Grafana Dashboard.
 - [#852](https://github.com/spegel-org/spegel/pull/852) Remove use of Afero in Containerd config.
 - [#854](https://github.com/spegel-org/spegel/pull/854) Implement unit tests for cleanup logic.
 - [#860](https://github.com/spegel-org/spegel/pull/860) Update Go to 1.24.2.

--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -1303,6 +1303,7 @@
   "timezone": "",
   "title": "Spegel stateless cluster local OCI registry mirror",
   "uid": "1iY4QMJVk-psee",
+  "gnetId": 18089,
   "version": 4,
   "weekStart": ""
 }

--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
+  "id": 16690,
   "links": [],
   "panels": [
     {
@@ -89,7 +89,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -155,7 +155,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -219,7 +219,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -285,7 +285,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -357,7 +357,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -366,7 +366,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(rate(http_request_duration_seconds_bucket{job=\"spegel\"}[$__interval]))",
+          "expr": "max(rate(http_request_duration_seconds_bucket{job=\"$job\"}[$__interval]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -399,7 +399,7 @@
         "content": "<br>\n<div style=\"text-align: center;\"><a href=\"https://github.com/XenitAB/spegel\" target=\"_blank\">Spegel at GitHub</a> </div>\n\n",
         "mode": "html"
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "title": "Github link",
       "transparent": true,
       "type": "text"
@@ -499,7 +499,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -508,7 +508,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "spegel_advertised_images{job=~\"spegel\",instance=~\"$instance\"}",
+          "expr": "spegel_advertised_images{job=~\"$job\",instance=~\"$instance\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -522,7 +522,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "spegel_advertised_keys{job=~\"spegel\",instance=~\"$instance\"} ",
+          "expr": "spegel_advertised_keys{job=~\"$job\",instance=~\"$instance\"} ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -646,11 +646,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -659,7 +660,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "spegel_advertised_images{job=~\"spegel\",instance=~\"$instance\"}",
+          "expr": "spegel_advertised_images{job=~\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{ instance }}",
@@ -808,11 +809,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -910,11 +912,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -923,7 +926,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "spegel_advertised_keys{job=~\"spegel\",instance=~\"$instance\"} ",
+          "expr": "spegel_advertised_keys{job=~\"$job\",instance=~\"$instance\"} ",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{ instance }}",
@@ -1024,11 +1027,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -1122,11 +1126,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.0",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
           "datasource": {
@@ -1153,7 +1158,10 @@
   "templating": {
     "list": [
       {
-        "current": null,
+        "current": {
+          "text": "hub-devops-observability-prometheus",
+          "value": "P3D5ADE37875AD284"
+        },
         "includeAll": false,
         "label": "Data Source",
         "name": "datasource",
@@ -1184,7 +1192,10 @@
         "type": "custom"
       },
       {
-        "current": {},
+        "current": {
+          "text": "spegel-devops-hub-26b8d",
+          "value": "spegel-devops-hub-26b8d"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -1205,12 +1216,41 @@
         "type": "query"
       },
       {
-        "current": {},
+        "allowCustomValue": false,
+        "current": {
+          "text": "spegel-devops-hub",
+          "value": "spegel-devops-hub"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(spegel_advertised_keys{job=\"spegel\"},instance)",
+        "definition": "label_values(spegel_advertised_keys,job)",
+        "hide": 2,
+        "label": "job",
+        "name": "job",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spegel_advertised_keys,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spegel_advertised_keys{job=\"$job\"},instance)",
         "includeAll": true,
         "label": "instance",
         "multi": true,
@@ -1218,7 +1258,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(spegel_advertised_keys{job=\"spegel\"},instance)",
+          "query": "label_values(spegel_advertised_keys{job=\"$job\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1235,7 +1275,6 @@
   "timezone": "",
   "title": "Spegel stateless cluster local OCI registry mirror",
   "uid": "1iY4QMJVk-psee",
-  "version": 1,
-  "weekStart": "",
-  "gnetId": 18089
+  "version": 4,
+  "weekStart": ""
 }

--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -1,4 +1,53 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS",
+      "label": "dev-central-observability-prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -25,7 +74,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 16690,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -38,7 +87,6 @@
       },
       "id": 24,
       "panels": [],
-      "title": "",
       "type": "row"
     },
     {
@@ -94,7 +142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "count(spegel_advertised_keys{instance=~\"$instance\"})",
@@ -160,7 +208,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(kubelet_node_name{job=\"kubelet\"})",
@@ -223,7 +271,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(kubelet_running_containers)",
@@ -290,7 +339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(kubelet_running_pods)",
@@ -362,7 +411,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -379,10 +428,6 @@
       "type": "stat"
     },
     {
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 4,
         "w": 3,
@@ -415,7 +460,6 @@
       "id": 9,
       "panels": [],
       "repeat": "datasource",
-      "title": "",
       "type": "row"
     },
     {
@@ -504,7 +548,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -531,7 +575,6 @@
           "refId": "B"
         }
       ],
-      "title": "",
       "transformations": [
         {
           "id": "filterFieldsByName",
@@ -570,7 +613,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -675,7 +718,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$datasource"
+        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -839,7 +882,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -954,7 +997,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1053,7 +1096,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$datasource"
+        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1151,17 +1194,13 @@
       "type": "timeseries"
     }
   ],
-  "preload": false,
   "refresh": "30s",
   "schemaVersion": 40,
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "hub-devops-observability-prometheus",
-          "value": "P3D5ADE37875AD284"
-        },
+        "current": {},
         "includeAll": false,
         "label": "Data Source",
         "name": "datasource",
@@ -1192,13 +1231,10 @@
         "type": "custom"
       },
       {
-        "current": {
-          "text": "spegel-devops-hub-26b8d",
-          "value": "spegel-devops-hub-26b8d"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${datasource}"
+          "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
         },
         "definition": "label_values(spegel_advertised_images,pod)",
         "description": "",
@@ -1217,10 +1253,7 @@
       },
       {
         "allowCustomValue": false,
-        "current": {
-          "text": "spegel-devops-hub",
-          "value": "spegel-devops-hub"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -1240,15 +1273,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${datasource}"
+          "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
         },
         "definition": "label_values(spegel_advertised_keys{job=\"$job\"},instance)",
         "includeAll": true,

--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS",
-      "label": "dev-central-observability-prometheus",
+      "name": "datasource",
+      "label": "datasource",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -142,7 +142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "count(spegel_advertised_keys{instance=~\"$instance\"})",
@@ -208,7 +208,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(kubelet_node_name{job=\"kubelet\"})",
@@ -272,7 +272,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(kubelet_running_containers)",
@@ -339,7 +339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(kubelet_running_pods)",
@@ -411,7 +411,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -548,7 +548,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -613,7 +613,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -718,7 +718,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -882,7 +882,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -997,7 +997,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1096,7 +1096,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1234,7 +1234,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "definition": "label_values(spegel_advertised_images,pod)",
         "description": "",
@@ -1276,7 +1276,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_DEV-CENTRAL-OBSERVABILITY-PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "definition": "label_values(spegel_advertised_keys{job=\"$job\"},instance)",
         "includeAll": true,


### PR DESCRIPTION
fixes #879 

This handles the most common case of having one spegel instance per datasource.