### PR TITLE
Rename package mux to httpx and refactor http helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#880](https://github.com/spegel-org/spegel/pull/880) Refactor store advertisement to list content.
 - [#888](https://github.com/spegel-org/spegel/pull/888) Refactor OCI events to support content events.
 - [#890](https://github.com/spegel-org/spegel/pull/890) Refactor Containerd options to use config struct.
+- [#896](https://github.com/spegel-org/spegel/pull/896) Rename package mux to httpx and refactor http helpers.
 
 ### Deprecated
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -3,7 +3,6 @@ package cleanup
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spegel-org/spegel/internal/channel"
+	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 )
 
@@ -135,8 +135,9 @@ func probeIPs(ctx context.Context, client *http.Client, ips []net.IPAddr, port s
 			if err != nil {
 				return err
 			}
-			if resp.StatusCode != http.StatusOK {
-				return fmt.Errorf("unexpected status code %s", resp.Status)
+			err = httpx.CheckResponseStatus(resp, http.StatusOK)
+			if err != nil {
+				return err
 			}
 			return nil
 		})

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/common/expfmt"
 
-	"github.com/spegel-org/spegel/pkg/mux"
+	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
 )
@@ -44,14 +44,14 @@ func NewWeb(router routing.Router) (*Web, error) {
 }
 
 func (w *Web) Handler(log logr.Logger) http.Handler {
-	m := mux.NewServeMux(log)
+	m := httpx.NewServeMux(log)
 	m.Handle("GET /debug/web/", w.indexHandler)
 	m.Handle("GET /debug/web/stats", w.statsHandler)
 	m.Handle("GET /debug/web/measure", w.measureHandler)
 	return m
 }
 
-func (w *Web) indexHandler(rw mux.ResponseWriter, req *http.Request) {
+func (w *Web) indexHandler(rw httpx.ResponseWriter, req *http.Request) {
 	err := w.tmpls.ExecuteTemplate(rw, "index.html", nil)
 	if err != nil {
 		rw.WriteError(http.StatusInternalServerError, err)
@@ -59,7 +59,7 @@ func (w *Web) indexHandler(rw mux.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (w *Web) statsHandler(rw mux.ResponseWriter, req *http.Request) {
+func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 	//nolint: errcheck // Ignore error.
 	srvAddr := req.Context().Value(http.LocalAddrContextKey).(net.Addr)
 	resp, err := http.Get(fmt.Sprintf("http://%s/metrics", srvAddr.String()))
@@ -112,7 +112,7 @@ type pullResult struct {
 	Duration   time.Duration
 }
 
-func (w *Web) measureHandler(rw mux.ResponseWriter, req *http.Request) {
+func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
 	// Parse image name.
 	imgName := req.URL.Query().Get("image")
 	if imgName == "" {

--- a/pkg/httpx/httpx.go
+++ b/pkg/httpx/httpx.go
@@ -1,0 +1,7 @@
+package httpx
+
+const (
+	HeaderContentType   = "Content-Type"
+	HeaderContentLength = "Content-Length"
+	HeaderAcceptRanges  = "Accept-Ranges"
+)

--- a/pkg/httpx/metrics.go
+++ b/pkg/httpx/metrics.go
@@ -1,4 +1,4 @@
-package mux
+package httpx
 
 import "github.com/prometheus/client_golang/prometheus"
 

--- a/pkg/httpx/mux.go
+++ b/pkg/httpx/mux.go
@@ -1,4 +1,4 @@
-package mux
+package httpx
 
 import (
 	"errors"

--- a/pkg/httpx/mux_test.go
+++ b/pkg/httpx/mux_test.go
@@ -1,4 +1,4 @@
-package mux
+package httpx
 
 import (
 	"net/http"

--- a/pkg/httpx/response.go
+++ b/pkg/httpx/response.go
@@ -1,4 +1,4 @@
-package mux
+package httpx
 
 import (
 	"bufio"

--- a/pkg/httpx/response_test.go
+++ b/pkg/httpx/response_test.go
@@ -1,4 +1,4 @@
-package mux
+package httpx
 
 import (
 	"errors"

--- a/pkg/httpx/status.go
+++ b/pkg/httpx/status.go
@@ -1,0 +1,63 @@
+package httpx
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+type StatusError struct {
+	Message       string
+	ExpectedCodes []int
+	StatusCode    int
+}
+
+func (e *StatusError) Error() string {
+	expectedCodeStrs := []string{}
+	for _, expected := range e.ExpectedCodes {
+		expectedCodeStrs = append(expectedCodeStrs, fmt.Sprintf("%d %s", expected, http.StatusText(expected)))
+	}
+	msg := fmt.Sprintf("expected one of the following statuses [%s], but received %d %s", strings.Join(expectedCodeStrs, ", "), e.StatusCode, http.StatusText(e.StatusCode))
+	if e.Message != "" {
+		msg += ": " + e.Message
+	}
+	return msg
+}
+
+func CheckResponseStatus(resp *http.Response, expectedCodes ...int) error {
+	if len(expectedCodes) == 0 {
+		return errors.New("expected codes cannot be empty")
+	}
+	if slices.Contains(expectedCodes, resp.StatusCode) {
+		return nil
+	}
+	message, messageErr := getErrorMessage(resp)
+	statusErr := &StatusError{
+		Message:       message,
+		ExpectedCodes: expectedCodes,
+		StatusCode:    resp.StatusCode,
+	}
+	return errors.Join(statusErr, messageErr)
+}
+
+func getErrorMessage(resp *http.Response) (string, error) {
+	defer resp.Body.Close()
+	if resp.Request.Method == http.MethodHead {
+		return "", nil
+	}
+	contentTypes := []string{
+		"text/plain",
+		"text/html",
+		"application/json",
+		"application/xml",
+	}
+	if !slices.Contains(contentTypes, resp.Header.Get(HeaderContentType)) {
+		_, err := io.Copy(io.Discard, resp.Body)
+		return "", err
+	}
+	b, err := io.ReadAll(resp.Body)
+	return string(b), err
+}

--- a/pkg/httpx/status_test.go
+++ b/pkg/httpx/status_test.go
@@ -1,0 +1,97 @@
+package httpx
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		contentType   string
+		body          string
+		expectedError string
+		requestMethod string
+		expectedCodes []int
+		statusCode    int
+	}{
+		{
+			name:          "status code matches one of expected",
+			contentType:   "text/plain",
+			body:          "Hello World",
+			statusCode:    http.StatusOK,
+			expectedCodes: []int{http.StatusNotFound, http.StatusOK},
+			requestMethod: http.MethodGet,
+			expectedError: "",
+		},
+		{
+			name:          "no expected status codes",
+			contentType:   "text/plain",
+			statusCode:    http.StatusOK,
+			expectedCodes: []int{},
+			expectedError: "expected codes cannot be empty",
+		},
+		{
+			name:          "wrong code with text content and GET request",
+			contentType:   "text/plain",
+			body:          "Hello World",
+			statusCode:    http.StatusNotFound,
+			expectedCodes: []int{http.StatusOK},
+			requestMethod: http.MethodGet,
+			expectedError: "expected one of the following statuses [200 OK], but received 404 Not Found: Hello World",
+		},
+		{
+			name:          "wrong code with text content and HEAD request",
+			contentType:   "text/plain",
+			body:          "Hello World",
+			statusCode:    http.StatusNotFound,
+			expectedCodes: []int{http.StatusOK, http.StatusPartialContent},
+			requestMethod: http.MethodHead,
+			expectedError: "expected one of the following statuses [200 OK, 206 Partial Content], but received 404 Not Found",
+		},
+		{
+			name:          "wrong code with text content and GET request but octet stream",
+			contentType:   "application/octet-stream",
+			body:          "Hello World",
+			statusCode:    http.StatusNotFound,
+			expectedCodes: []int{http.StatusOK},
+			requestMethod: http.MethodGet,
+			expectedError: "expected one of the following statuses [200 OK], but received 404 Not Found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(tt.statusCode)
+			rec.Header().Set("Content-Type", tt.contentType)
+			rec.Body = bytes.NewBufferString(tt.body)
+
+			resp := &http.Response{
+				StatusCode: tt.statusCode,
+				Status:     http.StatusText(tt.statusCode),
+				Header:     rec.Header(),
+				Body:       io.NopCloser(rec.Body),
+				Request: &http.Request{
+					Method: tt.requestMethod,
+				},
+			}
+
+			err := CheckResponseStatus(resp, tt.expectedCodes...)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.expectedError)
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/spegel-org/spegel/pkg/mux"
+	"github.com/spegel-org/spegel/pkg/httpx"
 )
 
 var (
@@ -50,5 +50,5 @@ func Register() {
 	DefaultRegisterer.MustRegister(AdvertisedImageTags)
 	DefaultRegisterer.MustRegister(AdvertisedImageDigests)
 	DefaultRegisterer.MustRegister(AdvertisedKeys)
-	mux.RegisterMetrics(DefaultRegisterer)
+	httpx.RegisterMetrics(DefaultRegisterer)
 }

--- a/pkg/oci/client_test.go
+++ b/pkg/oci/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,9 +73,9 @@ func TestPull(t *testing.T) {
 			return
 		}
 
-		rw.Header().Set(ContentTypeHeader, mt)
+		rw.Header().Set(httpx.HeaderContentType, mt)
 		dgst := digest.SHA256.FromBytes(b)
-		rw.Header().Set(DigestHeader, dgst.String())
+		rw.Header().Set(HeaderDockerDigest, dgst.String())
 		rw.WriteHeader(http.StatusOK)
 
 		//nolint: errcheck // Ignore error.


### PR DESCRIPTION
This change cleans up some of the http helpers which were spread out in different packages. Renaming mux to httpx indicates that there is now a place for any http logic which isn't found in stdlib.