### PR TITLE
Disable data dir when running Spegel in Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#872](https://github.com/spegel-org/spegel/pull/872) Allow returning libp2p crypto priv key in linter.
 - [#894](https://github.com/spegel-org/spegel/pull/894) Update Kind to v0.29.0 and Fix Containerd v2 support.
 - [#899](https://github.com/spegel-org/spegel/pull/899) Handle situation where digest is missing in reigstry response header.
+- [#902](https://github.com/spegel-org/spegel/pull/902) Disable data dir when running Spegel in Kubernetes.
 
 ### Security
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -30,7 +30,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | priorityClassName | string | `"system-node-critical"` | Priority class name to use for the pod. |
 | resources | object | `{"limits":{"memory":"128Mi"},"requests":{"memory":"128Mi"}}` | Resource requests and limits for the Spegel container. |
 | revisionHistoryLimit | int | `10` | The number of old history to retain to allow rollback. |
-| securityContext | object | `{}` | Security context for the Spegel container. |
+| securityContext | object | `{"readOnlyRootFilesystem":true}` | Security context for the Spegel container. |
 | service.cleanup.port | int | `8080` | Port to expose cleanup probe on. |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |
 | service.registry.hostPort | int | `30020` | Local host port to expose the registry. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -104,6 +104,8 @@ spec:
           {{- end }}
           - --debug-web-enabled={{ .Values.spegel.debugWebEnabled }}
         env:
+        - name: DATA_DIR
+          value: ""
         {{- if ((.Values.resources).limits).cpu }}
         - name: GOMAXPROCS
           valueFrom:

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -35,13 +35,8 @@ podSecurityContext: {}
 revisionHistoryLimit: 10
 
 # -- Security context for the Spegel container.
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext: 
+  readOnlyRootFilesystem: true
 
 service:
   registry:


### PR DESCRIPTION
The introduction of data dir was meant to help people running Spegel outside of containers. The change introduced a new flag data dir with the default value `/var/lib/spegel`. As the flag has  a default value it would be used when running Spegel in a container. This is only a problem if you enforce read only file systems.

We do not use the data dir to persist any information anyways so it is easier to just disable it when running in Kubernetes until we do. This change also enforces read only filesystem by default to avoid regression in the future.

Fixes #863 
Fixes #882 