### PR TITLE
Add descriptor to header conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#888](https://github.com/spegel-org/spegel/pull/888) Refactor OCI events to support content events.
 - [#890](https://github.com/spegel-org/spegel/pull/890) Refactor Containerd options to use config struct.
 - [#896](https://github.com/spegel-org/spegel/pull/896) Rename package mux to httpx and refactor http helpers.
+- [#897](https://github.com/spegel-org/spegel/pull/897) Add descriptor to header conversion.
 
 ### Deprecated
 

--- a/pkg/httpx/status_test.go
+++ b/pkg/httpx/status_test.go
@@ -73,7 +73,7 @@ func TestStatusError(t *testing.T) {
 
 			rec := httptest.NewRecorder()
 			rec.WriteHeader(tt.statusCode)
-			rec.Header().Set("Content-Type", tt.contentType)
+			rec.Header().Set(HeaderContentType, tt.contentType)
 			rec.Body = bytes.NewBufferString(tt.body)
 
 			resp := &http.Response{


### PR DESCRIPTION
Adds helper functions to get descriptor from http headers and vice versa. Makes things easier to test.