### PR TITLE
Enable debug web by default and add last successful mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#995](https://github.com/spegel-org/spegel/pull/995) Cleanup http logger to allow generic attribute.
 - [#1000](https://github.com/spegel-org/spegel/pull/1000) Update Go to 1.25.1.
 - [#1008](https://github.com/spegel-org/spegel/pull/1008) Add options to state tracker.
+- [#1010](https://github.com/spegel-org/spegel/pull/1010) Enable debug web by default and add last successful mirror.
 
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -58,7 +58,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
-| spegel.debugWebEnabled | bool | `false` | When true enables debug web page. |
+| spegel.debugWebEnabled | bool | `true` | When true enables debug web page. |
 | spegel.logLevel | string | `"INFO"` | Minimum log level to output. Value should be DEBUG, INFO, WARN, or ERROR. |
 | spegel.mirrorResolveRetries | int | `3` | Max amount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"20ms"` | Max duration spent finding a mirror. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -172,7 +172,7 @@ spegel:
   # -- When true existing mirror configuration will be kept and Spegel will prepend it's configuration.
   prependExisting: false
   # -- When true enables debug web page.
-  debugWebEnabled: false
+  debugWebEnabled: true
 
 verticalPodAutoscaler:
   # -- If true creates a Vertical Pod Autoscaler.

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -54,10 +54,14 @@
 		}
 
 		.stat-box {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			align-items: center;
+			min-height: 100px;
 			padding: 16px;
 			border-radius: 8px;
 			box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-			text-align: center;
 		}
 
 		.stat-title {

--- a/internal/web/templates/stats.html
+++ b/internal/web/templates/stats.html
@@ -1,10 +1,18 @@
 <div>
   <div class="stat-container">
-    <div class="stat-box">
+    <div class="stat-box" style="background-color: {{if .MirrorLastSuccess}}#81C784{{else}}#FAA93B{{end}};">
+      <div class="stat-title">Last Mirror Success</div>
+      {{- if .MirrorLastSuccess }}
+      <div class="stat-value">{{ .MirrorLastSuccess | formatDuration }} ago</div>
+      {{- else }}
+      <div class="stat-value">Pending</div>
+      {{- end }}
+    </div>
+    <div class="stat-box" style="background-color: {{if .ImageCount}}#81C784{{else}}#E57373{{end}};">
       <div class="stat-title">Images</div>
       <div class="stat-value">{{ .ImageCount }}</div>
     </div>
-    <div class="stat-box">
+    <div class="stat-box" style="background-color: {{if .LayerCount}}#81C784{{else}}#E57373{{end}};">
       <div class="stat-title">Layers</div>
       <div class="stat-value">{{ .LayerCount }}</div>
     </div>

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -62,11 +62,11 @@ func TestDuration(t *testing.T) {
 		},
 		{
 			duration: 5*time.Minute + 128*time.Second,
-			expected: "7m8s",
+			expected: "7m 8s",
 		},
 		{
 			duration: 2 * time.Hour,
-			expected: "120m",
+			expected: "2h",
 		},
 	}
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ type RegistryCmd struct {
 	RegistryFilters              []*regexp.Regexp `arg:"--registry-filters,env:REGISTRY_FILTERS" help:"Regular expressions to filter out tags/registries, if slice is empty all registries/tags are resolved."`
 	MirrorResolveTimeout         time.Duration    `arg:"--mirror-resolve-timeout,env:MIRROR_RESOLVE_TIMEOUT" default:"20ms" help:"Max duration spent finding a mirror."`
 	MirrorResolveRetries         int              `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
-	DebugWebEnabled              bool             `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"false" help:"When true enables debug web page."`
+	DebugWebEnabled              bool             `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"true" help:"When true enables debug web page."`
 	ResolveLatestTag             bool             `arg:"--resolve-latest-tag,env:RESOLVE_LATEST_TAG" default:"true" help:"When true latest tags will be resolved to digests."`
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,6 +21,10 @@ var (
 		Name: "spegel_mirror_requests_total",
 		Help: "Total number of mirror requests.",
 	}, []string{"registry", "cache"})
+	MirrorLastSuccessTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "spegel_mirror_last_success_timestamp_seconds",
+		Help: "The timestamp of the last successful mirror request.",
+	})
 	ResolveDurHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "spegel_resolve_duration_seconds",
 		Help: "The duration for router to resolve a peer.",
@@ -45,6 +49,7 @@ var (
 
 func Register() {
 	DefaultRegisterer.MustRegister(MirrorRequestsTotal)
+	DefaultRegisterer.MustRegister(MirrorLastSuccessTimestamp)
 	DefaultRegisterer.MustRegister(ResolveDurHistogram)
 	DefaultRegisterer.MustRegister(AdvertisedImages)
 	DefaultRegisterer.MustRegister(AdvertisedImageTags)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -270,6 +270,7 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 			cacheType = "miss"
 		}
 		metrics.MirrorRequestsTotal.WithLabelValues(dist.Registry, cacheType).Inc()
+		metrics.MirrorLastSuccessTimestamp.SetToCurrentTime()
 	}()
 
 	mirrorDetails := MirrorErrorDetails{


### PR DESCRIPTION
This change attempts to add a visual method of understanding if Spegel is working or not. Showing the last successful mirror will indicate if everything has been configured properly or not.