### PR TITLE
Update Go to 1.25.0

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
           go-version-file: go.mod
+      # https://github.com/golang/go/issues/75031
+      - name: Set toolchain version
+        run: go env -w GOTOOLCHAIN=go1.25.0+auto
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage reports to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#932](https://github.com/spegel-org/spegel/pull/932) Switch to using spegel-org images in e2e tests.
 - [#957](https://github.com/spegel-org/spegel/pull/957) Refactor memory store to include descriptor.
 - [#970](https://github.com/spegel-org/spegel/pull/970) Refactor bootstraper to use address info instead of string.
+- [#975](https://github.com/spegel-org/spegel/pull/975) Update Go to 1.25.0.
 
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/spegel-org/spegel
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.0
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20250530080122-d0efc28a5723


### PR DESCRIPTION
This updates the toolchain to use Go 1.25 when building.