### PR TITLE
feat(helm): Add support for annotations on DaemonSet

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -9,10 +9,10 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings for pod assignment. |
-| annotations | object | `{}` | Annotations to add to the DaemonSet. |
 | basicAuthSecretName | string | `""` | Name of secret containing basic authentication credentials for registry. |
 | clusterDomain | string | `"cluster.local."` | Domain configured for service domain names. |
 | commonLabels | object | `{}` | Common labels to apply to all rendered resources. |
+| daemonsetAnnotations | object | `{}` | Annotations to add to the DaemonSet. |
 | fullnameOverride | string | `""` | Overrides the full name of the chart. |
 | grafanaDashboard.annotations | object | `{}` | Annotations that ConfigMaps can have to get configured in Grafana, See: sidecar.dashboards.folderAnnotation for specifying the dashboard folder. https://github.com/grafana/helm-charts/tree/main/charts/grafana |
 | grafanaDashboard.enabled | bool | `false` | If true creates a Grafana dashboard. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "spegel.fullname" . }}
   namespace: {{ include "spegel.namespace" . }}
-  {{- with .Values.annotations }}
+  {{- with .Values.daemonsetAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -25,7 +25,7 @@ serviceAccount:
   name: ""
 
 # -- Annotations to add to the DaemonSet.
-annotations: {}
+daemonsetAnnotations: {}
 
 # -- Annotations to add to the pod.
 podAnnotations: {}


### PR DESCRIPTION
## Summary
Adds configurable annotations to the Spegel DaemonSet via Helm chart.

## Changes
- Added `daemonsetAnnotations` field to values.yaml
- Updated DaemonSet template to include annotations
- Generated Helm documentation

## Usage
```yaml
daemonsetAnnotations:
  example.com/annotation: "value"
```
---
## Testing
Verified template rendering with test annotations in values.yaml using:
```bash
helm template ./ -f values.yaml