### PR TITLE
Refactor bootstraper to use address info instead of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#931](https://github.com/spegel-org/spegel/pull/931) Cleanup e2e tests to use more standardized node labels.
 - [#932](https://github.com/spegel-org/spegel/pull/932) Switch to using spegel-org images in e2e tests.
 - [#957](https://github.com/spegel-org/spegel/pull/957) Refactor memory store to include descriptor.
+- [#970](https://github.com/spegel-org/spegel/pull/970) Refactor bootstraper to use address info instead of string.
 
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ipfs/go-cid v0.5.0
 	github.com/libp2p/go-libp2p v0.41.1
 	github.com/libp2p/go-libp2p-kad-dht v0.33.1
+	github.com/miekg/dns v1.1.66
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multicodec v0.9.2
 	github.com/multiformats/go-multihash v0.2.3
@@ -102,7 +103,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/miekg/dns v1.1.66 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -2,13 +2,14 @@ package routing
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
+	"net"
 	"testing"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/miekg/dns"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestStaticBootstrap(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		return bs.Run(gCtx, "")
+		return bs.Run(gCtx, peer.AddrInfo{})
 	})
 
 	bsPeers, err := bs.Get(t.Context())
@@ -44,31 +45,91 @@ func TestStaticBootstrap(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestHTTPBootstrap(t *testing.T) {
+func TestDNSBootstrap(t *testing.T) {
 	t.Parallel()
-
-	id := "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		//nolint:errcheck // ignore
-		w.Write([]byte(id))
-	}))
-	defer svr.Close()
-
-	bs := NewHTTPBootstrapper(":", svr.URL)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	g, gCtx := errgroup.WithContext(ctx)
+
+	rr, err := dns.NewRR("example.com. 30 IN A 10.1.2.3")
+	require.NoError(t, err)
+	mux := dns.NewServeMux()
+	mux.Handle("peers", dns.HandlerFunc(func(w dns.ResponseWriter, m *dns.Msg) {
+		msg := &dns.Msg{}
+		msg.SetReply(m)
+		msg.Answer = []dns.RR{rr}
+		//nolint:errcheck // Ignore.
+		w.WriteMsg(msg)
+	}))
+	//nolint:noctx // Context not important for testing.
+	pc, err := net.ListenPacket("udp", ":0")
+	require.NoError(t, err)
+	srv := &dns.Server{
+		PacketConn: pc,
+		Handler:    mux,
+	}
 	g.Go(func() error {
-		return bs.Run(gCtx, "")
+		return srv.ActivateAndServe()
+	})
+	g.Go(func() error {
+		<-gCtx.Done()
+		return srv.Shutdown()
 	})
 
-	addrInfos, err := bs.Get(t.Context())
+	bs := NewDNSBootstrapper("peers", 10)
+	bs.resolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			//nolint:noctx // Context not important for testing.
+			return net.Dial("udp", pc.LocalAddr().String())
+		},
+	}
+	g.Go(func() error {
+		return bs.Run(gCtx, peer.AddrInfo{})
+	})
+	addrInfos, err := bs.Get(ctx)
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
-	addrInfo := addrInfos[0]
-	require.Len(t, addrInfo.Addrs, 1)
-	require.Equal(t, "/ip4/104.131.131.82/tcp/4001", addrInfo.Addrs[0].String())
-	require.Equal(t, "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ", addrInfo.ID.String())
+	require.Len(t, addrInfos[0].Addrs, 1)
+	require.Equal(t, "{: [/ip4/10.1.2.3]}", addrInfos[0].String())
+
+	cancel()
+	err = g.Wait()
+	require.NoError(t, err)
+}
+
+func TestHTTPBootstrap(t *testing.T) {
+	t.Parallel()
+
+	//nolint:noctx // Context not important for testing.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	err = ln.Close()
+	require.NoError(t, err)
+	parentAddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
+	require.NoError(t, err)
+	id, err := peer.Decode("12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB")
+	require.NoError(t, err)
+	parentAddrInfo := peer.AddrInfo{
+		ID:    id,
+		Addrs: []ma.Multiaddr{parentAddr},
+	}
+	parentBs := NewHTTPBootstrapper(ln.Addr().String(), "")
+	ctx, cancel := context.WithCancel(t.Context())
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return parentBs.Run(gCtx, parentAddrInfo)
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	childBs := NewHTTPBootstrapper(":", "http://"+ln.Addr().String())
+	addrInfos, err := childBs.Get(t.Context())
+	require.NoError(t, err)
+	require.Len(t, addrInfos, 1)
+	require.Len(t, addrInfos[0].Addrs, 1)
+	require.Equal(t, parentAddrInfo.ID, addrInfos[0].ID)
+	require.Equal(t, "{12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB: [/ip4/127.0.0.1/tcp/4001]}", addrInfos[0].String())
 
 	cancel()
 	err = g.Wait()

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -163,8 +163,7 @@ func NewP2PRouter(ctx context.Context, addr string, bs Bootstrapper, registryPor
 }
 
 func (r *P2PRouter) Run(ctx context.Context) (err error) {
-	self := fmt.Sprintf("%s/p2p/%s", r.host.Addrs()[0].String(), r.host.ID().String())
-	logr.FromContextOrDiscard(ctx).WithName("p2p").Info("starting p2p router", "id", self)
+	logr.FromContextOrDiscard(ctx).WithName("p2p").Info("starting p2p router", "id", r.host.ID())
 	if err := r.kdht.Bootstrap(ctx); err != nil {
 		return fmt.Errorf("could not bootstrap distributed hash table: %w", err)
 	}
@@ -174,7 +173,7 @@ func (r *P2PRouter) Run(ctx context.Context) (err error) {
 			err = errors.Join(err, cerr)
 		}
 	}()
-	err = r.bootstrapper.Run(ctx, self)
+	err = r.bootstrapper.Run(ctx, *host.InfoFromHost(r.host))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Updates the bootstrap to use address info instead of a string. This fixes possible issues related to supporting dual stack deployments.

Relates to #709