### PR TITLE
fix: add content-create events for image tag

### DIFF
--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -453,9 +453,14 @@ func (c *Containerd) convertEvent(ctx context.Context, envelope events.Envelope)
 		if err != nil {
 			return nil, err
 		}
-		// Pull by tag creates an event only for the tag. We dont get content to avoid advertising twice.
+		events := []OCIEvent{}
 		if img.Digest == "" {
-			return []OCIEvent{{Type: CreateEvent, Key: e.GetName()}}, nil
+			events = append(events, OCIEvent{Type: CreateEvent, Key: e.GetName()})
+			dgst, err := c.Resolve(ctx, img.String())
+			if err != nil {
+				return nil, err
+			}
+			img.Digest = dgst
 		}
 		// If Containerd supports content events we can skip walking the image.
 		feats, err := c.Features(ctx)
@@ -463,13 +468,12 @@ func (c *Containerd) convertEvent(ctx context.Context, envelope events.Envelope)
 			return nil, err
 		}
 		if feats.Has(FeatureContentEvent) {
-			return nil, nil
+			return events, nil
 		}
 		dgsts, err := WalkImage(ctx, c, img)
 		if err != nil {
 			return nil, fmt.Errorf("could not get digests for image %s: %w", img.String(), err)
 		}
-		events := []OCIEvent{}
 		for _, dgst := range dgsts {
 			events = append(events, OCIEvent{Type: CreateEvent, Key: dgst.String()})
 		}


### PR DESCRIPTION
While working on #977, I found that newly-pushed images were not immediately advertising their associated content, and learned that for containerd versions not supporting native content-create events, the logic to create `OCIEvent` from images was explicitly skipped for tag-referenced images:

https://github.com/spegel-org/spegel/blob/a78e9f442863f23f5edd51a185f3f5eb982e1041/pkg/oci/containerd.go#L456-L459

This PR fixes the issue by resolving the image digest from the tag and allows the existing logic to walk the image to create associated content events.

(note: this fix works for my case, but I'm not 100% confident it will work in the general case since I didn't fully understand the existing comment about advertising twice. In my own tests, I only saw a single `/images/create` event when pulling an image by tag. My tests were on containerd v1.7.20 in case version-specific behavior is related.)