### PR TITLE
Deprecate resolve latest in favor of registry filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- [#1009](https://github.com/spegel-org/spegel/pull/1009) Deprecate resolve latest in favor of registry filters.
+
 ### Removed
 
 ### Fixed

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -58,6 +58,7 @@ func WithResolveRetries(resolveRetries int) RegistryOption {
 	}
 }
 
+// Deprecated: Resolve latest tag is replaced by registry filter which offers more customizable behavior. Use the filter `:latest$` to achieve the same behavior.
 func WithResolveLatestTag(resolveLatestTag bool) RegistryOption {
 	return func(cfg *RegistryConfig) error {
 		cfg.ResolveLatestTag = resolveLatestTag

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -33,6 +33,7 @@ func (cfg *TrackerConfig) Apply(opts ...TrackerOption) error {
 
 type TrackerOption func(t *TrackerConfig) error
 
+// Deprecated: Resolve latest tag is replaced by registry filter which offers more customizable behavior. Use the filter `:latest$` to achieve the same behavior.
 func WithResolveLatestTag(resolveLatestTag bool) TrackerOption {
 	return func(cfg *TrackerConfig) error {
 		cfg.ResolveLatestTag = resolveLatestTag


### PR DESCRIPTION
This change deprecates the resolve latest option in favor of using registry filters. There is no need to have multiple features with overlapping use cases. Some time in the future we will remove the feature all together.