### PR TITLE
Enforce use of request contexts and fix response closing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - staticcheck
     - testifylint
     - unused
+    - noctx
   settings:
     errcheck:
       disable-default-exclusions: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#911](https://github.com/spegel-org/spegel/pull/911) Enforce use of request contexts and fix response closing.
+
 ### Security
 
 ## v0.3.0

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -10,7 +10,7 @@ import (
 func TestWeb(t *testing.T) {
 	t.Parallel()
 
-	w, err := NewWeb(nil)
+	w, err := NewWeb(nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, w.tmpls)
 }

--- a/pkg/httpx/status.go
+++ b/pkg/httpx/status.go
@@ -44,7 +44,6 @@ func CheckResponseStatus(resp *http.Response, expectedCodes ...int) error {
 }
 
 func getErrorMessage(resp *http.Response) (string, error) {
-	defer resp.Body.Close()
 	if resp.Request.Method == http.MethodHead {
 		return "", nil
 	}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
 )
@@ -236,7 +237,7 @@ func TestMirrorHandler(t *testing.T) {
 				srv.Handler.ServeHTTP(rw, req)
 
 				resp := rw.Result()
-				defer resp.Body.Close()
+				defer httpx.DrainAndClose(resp.Body)
 				b, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedStatus, resp.StatusCode)


### PR DESCRIPTION
This change adds a new linter for request context. It also removes all use of default clients. This change also fixes some areas where response bodies were not closed.