### PR TITLE
Skip writing headers and status code on mirror retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#911](https://github.com/spegel-org/spegel/pull/911) Enforce use of request contexts and fix response closing.
 - [#914](https://github.com/spegel-org/spegel/pull/914) Fix OCI client header parsing and improve tests.
 - [#935](https://github.com/spegel-org/spegel/pull/935) Fix node selector in e2e pull test.
+- [#942](https://github.com/spegel-org/spegel/pull/942) Skip writing headers and status code on mirror retries.
 
 ### Security
 

--- a/pkg/httpx/response_test.go
+++ b/pkg/httpx/response_test.go
@@ -31,7 +31,7 @@ func TestResponseWriter(t *testing.T) {
 		ResponseWriter: httptest.NewRecorder(),
 	}
 	rw.WriteHeader(http.StatusNotFound)
-	require.True(t, rw.writtenHeader)
+	require.True(t, rw.wroteHeader)
 	require.Equal(t, http.StatusNotFound, rw.Status())
 	rw.WriteHeader(http.StatusBadGateway)
 	require.Equal(t, http.StatusNotFound, rw.Status())


### PR DESCRIPTION
You are unable to write additional headers after the status code has been written or body has been written to the response writer. For this reason a check is added to avoid doing these writes on retries. This change also fixes so that the correct status code is returned from the upstream registry in case of a partial response.