### PR TITLE
Remove setup Helm in favor of built in binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,10 +18,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Setup Cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac #v3.9.1
-      - name: Setup Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 #v4.3.0
-        with:
-          version: v3.17.3
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1


### PR DESCRIPTION
This change removes the custom setup Helm action in favor of using the binary built into the GitHub runner. We used this initially as the version was pretty old.

Relates to #940 