### PR TITLE
Add optional liveness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#951](https://github.com/spegel-org/spegel/pull/951) Add tests for channel merge.
 - [#953](https://github.com/spegel-org/spegel/pull/953) Add OCI errors to registry 4xx responses.
 - [#954](https://github.com/spegel-org/spegel/pull/954) Allow setting _default mirrored registry.
+- [#962](https://github.com/spegel-org/spegel/pull/962) Add optional liveness probe.
 
 ### Changed
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -22,6 +22,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | image.repository | string | `"ghcr.io/spegel-org/spegel"` | Image repository. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image Pull Secrets |
+| livenessProbe.enabled | bool | `false` | When enabled a liveness probe will be added to the registry.  |
 | nameOverride | string | `""` | Overrides the name of the chart. |
 | namespaceOverride | string | `""` | Overrides the namespace where spegel resources are installed. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for pod assignment. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -142,12 +142,18 @@ spec:
           periodSeconds: 3
           failureThreshold: 60
           httpGet:
-            path: /healthz
+            path: /readyz
             port: registry
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: registry
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: registry
+        {{- end }}
         volumeMounts:
           {{- if .Values.basicAuthSecretName }}
           - name: basic-auth

--- a/charts/spegel/templates/post-delete-hook.yaml
+++ b/charts/spegel/templates/post-delete-hook.yaml
@@ -39,7 +39,7 @@ spec:
           - --addr=:{{ .Values.service.cleanup.port }}
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: readiness
         ports:
           - name: readiness

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -191,3 +191,7 @@ verticalPodAutoscaler:
     # -- Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     updateMode: Auto
+
+livenessProbe:
+  # -- When enabled a liveness probe will be added to the registry. 
+  enabled: false

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -27,7 +27,7 @@ func Run(ctx context.Context, addr, configPath string) error {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	mux := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodGet && req.URL.Path != "/healthz" {
+		if req.Method != http.MethodGet && req.URL.Path != "/readyz" {
 			log.Error(errors.New("unknown request"), "unsupported probe request", "path", req.URL.Path, "method", req.Method)
 			rw.WriteHeader(http.StatusNotFound)
 			return
@@ -117,7 +117,7 @@ func probeIPs(ctx context.Context, client *http.Client, ips []net.IPAddr, port s
 			u := url.URL{
 				Scheme: "http",
 				Host:   net.JoinHostPort(ip.String(), port),
-				Path:   "/healthz",
+				Path:   "/readyz",
 			}
 			reqCtx, cancel := context.WithTimeout(gCtx, 1*time.Second)
 			defer cancel()

--- a/pkg/httpx/mux.go
+++ b/pkg/httpx/mux.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -57,8 +58,8 @@ func (s *ServeMux) Handle(pattern string, handler HandlerFunc) {
 			HttpRequestDurHistogram.WithLabelValues(metricsPath, req.Method, statusCode).Observe(latency.Seconds())
 			HttpResponseSizeHistogram.WithLabelValues(metricsPath, req.Method, statusCode).Observe(float64(rw.Size()))
 
-			// Ignore logging requests to healthz to reduce log noise
-			if req.URL.Path == "/healthz" {
+			// Ignore logging requests to readyz and livez to reduce log noise
+			if slices.Contains([]string{"/readyz", "/livez"}, req.URL.Path) {
 				return
 			}
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -152,7 +152,8 @@ func NewRegistry(ociStore oci.Store, router routing.Router, opts ...RegistryOpti
 
 func (r *Registry) Handler() *httpx.ServeMux {
 	m := httpx.NewServeMux(r.log)
-	m.Handle("GET /healthz", r.readyHandler)
+	m.Handle("GET /readyz", r.readyHandler)
+	m.Handle("GET /livez", r.livenesHandler)
 	m.Handle("GET /v2/", r.registryHandler)
 	m.Handle("HEAD /v2/", r.registryHandler)
 	return m
@@ -167,7 +168,7 @@ func (r *Registry) Server(addr string) (*http.Server, error) {
 }
 
 func (r *Registry) readyHandler(rw httpx.ResponseWriter, req *http.Request) {
-	rw.SetHandler("ready")
+	rw.SetHandler("readyz")
 
 	ok, err := r.router.Ready(req.Context())
 	if err != nil {
@@ -178,6 +179,13 @@ func (r *Registry) readyHandler(rw httpx.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	rw.WriteHeader(http.StatusOK)
+}
+
+func (r *Registry) livenesHandler(rw httpx.ResponseWriter, req *http.Request) {
+	rw.SetHandler("livez")
+
+	rw.WriteHeader(http.StatusOK)
 }
 
 func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -44,7 +44,7 @@ func TestRegistryOptions(t *testing.T) {
 	require.Equal(t, "bar", cfg.Password)
 }
 
-func TestReadyHandler(t *testing.T) {
+func TestProbeHandlers(t *testing.T) {
 	t.Parallel()
 
 	router := routing.NewMemoryRouter(map[string][]netip.AddrPort{}, netip.MustParseAddrPort("127.0.0.1:8080"))
@@ -54,13 +54,21 @@ func TestReadyHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "http://localhost/healthz", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/readyz", nil)
 	srv.Handler.ServeHTTP(rw, req)
 	require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+	rw = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "http://localhost/livez", nil)
+	srv.Handler.ServeHTTP(rw, req)
+	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
 
 	router.Add("foo", netip.MustParseAddrPort("127.0.0.1:9090"))
 	rw = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "http://localhost/healthz", nil)
+	req = httptest.NewRequest(http.MethodGet, "http://localhost/readyz", nil)
+	srv.Handler.ServeHTTP(rw, req)
+	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+	rw = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "http://localhost/livez", nil)
 	srv.Handler.ServeHTTP(rw, req)
 	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -156,7 +156,7 @@ func TestE2E(t *testing.T) {
 		if addr.Is6() {
 			hostIP = fmt.Sprintf("[%s]", hostIP)
 		}
-		httpCode := command(t.Context(), t, fmt.Sprintf("docker exec %s-worker curl -s -o /dev/null -w \"%%{http_code}\" http://%s:%s/healthz || true", kindName, hostIP, tt.port))
+		httpCode := command(t.Context(), t, fmt.Sprintf("docker exec %s-worker curl -s -o /dev/null -w \"%%{http_code}\" http://%s:%s/readyz || true", kindName, hostIP, tt.port))
 		require.Equal(t, tt.expected, httpCode)
 	}
 


### PR DESCRIPTION
This change adds a liveness probe to Spegel that is separate to the readiness probe. By default the liveness probe is disabled. The change also changes the path of the readiness probe from `/healthz` to `/readyz` to align things with the new endpoint `/livez`. The reason the probe has its own endpoint is to avoid restarts of Spegel occurring when part of the external health checking fails. The liveness probe is there to detect any potential deadlock or freezing that may occur.

Fixes #945
Fixes #946 