### PR TITLE
Update to Go v1.25.1

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,8 +28,6 @@ jobs:
         with:
           go-version-file: go.mod
       # https://github.com/golang/go/issues/75031
-      - name: Set toolchain version
-        run: go env -w GOTOOLCHAIN=go1.25.0+auto
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage reports to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#970](https://github.com/spegel-org/spegel/pull/970) Refactor bootstraper to use address info instead of string.
 - [#975](https://github.com/spegel-org/spegel/pull/975) Update Go to 1.25.0.
 - [#995](https://github.com/spegel-org/spegel/pull/995) Cleanup http logger to allow generic attribute.
+- [#1000](https://github.com/spegel-org/spegel/pull/1000) Update Go to 1.25.1.
 
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/spegel-org/spegel
 
 go 1.24.0
 
-toolchain go1.25.0
+toolchain go1.25.1
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20250530080122-d0efc28a5723


### PR DESCRIPTION
We can now remove setting the toolchain as that has been fixed.