### PR TITLE
Return state context error and text shutdown exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#955](https://github.com/spegel-org/spegel/pull/955) Cleanup and move set handler to handler functions.
 - [#956](https://github.com/spegel-org/spegel/pull/956) Remove setting logger for klog.
 - [#984](https://github.com/spegel-org/spegel/pull/984) Fix host matches to support dual stack deployments.
+- [#996](https://github.com/spegel-org/spegel/pull/996) Return state context error and text shutdown exit code.
 
 ### Security
 

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	// State tracking
 	g.Go(func() error {
 		err := state.Track(ctx, ociStore, router, args.ResolveLatestTag)
-		if err != nil {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			return err
 		}
 		return nil

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -28,7 +28,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resol
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-tickerCh:
 			log.Info("running state update")
 			err := tick(ctx, ociStore, router, resolveLatestTag)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -103,7 +103,7 @@ func TestTrack(t *testing.T) {
 
 			cancel()
 			err := g.Wait()
-			require.NoError(t, err)
+			require.ErrorIs(t, err, context.Canceled)
 		})
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -117,7 +117,8 @@ func TestE2E(t *testing.T) {
 	// Remove Spegel from the last node to test that the mirror fallback is working.
 	workerPod := command(t.Context(), t, fmt.Sprintf("kubectl --kubeconfig %s --namespace spegel get pods --no-headers -o name --field-selector spec.nodeName=%s-worker4", kcPath, kindName))
 	command(t.Context(), t, fmt.Sprintf("kubectl --kubeconfig %s label nodes %s-worker4 spegel.dev/enabled-", kcPath, kindName))
-	command(t.Context(), t, fmt.Sprintf("kubectl --kubeconfig %s --namespace spegel wait --for=delete %s --timeout=60s", kcPath, workerPod))
+	exitCode := command(t.Context(), t, fmt.Sprintf("kubectl --kubeconfig %s --namespace spegel wait --for=jsonpath='{.status.containerStatuses[0].state.terminated}' -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' %s --timeout=30s", kcPath, workerPod))
+	require.Equal(t, "0", exitCode)
 
 	// Pull image from registry after Spegel has started.
 	command(t.Context(), t, fmt.Sprintf("docker exec %s-worker ctr -n k8s.io image pull %s", kindName, images[5]))


### PR DESCRIPTION
This change returns the context error as suggested in #989, but also fixes unit tests and adds an additional check in the e2e test to verify that Spegel exits with code 0 on shutdown. This will hopefully catch any regression in the future.