### PR TITLE
Refactor debug logs for when e2e tests fail

### DIFF
--- a/test/e2e/testdata/conformance-job.yaml
+++ b/test/e2e/testdata/conformance-job.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: conformance
-        image: ghcr.io/spegel-org/conformance:583e014
+        image: ghcr.io/spegel-org/conformance:9d1b925
         env:
         - name: OCI_TEST_PULL
           value: "1"


### PR DESCRIPTION
These changes make it easier to read the relevant error logs when tests fail.