### PR TITLE
Return context error when context is done

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -28,7 +28,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resol
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-tickerCh:
 			log.Info("running state update")
 			err := tick(ctx, ociStore, router, resolveLatestTag)


### PR DESCRIPTION
Allows callers of state.Track to see error returned by context cancellation.