### PR TITLE
Fix lint errors and add forbidgo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - testifylint
     - unused
     - noctx
+    - forbidigo
   settings:
     errcheck:
       disable-default-exclusions: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#914](https://github.com/spegel-org/spegel/pull/914) Fix OCI client header parsing and improve tests.
 - [#935](https://github.com/spegel-org/spegel/pull/935) Fix node selector in e2e pull test.
 - [#942](https://github.com/spegel-org/spegel/pull/942) Skip writing headers and status code on mirror retries.
+- [#950](https://github.com/spegel-org/spegel/pull/950) Fix lint errors and add forbidgo.
 
 ### Security
 

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -31,10 +31,9 @@ func TestCleanupFail(t *testing.T) {
 func TestCleanupSucceed(t *testing.T) {
 	t.Parallel()
 
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		panic(err)
-	}
+	listenCfg := &net.ListenConfig{}
+	listener, err := listenCfg.Listen(t.Context(), "tcp", ":")
+	require.NoError(t, err)
 	addr := listener.Addr().String()
 	err = listener.Close()
 	require.NoError(t, err)


### PR DESCRIPTION
Forbid go blocks fmt.Print statements by default.