### PR TITLE
Set timeout for mirror requests and switch to using OCI client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#909](https://github.com/spegel-org/spegel/pull/909) Add base http client and transport.
 - [#910](https://github.com/spegel-org/spegel/pull/910) Add drain and close function.
 - [#933](https://github.com/spegel-org/spegel/pull/933) Verify that OCI volumes works with Sepgel in e2e tests.
+- [#949](https://github.com/spegel-org/spegel/pull/949) Set timeout for mirror requests and switch to using OCI client.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -141,8 +141,6 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		return err
 	}
 
-	ociClient := oci.NewClient()
-
 	// OCI Store
 	ociStore, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, args.MirroredRegistries, oci.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
@@ -226,7 +224,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
 	if args.DebugWebEnabled {
-		web, err := web.NewWeb(router, ociClient)
+		web, err := web.NewWeb(router, oci.NewClient(nil))
 		if err != nil {
 			return err
 		}

--- a/pkg/httpx/range.go
+++ b/pkg/httpx/range.go
@@ -1,26 +1,104 @@
 package httpx
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
-type ByteRange struct {
+const rangeUnit = "bytes"
+
+type Range struct {
 	Start int64 `json:"start"`
 	End   int64 `json:"end"`
 }
 
-func FormatRangeHeader(byteRange ByteRange) string {
-	return fmt.Sprintf("bytes=%d-%d", byteRange.Start, byteRange.End)
+func (rng Range) String() string {
+	return fmt.Sprintf("%s=%d-%d", rangeUnit, rng.Start, rng.End)
 }
 
-func FormatMultipartRangeHeader(byteRanges []ByteRange) string {
-	if len(byteRanges) == 0 {
-		return ""
+func (rng Range) Size() int64 {
+	return rng.End - rng.Start + 1
+}
+
+func ParseRangeHeader(h string, size int64) (Range, error) {
+	if size <= 0 {
+		return Range{}, fmt.Errorf("size %d cannot be equal or less than zero", size)
 	}
-	ranges := []string{}
-	for _, br := range byteRanges {
-		ranges = append(ranges, fmt.Sprintf("%d-%d", br.Start, br.End))
+	rangeUnitPrefix := rangeUnit + "="
+	if !strings.HasPrefix(h, rangeUnitPrefix) {
+		return Range{}, errors.New("invalid range unit")
 	}
-	return "bytes=" + strings.Join(ranges, ", ")
+	ranges := strings.Split(strings.TrimPrefix(h, rangeUnitPrefix), ",")
+	if len(ranges) != 1 {
+		return Range{}, errors.New("multiple ranges not supported")
+	}
+	parts := strings.SplitN(strings.TrimSpace(ranges[0]), "-", 2)
+	if len(parts) != 2 {
+		return Range{}, errors.New("invalid range format")
+	}
+
+	// Suffix byte range
+	if parts[0] == "" {
+		suffixLen, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return Range{}, err
+		}
+		if suffixLen <= 0 {
+			return Range{}, fmt.Errorf("invalid suffix range %d", suffixLen)
+		}
+		if suffixLen > size {
+			suffixLen = size
+		}
+		rng := Range{
+			Start: size - suffixLen,
+			End:   size - 1,
+		}
+		return rng, nil
+	}
+
+	rng := Range{}
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return Range{}, err
+	}
+	if start < 0 {
+		return Range{}, fmt.Errorf("invalid start %d", start)
+	}
+	rng.Start = start
+	if parts[1] == "" {
+		rng.End = size - 1
+	} else {
+		end, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return Range{}, err
+		}
+		if end >= size {
+			end = size - 1
+		}
+		rng.End = end
+	}
+	if rng.Start > rng.End {
+		return Range{}, fmt.Errorf("start %d cannot be larger than end %d", rng.Start, rng.End)
+	}
+	return rng, nil
+}
+
+type ContentRange struct {
+	Start int64
+	End   int64
+	Size  int64
+}
+
+func ContentRangeFromRange(rng Range, size int64) ContentRange {
+	return ContentRange{
+		Start: rng.Start,
+		End:   rng.End,
+		Size:  size,
+	}
+}
+
+func (crng ContentRange) String() string {
+	return fmt.Sprintf("%s %d-%d/%d", rangeUnit, crng.Start, crng.End, crng.Size)
 }

--- a/pkg/httpx/range_test.go
+++ b/pkg/httpx/range_test.go
@@ -6,30 +6,150 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFormatRangeHeader(t *testing.T) {
+func TestRange(t *testing.T) {
 	t.Parallel()
 
-	br := ByteRange{Start: 10, End: 2000}
-	val := FormatRangeHeader(br)
-	require.Equal(t, "bytes=10-2000", val)
-}
-
-func TestFormatMultipartRangeHeader(t *testing.T) {
-	t.Parallel()
-
-	brr := []ByteRange{
+	//nolint: govet // Ignore fieldalignment for readability.
+	validTests := []struct {
+		value          string
+		length         int64
+		expectedRange  Range
+		expectedString string
+		expectedSize   int64
+	}{
 		{
-			Start: 10,
-			End:   100,
+			value:  "bytes=0-0",
+			length: 1,
+			expectedRange: Range{
+				Start: 0,
+				End:   0,
+			},
+			expectedString: "bytes=0-0",
+			expectedSize:   1,
 		},
 		{
-			Start: 0,
-			End:   1,
+			value:  "bytes=0-499",
+			length: 1000,
+			expectedRange: Range{
+				Start: 0,
+				End:   499,
+			},
+			expectedString: "bytes=0-499",
+			expectedSize:   500,
+		},
+		{
+			value:  "bytes=500-999",
+			length: 1500,
+			expectedRange: Range{
+				Start: 500,
+				End:   999,
+			},
+			expectedString: "bytes=500-999",
+			expectedSize:   500,
+		},
+		{
+			value:  "bytes=500-",
+			length: 1200,
+			expectedRange: Range{
+				Start: 500,
+				End:   1199,
+			},
+			expectedString: "bytes=500-1199",
+			expectedSize:   700,
+		},
+		{
+			value:  "bytes=-200",
+			length: 1000,
+			expectedRange: Range{
+				Start: 800,
+				End:   999,
+			},
+			expectedString: "bytes=800-999",
+			expectedSize:   200,
+		},
+		{
+			value:  "bytes=0-1000",
+			length: 1000,
+			expectedRange: Range{
+				Start: 0,
+				End:   999,
+			},
+			expectedString: "bytes=0-999",
+			expectedSize:   1000,
+		},
+		{
+			value:  "bytes=999-1000",
+			length: 1000,
+			expectedRange: Range{
+				Start: 999,
+				End:   999,
+			},
+			expectedString: "bytes=999-999",
+			expectedSize:   1,
 		},
 	}
-	val := FormatMultipartRangeHeader(brr)
-	require.Equal(t, "bytes=10-100, 0-1", val)
+	for _, tt := range validTests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
 
-	val = FormatMultipartRangeHeader(nil)
-	require.Empty(t, val)
+			r, err := ParseRangeHeader(tt.value, tt.length)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedRange, r)
+			require.Equal(t, tt.expectedString, r.String())
+			require.Equal(t, tt.expectedSize, r.Size())
+		})
+	}
+
+	//nolint: govet // Ignore fieldalignment for readability.
+	errorTests := []struct {
+		value    string
+		length   int64
+		expected string
+	}{
+		{
+			value:    "bytes=",
+			length:   10,
+			expected: "invalid range format",
+		},
+		{
+			value:    "bytes=abc-def",
+			length:   10,
+			expected: "strconv.ParseInt: parsing \"abc\": invalid syntax",
+		},
+		{
+			value:    "bytes=-0",
+			length:   10,
+			expected: "invalid suffix range 0",
+		},
+		{
+			value:    "bytes=100-50",
+			length:   400,
+			expected: "start 100 cannot be larger than end 50",
+		},
+		{
+			value:    "bytes=0-499,500-999",
+			length:   1500,
+			expected: "multiple ranges not supported",
+		},
+	}
+	for _, tt := range errorTests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseRangeHeader(tt.value, tt.length)
+			require.EqualError(t, err, tt.expected)
+		})
+	}
+}
+
+func TestContentRange(t *testing.T) {
+	t.Parallel()
+
+	rng := Range{
+		Start: 0,
+		End:   50,
+	}
+	crng := ContentRangeFromRange(rng, 100)
+	expected := "bytes 0-50/100"
+	require.Equal(t, expected, crng.String())
 }

--- a/pkg/oci/client_test.go
+++ b/pkg/oci/client_test.go
@@ -62,7 +62,7 @@ func TestClient(t *testing.T) {
 		srv.Close()
 	})
 
-	client := NewClient()
+	client := NewClient(srv.Client())
 	mirror, err := url.Parse(srv.URL)
 	require.NoError(t, err)
 	pullResults, err := client.Pull(t.Context(), img, WithFetchMirror(mirror))


### PR DESCRIPTION
Switching to the OCI client moves the logic to a single place, instead of having some in the registry and other parts in the debug logic. On top of that it opens up the ability to do more complicated logic for the mirror. This change also adds timeouts to HEAD and manifest requests. These are tuned to the fact that we run Spegel within fast private networks, so we do not have to make considerations that traffic over public internet has to.

Blob timeouts will be added in a future PR but needs some thought put into it, as it needs to be dynamic based on content size.