### PR TITLE
Update Kind to v0.29.0 and Fix Containerd v2 support

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 #v1.12.0
         with:
-          version: v0.27.0
+          version: v0.29.0
           install_only: true
       - name: Run e2e
         run: make test-e2e E2E_PROXY_MODE=${{ matrix.proxy-mode }} E2E_IP_FAMILY=${{ matrix.ip-family }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#869](https://github.com/spegel-org/spegel/pull/869) Fix request logging for redirects and not found pages.
 - [#872](https://github.com/spegel-org/spegel/pull/872) Allow returning libp2p crypto priv key in linter.
+- [#894](https://github.com/spegel-org/spegel/pull/894) Update Kind to v0.29.0 and Fix Containerd v2 support.
 
 ### Security
 

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -438,7 +438,7 @@ func (c *Containerd) convertEvent(ctx context.Context, envelope events.Envelope)
 		if err != nil {
 			return nil, err
 		}
-		if filter.Match(content.AdaptInfo(info)) {
+		if !filter.Match(content.AdaptInfo(info)) {
 			return nil, nil
 		}
 		return []OCIEvent{{Type: CreateEvent, Key: e.GetDigest()}}, nil

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -367,7 +367,8 @@ func forwardRequest(client *http.Client, bufferPool *sync.Pool, req *http.Reques
 	defer forwardResp.Body.Close()
 
 	// Clear body and try next if non 200 response.
-	if forwardResp.StatusCode != http.StatusOK {
+	//nolint:staticcheck // Keep things readable.
+	if !(forwardResp.StatusCode == http.StatusOK || forwardResp.StatusCode == http.StatusPartialContent) {
 		_, err = io.Copy(io.Discard, forwardResp.Body)
 		if err != nil {
 			return err


### PR DESCRIPTION
Updates Kind to v0.29.0 version using Containerd v2.1.1 in E2E tests.

Some updates to Crictl caused range header to be added. This showed that we did not expect a 206 response from the mirror which caused errors.

On top of that the content filter was wrong which caused all valid content events to be ignored.