### PR TITLE
Introduce a liveness probe for spegel

### DIFF
--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -145,6 +145,12 @@ spec:
           httpGet:
             path: /healthz
             port: registry
+        livenessProbe:
+          periodSeconds: 10
+          failureThreshold: 30
+          httpGet:
+            path: /healthz
+            port: registry
         volumeMounts:
           {{- if .Values.basicAuthSecretName }}
           - name: basic-auth


### PR DESCRIPTION
Introduce a liveness probe for spegel to restart spegel pod if it's being unresponsive for 5 minutes.

Fixes #945