### PR TITLE
Add support for push endpoints to registry server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/go-logr/logr v1.4.3
+	github.com/google/uuid v1.6.0
 	github.com/ipfs/go-cid v0.5.0
 	github.com/libp2p/go-libp2p v0.43.0
 	github.com/libp2p/go-libp2p-kad-dht v0.34.0
@@ -66,7 +67,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -59,9 +59,7 @@ type RegistryCmd struct {
 	MirrorResolveRetries         int           `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
 	ResolveLatestTag             bool          `arg:"--resolve-latest-tag,env:RESOLVE_LATEST_TAG" default:"true" help:"When true latest tags will be resolved to digests."`
 	DebugWebEnabled              bool          `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"false" help:"When true enables debug web page."`
-	Push                         bool          `arg:"--push,env:PUSH" default:"false" help:"When true handles push endpoints by writing to the Containerd content and image store."`
-	PushUpstream                 bool          `arg:"--push-upstream,env:PUSH_UPSTREAM" default:"false" help:"When true asynchronously pushes uploaded images to the upstream registry."`
-	LeaseDuration                time.Duration `arg:"--lease-duration,env:LEASE_DURATION" default:"10m" help:"Temporary lease duration for pushed images."`
+	registry.PushConfig
 }
 
 type CleanupCmd struct {
@@ -187,9 +185,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
 		registry.WithLogger(log),
 		registry.WithBasicAuth(username, password),
-		registry.WithPush(args.Push),
-		registry.WithPushUpstream(args.PushUpstream),
-		registry.WithLeaseDuration(args.LeaseDuration),
+		registry.WithPushConfig(args.PushConfig),
 	}
 	reg, err := registry.NewRegistry(ociStore, router, registryOpts...)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ type RegistryCmd struct {
 	MirrorResolveRetries         int           `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
 	ResolveLatestTag             bool          `arg:"--resolve-latest-tag,env:RESOLVE_LATEST_TAG" default:"true" help:"When true latest tags will be resolved to digests."`
 	DebugWebEnabled              bool          `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"false" help:"When true enables debug web page."`
+	Push                         bool          `arg:"--push,env:PUSH" default:"false" help:"When true handles push endpoints by writing to the Containerd content and image store."`
+	PushUpstream                 bool          `arg:"--push-upstream,env:PUSH_UPSTREAM" default:"false" help:"When true asynchronously pushes uploaded images to the upstream registry."`
+	LeaseDuration                time.Duration `arg:"--lease-duration,env:LEASE_DURATION" default:"10m" help:"Temporary lease duration for pushed images."`
 }
 
 type CleanupCmd struct {
@@ -184,6 +187,9 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
 		registry.WithLogger(log),
 		registry.WithBasicAuth(username, password),
+		registry.WithPush(args.Push),
+		registry.WithPushUpstream(args.PushUpstream),
+		registry.WithLeaseDuration(args.LeaseDuration),
 	}
 	reg, err := registry.NewRegistry(ociStore, router, registryOpts...)
 	if err != nil {

--- a/pkg/registry/push.go
+++ b/pkg/registry/push.go
@@ -1,0 +1,340 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/containerd/v2/pkg/labels"
+	"github.com/containerd/errdefs"
+	"github.com/google/uuid"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/spegel-org/spegel/pkg/httpx"
+	"github.com/spegel-org/spegel/pkg/oci"
+)
+
+// Add a temporary lease to newly created content and images.
+func (r *Registry) withLease(ctx context.Context) (context.Context, error) {
+	if r.leaseDuration == 0 {
+		return ctx, nil
+	}
+	cd, ok := r.ociStore.(*oci.Containerd)
+	if !ok {
+		return nil, errors.New("lease requires containerd store")
+	}
+	cdc, err := cd.Client()
+	if err != nil {
+		return nil, err
+	}
+	lease := cdc.LeasesService()
+
+	l, err := lease.Create(ctx, leases.WithRandomID(), leases.WithExpiration(r.leaseDuration))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lease: %w", err)
+	}
+	return leases.WithLease(ctx, l.ID), nil
+}
+
+func uploadRef(id string) string {
+	return ("spegel-upload:") + id
+}
+
+func withSource(dist oci.DistributionPath) content.Opt {
+	return content.WithLabels(map[string]string{labels.LabelDistributionSource + "." + dist.Registry: dist.Name})
+}
+
+func uploadStatus(rw httpx.ResponseWriter, dist oci.DistributionPath, offset int64) {
+	rw.Header().Set("Location", "/v2/"+dist.Name+"/blobs/uploads/"+dist.Session)
+	rw.Header().Set("Docker-Upload-UUID", dist.Session)
+	rw.Header().Set("Range", "0-"+strconv.FormatInt(max(0, offset-1), 10))
+	rw.Header().Set(httpx.HeaderContentLength, "0")
+}
+
+func created(rw httpx.ResponseWriter, dist oci.DistributionPath) {
+	rw.Header().Set(oci.HeaderDockerDigest, dist.Digest.String())
+	rw.Header().Set("Location", dist.URL().Path)
+	rw.Header().Set(httpx.HeaderContentLength, "0")
+	rw.WriteHeader(http.StatusCreated)
+}
+
+func (r *Registry) pushHandler(rw httpx.ResponseWriter, req *http.Request) {
+	rw.SetHandler("push")
+
+	if !r.push {
+		rw.WriteError(http.StatusMethodNotAllowed, oci.NewDistributionError(oci.ErrCodeUnsupported, "push endpoints disabled", nil))
+		return
+	}
+
+	// Check basic authentication
+	if r.username != "" || r.password != "" {
+		username, password, _ := req.BasicAuth()
+		if r.username != username || r.password != password {
+			rw.WriteError(http.StatusUnauthorized, oci.NewDistributionError(oci.ErrCodeUnauthorized, "invalid credentials", nil))
+			return
+		}
+	}
+
+	// Parse out path components from request.
+	dist, err := oci.ParseDistributionPath(req.URL)
+	if err != nil {
+		rw.WriteError(http.StatusNotFound, fmt.Errorf("could not parse path according to OCI distribution spec: %w", err))
+		return
+	}
+
+	cdc, cs, err := r.getContainerdClient()
+	if err != nil {
+		rw.WriteError(http.StatusMethodNotAllowed, oci.NewDistributionError(oci.ErrCodeUnsupported, err.Error(), nil))
+		return
+	}
+
+	if dist.Kind == oci.DistributionKindUpload {
+		if req.Method == http.MethodPost && dist.Session == "" {
+			if string(dist.Digest) == "" {
+				r.handleBlobUploadStart(rw, req, dist, cs)
+			} else {
+				r.handleBlobUploadMonolithic(rw, req, dist, cs)
+			}
+			return
+		}
+		if dist.Session != "" {
+			switch req.Method {
+			case http.MethodPatch:
+				r.handleBlobUploadChunk(rw, req, dist, cs)
+				return
+			case http.MethodPut:
+				r.handleBlobUploadCommit(rw, req, dist, cs)
+				return
+			case http.MethodGet:
+				r.handleBlobUploadGet(rw, req, dist, cs)
+				return
+			}
+		}
+
+	}
+
+	if dist.Kind == oci.DistributionKindManifest && req.Method == http.MethodPut {
+		r.handleManifestPut(rw, req, dist, cdc)
+		return
+	}
+
+	rw.WriteError(http.StatusNotFound, oci.NewDistributionError(oci.ErrCodeUnsupported, "unsupported push endpoint", nil))
+}
+
+func (r *Registry) getContainerdClient() (*client.Client, content.Store, error) {
+	cd, ok := r.ociStore.(*oci.Containerd)
+	if !ok {
+		return nil, nil, errors.New("push requires containerd store")
+	}
+	cdc, err := cd.Client()
+	if err != nil {
+		return nil, nil, err
+	}
+	return cdc, cdc.ContentStore(), nil
+}
+
+func (r *Registry) handleBlobUploadMonolithic(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath, cs content.Store) {
+	if err := dist.Digest.Validate(); err != nil {
+		rw.WriteError(http.StatusBadRequest, oci.NewDistributionError(oci.ErrCodeDigestInvalid, "invalid digest", err.Error()))
+		return
+	}
+	ctx, err := r.withLease(req.Context())
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	w, err := cs.Writer(ctx, content.WithRef(uploadRef(uuid.NewString())))
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	defer w.Close()
+
+	n, err := io.Copy(w, req.Body)
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	if err = w.Commit(ctx, n, dist.Digest, withSource(dist)); err != nil && !errdefs.IsAlreadyExists(err) {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	created(rw, dist)
+}
+
+func (r *Registry) handleBlobUploadStart(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath, cs content.Store) {
+	dist.Session = uuid.NewString()
+	w, err := cs.Writer(req.Context(), content.WithRef(uploadRef(dist.Session)))
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	_ = w.Close()
+	uploadStatus(rw, dist, 0)
+	rw.WriteHeader(http.StatusAccepted)
+}
+
+func (r *Registry) handleBlobUploadChunk(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath, cs content.Store) {
+	ctx, err := r.withLease(req.Context())
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	w, err := cs.Writer(ctx, content.WithRef(uploadRef(dist.Session)))
+	if err != nil {
+		rw.WriteError(http.StatusNotFound, oci.NewDistributionError(oci.ErrCodeBlobUploadUnknown, "unknown upload session", nil))
+		return
+	}
+	if _, err = io.Copy(w, req.Body); err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	status, err := w.Status()
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	uploadStatus(rw, dist, status.Offset)
+	rw.WriteHeader(http.StatusAccepted)
+}
+
+func (r *Registry) handleBlobUploadCommit(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath, cs content.Store) {
+	if err := dist.Digest.Validate(); err != nil {
+		rw.WriteError(http.StatusBadRequest, oci.NewDistributionError(oci.ErrCodeDigestInvalid, "invalid digest", err.Error()))
+		return
+	}
+	ctx, err := r.withLease(req.Context())
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	desc := ocispec.Descriptor{Digest: dist.Digest}
+	w, err := cs.Writer(ctx, content.WithRef(uploadRef(dist.Session)), content.WithDescriptor(desc))
+	if err != nil {
+		rw.WriteError(http.StatusNotFound, oci.NewDistributionError(oci.ErrCodeBlobUploadUnknown, "unknown upload session", nil))
+		return
+	}
+	defer w.Close()
+
+	// final chunk
+	if _, err = io.Copy(w, req.Body); err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	status, err := w.Status()
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	if err = w.Commit(ctx, status.Offset, dist.Digest, withSource(dist)); err != nil && !errdefs.IsAlreadyExists(err) {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	created(rw, dist)
+}
+
+func (r *Registry) handleBlobUploadGet(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath, cs content.Store) {
+	status, err := cs.Status(req.Context(), uploadRef(dist.Session))
+	if err != nil && errdefs.IsNotFound(err) {
+		rw.WriteError(http.StatusNotFound, oci.NewDistributionError(oci.ErrCodeBlobUploadUnknown, "unknown upload session", nil))
+		return
+	} else if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	uploadStatus(rw, dist, status.Offset)
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+func (r *Registry) handleManifestPut(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath, client *client.Client) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	mediaType := req.Header.Get(httpx.HeaderContentType)
+	if mediaType == "" {
+		mediaType, err = oci.DetermineMediaType(body)
+		if err != nil {
+			rw.WriteError(http.StatusBadRequest, oci.NewDistributionError(oci.ErrCodeManifestInvalid, "cannot determine manifest media type", nil))
+			return
+		}
+	}
+	size := int64(len(body))
+	desc := ocispec.Descriptor{MediaType: mediaType, Digest: digest.FromBytes(body), Size: size}
+
+	ctx, err := r.withLease(req.Context())
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	cs := client.ContentStore()
+	w, err := cs.Writer(ctx, content.WithRef(dist.Reference()))
+	if err != nil && !errdefs.IsAlreadyExists(err) {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	if err == nil {
+		defer w.Close()
+		if _, err := io.Copy(w, bytes.NewReader(body)); err != nil {
+			rw.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		if err = w.Commit(ctx, size, desc.Digest, withSource(dist)); err != nil && !errdefs.IsAlreadyExists(err) {
+			rw.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+	}
+
+	ref := dist.Reference()
+	if dist.Digest != "" {
+		ref = fmt.Sprintf("%s/%s@%s", dist.Registry, dist.Name, desc.Digest)
+	}
+	if _, err = client.ImageService().Create(ctx, (images.Image{Name: ref, Target: desc})); err != nil && !errdefs.IsAlreadyExists(err) {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	dist.Digest = desc.Digest
+	created(rw, dist)
+	if r.pushUpstream {
+		pushHeaders := req.Header.Clone()
+		go func() {
+			log := r.log.WithName("backgroundPush").WithValues("ref", ref, "desc", desc)
+			log.Info("Starting upstream image push")
+			ctx := context.Background()
+
+			pusher, err := docker.NewResolver(docker.ResolverOptions{Headers: pushHeaders}).Pusher(ctx, ref)
+			if err != nil {
+				log.Error(err, "failed to get pusher")
+				return
+			}
+
+			if err = remotes.PushContent(ctx, pusher, desc, cs, nil, nil, nil); err != nil {
+				log.Error(err, "failed to push image upstream")
+				return
+			}
+			log.Info("Finished upstream image push")
+		}()
+	}
+}

--- a/pkg/registry/push.go
+++ b/pkg/registry/push.go
@@ -248,6 +248,7 @@ func (r *Registry) handleBlobUploadCommit(rw httpx.ResponseWriter, req *http.Req
 		return
 	}
 
+	dist.Kind = oci.DistributionKindBlob
 	created(rw, dist)
 }
 

--- a/pkg/registry/push.go
+++ b/pkg/registry/push.go
@@ -319,6 +319,11 @@ func (r *Registry) handleManifestPut(rw httpx.ResponseWriter, req *http.Request,
 
 	dist.Digest = desc.Digest
 	created(rw, dist)
+
+	if err = images.Dispatch(ctx, images.SetChildrenLabels(cs, images.ChildrenHandler(cs)), nil, desc); err != nil {
+		r.log.Error(err, "failed to set image labels")
+		return
+	}
 	go func() {
 		// Broadcast image content for immediate discovery.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/pkg/routing/memory.go
+++ b/pkg/routing/memory.go
@@ -49,7 +49,7 @@ func (m *MemoryRouter) Resolve(ctx context.Context, key string, count int) (<-ch
 	return peerCh, nil
 }
 
-func (m *MemoryRouter) Advertise(ctx context.Context, keys []string) error {
+func (m *MemoryRouter) Advertise(ctx context.Context, keys []string, _ bool) error {
 	for _, key := range keys {
 		m.Add(key, m.self)
 	}

--- a/pkg/routing/memory_test.go
+++ b/pkg/routing/memory_test.go
@@ -16,7 +16,7 @@ func TestMemoryRouter(t *testing.T) {
 	isReady, err := r.Ready(t.Context())
 	require.NoError(t, err)
 	require.False(t, isReady)
-	err = r.Advertise(t.Context(), []string{"foo"})
+	err = r.Advertise(t.Context(), []string{"foo"}, false)
 	require.NoError(t, err)
 	isReady, err = r.Ready(t.Context())
 	require.NoError(t, err)

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -256,14 +256,14 @@ func (r *P2PRouter) Resolve(ctx context.Context, key string, count int) (<-chan 
 	return peerCh, nil
 }
 
-func (r *P2PRouter) Advertise(ctx context.Context, keys []string) error {
+func (r *P2PRouter) Advertise(ctx context.Context, keys []string, brdcst bool) error {
 	logr.FromContextOrDiscard(ctx).V(4).Info("advertising keys", "host", r.host.ID().String(), "keys", keys)
 	for _, key := range keys {
 		c, err := createCid(key)
 		if err != nil {
 			return err
 		}
-		err = r.rd.Provide(ctx, c, false)
+		err = r.rd.Provide(ctx, c, brdcst)
 		if err != nil {
 			return err
 		}

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -52,14 +52,14 @@ func TestP2PRouter(t *testing.T) {
 	// Flake results in a peer being returned without an address. Revisit in Go 1.24 to see if this can be solved better.
 	time.Sleep(1 * time.Second)
 
-	err = router.Advertise(ctx, nil)
+	err = router.Advertise(ctx, nil, false)
 	require.NoError(t, err)
 	peerCh, err := router.Resolve(ctx, "foo", 1)
 	require.NoError(t, err)
 	peer := <-peerCh
 	require.False(t, peer.IsValid())
 
-	err = router.Advertise(ctx, []string{"foo"})
+	err = router.Advertise(ctx, []string{"foo"}, false)
 	require.NoError(t, err)
 	peerCh, err = router.Resolve(ctx, "foo", 1)
 	require.NoError(t, err)

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -11,6 +11,6 @@ type Router interface {
 	Ready(ctx context.Context) (bool, error)
 	// Resolve asynchronously discovers addresses that can serve the content defined by the give key.
 	Resolve(ctx context.Context, key string, count int) (<-chan netip.AddrPort, error)
-	// Advertise broadcasts that the current router can serve the content.
-	Advertise(ctx context.Context, keys []string) error
+	// Advertise provides (and optionally broadcasts) that the current router can serve the content.
+	Advertise(ctx context.Context, keys []string, brdcst bool) error
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -70,7 +70,7 @@ func tick(ctx context.Context, ociStore oci.Store, router routing.Router, resolv
 		if !ok {
 			continue
 		}
-		err := router.Advertise(ctx, []string{tagName})
+		err := router.Advertise(ctx, []string{tagName}, false)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func tick(ctx context.Context, ociStore oci.Store, router routing.Router, resolv
 		return err
 	}
 	for _, content := range contents {
-		err := router.Advertise(ctx, []string{content.Digest.String()})
+		err := router.Advertise(ctx, []string{content.Digest.String()}, false)
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,7 @@ func handle(ctx context.Context, router routing.Router, event oci.OCIEvent) erro
 	if event.Type != oci.CreateEvent {
 		return nil
 	}
-	err := router.Advertise(ctx, []string{event.Key})
+	err := router.Advertise(ctx, []string{event.Key}, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is an attempt at #545, making it possible to push to Spegel by implementing a subset of the OCI Distribution specification's endpoints related to pushing images in the registry server (the `/blobs/uploads/` and `PUT /manifests/` endpoints). The new endpoints are only handled when the `Push` config-flag is enabled (default `false`).

An optional `PushUpstream` extension (default `false`) asynchronously pushes uploaded images back to the upstream registry, and a temporary lease (`LeaseDuration`, default `10m`) is placed on newly created content and images to prevent them from being immediately garbage collected.

My use-case for this feature is to have Spegel act as a proxy for an upstream image push while making it immediately available in the local mirror, which can significantly improve latency and network usage compared to having the image perform a round-trip to/from the remote upstream registry.

---
This PR works well enough for my use-case at this point. I'd like feedback and guidance on whether this seems like a decent enough approach for being eventually merged into the main project with some further work.

The implementation currently uses the containerd `client.Client` directly and doesn't include any tests. The next step would probably be to abstract the implementation into corresponding `oci.Store` / `oci.Client` interfaces and add some tests against an in-memory implementation. Also open to any more specific (or entirely different) directions you'd like to go with this implementation as well.