### PR TITLE
Add support for content create events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#877](https://github.com/spegel-org/spegel/pull/877) Add support for www authenticate header.
 - [#878](https://github.com/spegel-org/spegel/pull/878) Add dial timeout configuration in Containerd mirror configuration.
+- [#889](https://github.com/spegel-org/spegel/pull/889) Add support for content create events.
 
 ### Changed
 


### PR DESCRIPTION
This change adds support for Containerd content events that was introduced in Containerd v2.1.0. Advertising on content create rather than image create will make layers available as soon as they are present on disk.

Fixes #502 