### PR TITLE
Add OCI errors to registry 4xx responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#933](https://github.com/spegel-org/spegel/pull/933) Verify that OCI volumes works with Sepgel in e2e tests.
 - [#949](https://github.com/spegel-org/spegel/pull/949) Set timeout for mirror requests and switch to using OCI client.
 - [#951](https://github.com/spegel-org/spegel/pull/951) Add tests for channel merge.
+- [#953](https://github.com/spegel-org/spegel/pull/953) Add OCI errors to registry 4xx responses.
 
 ### Changed
 

--- a/pkg/httpx/error.go
+++ b/pkg/httpx/error.go
@@ -1,0 +1,6 @@
+package httpx
+
+type ResponseError interface {
+	error
+	ResponseBody() ([]byte, error)
+}

--- a/pkg/httpx/mux.go
+++ b/pkg/httpx/mux.go
@@ -45,7 +45,10 @@ func (s *ServeMux) Handle(pattern string, handler HandlerFunc) {
 	metricsPath := metricsFriendlyPath(pattern)
 	s.mux.HandleFunc(pattern, func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
-		rw := &response{ResponseWriter: w}
+		rw := &response{
+			ResponseWriter: w,
+			method:         req.Method,
+		}
 		defer func() {
 			latency := time.Since(start)
 			statusCode := strconv.FormatInt(int64(rw.Status()), 10)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -190,16 +190,16 @@ func TestRegistryHandler(t *testing.T) {
 	}{
 		{
 			name:            "request should timeout when no peers exists",
-			key:             "no-peers",
+			key:             "sha256:03ffdf45276dd38ffac79b0e9c6c14d89d9113ad783d5922580f4c66a3305591",
 			expectedStatus:  http.StatusNotFound,
-			expectedBody:    []byte{},
+			expectedBody:    []byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","detail":{"attempts":0},"message":"mirror with image component sha256:03ffdf45276dd38ffac79b0e9c6c14d89d9113ad783d5922580f4c66a3305591 could not be found"}]}`),
 			expectedHeaders: nil,
 		},
 		{
 			name:            "request should not timeout and give 404 if all peers fail",
 			key:             "sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6",
 			expectedStatus:  http.StatusNotFound,
-			expectedBody:    []byte{},
+			expectedBody:    []byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","detail":{"attempts":3},"message":"mirror with image component sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6 could not be found requests to 3 mirrors failed, all attempts have been exhausted or timeout has been reached"}]}`),
 			expectedHeaders: nil,
 		},
 		{
@@ -252,11 +252,13 @@ func TestRegistryHandler(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedStatus, resp.StatusCode)
 
-				if method == http.MethodGet {
+				switch method {
+				case http.MethodGet:
 					require.Equal(t, tt.expectedBody, b)
-				}
-				if method == http.MethodHead {
+				case http.MethodHead:
 					require.Empty(t, b)
+				default:
+					t.FailNow()
 				}
 
 				if tt.expectedHeaders == nil {


### PR DESCRIPTION
This change adds some more details to the errors returned which will help get insight when a pull fails. The details are extra interesting as it allows us to add Spegel specific information to errors.