### PR TITLE
Add spegel component label to spegel DaemonSet

### DIFF
--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "spegel.fullname" . }}
   namespace: {{ include "spegel.namespace" . }}
   labels:
+    app.kubernetes.io/component: spegel
     {{- include "spegel.labels" . | nindent 4 }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -11,6 +12,7 @@ spec:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
+      app.kubernetes.io/component: spegel
       {{- include "spegel.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -19,6 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        app.kubernetes.io/component: spegel
         {{- include "spegel.selectorLabels" . | nindent 8 }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "spegel.labels" . | nindent 4 }}
 spec:
   selector:
+    app.kubernetes.io/component: spegel
     {{- include "spegel.selectorLabels" . | nindent 4 }}
   ports:
     - name: metrics
@@ -29,6 +30,7 @@ metadata:
 spec:
   type: NodePort
   selector:
+    app.kubernetes.io/component: spegel
     {{- include "spegel.selectorLabels" . | nindent 4 }}
   ports:
     - name: registry
@@ -46,6 +48,7 @@ metadata:
     {{- include "spegel.labels" . | nindent 4 }}
 spec:
   selector:
+    app.kubernetes.io/component: spegel
     {{- include "spegel.selectorLabels" . | nindent 4 }}
   clusterIP: None
   publishNotReadyAddresses: true


### PR DESCRIPTION
On bootstrap, spegel is trying to resolve the `spegel-cleanup` pods causing error in spegel logs so it fails to start up with a single node.