### PR TITLE
Refactor OCI events to support content events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#873](https://github.com/spegel-org/spegel/pull/873) Refactor web to use internal mux router.
 - [#875](https://github.com/spegel-org/spegel/pull/875) Change debug unit formatting and add totals.
 - [#880](https://github.com/spegel-org/spegel/pull/880) Refactor store advertisement to list content.
+- [#888](https://github.com/spegel-org/spegel/pull/888) Refactor OCI events to support content events.
 
 ### Deprecated
 

--- a/pkg/oci/memory.go
+++ b/pkg/oci/memory.go
@@ -36,8 +36,8 @@ func (m *Memory) Verify(ctx context.Context) error {
 	return nil
 }
 
-func (m *Memory) Subscribe(ctx context.Context) (<-chan ImageEvent, <-chan error, error) {
-	return nil, nil, nil
+func (m *Memory) Subscribe(ctx context.Context) (<-chan OCIEvent, error) {
+	return nil, nil
 }
 
 func (m *Memory) ListImages(ctx context.Context) ([]Image, error) {

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -184,14 +184,14 @@ func TestOCIClient(t *testing.T) {
 			}
 
 			identifiersTests := []struct {
-				imageName    string
-				imageDigest  string
-				expectedKeys []string
+				imageName     string
+				imageDigest   string
+				expectedDgsts []digest.Digest
 			}{
 				{
 					imageName:   "ghcr.io/spegel-org/spegel:v0.0.8-with-media-type",
 					imageDigest: "sha256:9506c8e7a2d0a098d43cadfd7ecdc3c91697e8188d3a1245943b669f717747b4",
-					expectedKeys: []string{
+					expectedDgsts: []digest.Digest{
 						"sha256:9506c8e7a2d0a098d43cadfd7ecdc3c91697e8188d3a1245943b669f717747b4",
 						"sha256:44cb2cf712c060f69df7310e99339c1eb51a085446f1bb6d44469acff35b4355",
 						"sha256:d715ba0d85ee7d37da627d0679652680ed2cb23dde6120f25143a0b8079ee47e",
@@ -237,7 +237,7 @@ func TestOCIClient(t *testing.T) {
 				{
 					imageName:   "ghcr.io/spegel-org/spegel:v0.0.8-without-media-type",
 					imageDigest: "sha256:d8df04365d06181f037251de953aca85cc16457581a8fc168f4957c978e1008b",
-					expectedKeys: []string{
+					expectedDgsts: []digest.Digest{
 						"sha256:d8df04365d06181f037251de953aca85cc16457581a8fc168f4957c978e1008b",
 						"sha256:44cb2cf712c060f69df7310e99339c1eb51a085446f1bb6d44469acff35b4355",
 						"sha256:d715ba0d85ee7d37da627d0679652680ed2cb23dde6120f25143a0b8079ee47e",
@@ -287,9 +287,9 @@ func TestOCIClient(t *testing.T) {
 
 					img, err := ParseImageRequireDigest(tt.imageName, digest.Digest(tt.imageDigest))
 					require.NoError(t, err)
-					keys, err := WalkImage(ctx, ociStore, img)
+					dgsts, err := WalkImage(ctx, ociStore, img)
 					require.NoError(t, err)
-					require.Equal(t, tt.expectedKeys, keys)
+					require.Equal(t, tt.expectedDgsts, dgsts)
 				})
 			}
 		})

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3,7 +3,6 @@ package state
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -16,7 +15,7 @@ import (
 
 func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resolveLatestTag bool) error {
 	log := logr.FromContextOrDiscard(ctx)
-	eventCh, errCh, err := ociStore.Subscribe(ctx)
+	eventCh, err := ociStore.Subscribe(ctx)
 	if err != nil {
 		return err
 	}
@@ -31,7 +30,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resol
 		case <-ctx.Done():
 			return nil
 		case <-tickerCh:
-			log.Info("running tick state update")
+			log.Info("running state update")
 			err := tick(ctx, ociStore, router, resolveLatestTag)
 			if err != nil {
 				log.Error(err, "received errors when updating all images")
@@ -39,18 +38,14 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resol
 			}
 		case event, ok := <-eventCh:
 			if !ok {
-				return errors.New("image event channel closed")
+				return errors.New("event channel closed")
 			}
-			log.Info("received image event", "image", event.Image.String(), "type", event.Type)
-			if _, err := update(ctx, ociStore, router, event, false, resolveLatestTag); err != nil {
-				log.Error(err, "received error when updating image")
+			log.Info("OCI event", "key", event.Key, "type", event.Type)
+			err := handle(ctx, router, event)
+			if err != nil {
+				log.Error(err, "could not handle event")
 				continue
 			}
-		case err, ok := <-errCh:
-			if !ok {
-				return errors.New("image error channel closed")
-			}
-			log.Error(err, "event channel error")
 		}
 	}
 }
@@ -112,42 +107,13 @@ func tick(ctx context.Context, ociStore oci.Store, router routing.Router, resolv
 	return nil
 }
 
-func update(ctx context.Context, ociStore oci.Store, router routing.Router, event oci.ImageEvent, skipDigests, resolveLatestTag bool) (int, error) {
-	keys := []string{}
-	//nolint: staticcheck // Simplify in future.
-	if !(!resolveLatestTag && event.Image.IsLatestTag()) {
-		if tagName, ok := event.Image.TagName(); ok {
-			keys = append(keys, tagName)
-		}
+func handle(ctx context.Context, router routing.Router, event oci.OCIEvent) error {
+	if event.Type != oci.CreateEvent {
+		return nil
 	}
-	if event.Type == oci.DeleteEvent {
-		// We don't know how many digest keys were associated with the deleted image;
-		// that can only be updated by the full image list sync in all().
-		metrics.AdvertisedImages.WithLabelValues(event.Image.Registry).Sub(1)
-		// DHT doesn't actually have any way to stop providing a key, you just have to wait for the record to expire
-		// from the datastore. Record TTL is a datastore-level value, so we can't even re-provide with a shorter TTL.
-		return 0, nil
-	}
-	if !skipDigests {
-		dgsts, err := oci.WalkImage(ctx, ociStore, event.Image)
-		if err != nil {
-			return 0, fmt.Errorf("could not get digests for image %s: %w", event.Image.String(), err)
-		}
-		keys = append(keys, dgsts...)
-	}
-	err := router.Advertise(ctx, keys)
+	err := router.Advertise(ctx, []string{event.Key})
 	if err != nil {
-		return 0, fmt.Errorf("could not advertise image %s: %w", event.Image.String(), err)
+		return err
 	}
-	if event.Type == oci.CreateEvent {
-		// We don't know how many unique digest keys will be associated with the new image;
-		// that can only be updated by the full image list sync in all().
-		metrics.AdvertisedImages.WithLabelValues(event.Image.Registry).Add(1)
-		if event.Image.Tag == "" {
-			metrics.AdvertisedImageDigests.WithLabelValues(event.Image.Registry).Add(1)
-		} else {
-			metrics.AdvertisedImageTags.WithLabelValues(event.Image.Registry).Add(1)
-		}
-	}
-	return len(keys), nil
+	return nil
 }


### PR DESCRIPTION
This change is a much needed refactor of the events subscription design based on learnings over the year. It is also needed so that we can support Containerd content events.

A lot of this refactoring moves quirks related to Containerd out of the state logic and into the Containerd code. This makes implementing Containerd specific behavior a lot easier. A big change that has been done is the removal of update events, filtering of image events. This means that we avoid advertising duplicates.

The change also changes the ImageEvent to an OCIEvent, and makes it so that each layer is an individual event. This means that we will be able to send content create events in the future. 

Part of #502 