### PR TITLE
Add options to state tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#975](https://github.com/spegel-org/spegel/pull/975) Update Go to 1.25.0.
 - [#995](https://github.com/spegel-org/spegel/pull/995) Cleanup http logger to allow generic attribute.
 - [#1000](https://github.com/spegel-org/spegel/pull/1000) Update Go to 1.25.1.
+- [#1008](https://github.com/spegel-org/spegel/pull/1008) Add options to state tracker.
 
 ### Deprecated
 


### PR DESCRIPTION
This change changes optional args to an option list instead, which was suggested in #987. This allows some more flexibility in adding new optional args. The work in #1003 made me realize that this was important as we cant to deprecate the old resolve latest tag.