### PR TITLE
Refactor image parsing to include options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1013](https://github.com/spegel-org/spegel/pull/1013) Refactor image parsing to include options.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -309,7 +309,7 @@ func (c *Containerd) ListImages(ctx context.Context) ([]Image, error) {
 	}
 	imgs := []Image{}
 	for _, cImg := range cImgs {
-		img, err := ParseImageRequireDigest(cImg.Name(), cImg.Target().Digest)
+		img, err := ParseImage(cImg.Name(), WithStrict(), WithDigest(cImg.Target().Digest))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseImageRequireDigest(t *testing.T) {
+func TestParseImageStrict(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -78,7 +78,7 @@ func TestParseImageRequireDigest(t *testing.T) {
 				t.Parallel()
 
 				for _, extraDgst := range []string{tt.expectedDigest.String(), ""} {
-					img, err := ParseImageRequireDigest(fmt.Sprintf("%s/%s", registry, tt.image), digest.Digest(extraDgst))
+					img, err := ParseImage(fmt.Sprintf("%s/%s", registry, tt.image), WithStrict(), WithDigest(digest.Digest(extraDgst)))
 					if !tt.digestInImage && extraDgst == "" {
 						require.EqualError(t, err, "image needs to contain a digest")
 						continue
@@ -104,7 +104,7 @@ func TestParseImageRequireDigest(t *testing.T) {
 	}
 }
 
-func TestParseImageRequireDigestErrors(t *testing.T) {
+func TestParseImageStrictErrors(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -142,7 +142,7 @@ func TestParseImageRequireDigestErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := ParseImageRequireDigest(tt.s, tt.dgst)
+			_, err := ParseImage(tt.s, WithStrict(), WithDigest(tt.dgst))
 			require.EqualError(t, err, tt.expectedError)
 		})
 	}
@@ -151,7 +151,6 @@ func TestParseImageRequireDigestErrors(t *testing.T) {
 func TestNewImageErrors(t *testing.T) {
 	t.Parallel()
 
-	// TODO (phillebaba): Add test case for no digest or tag. One needs to be set.
 	tests := []struct {
 		name          string
 		registry      string
@@ -183,6 +182,14 @@ func TestNewImageErrors(t *testing.T) {
 			tag:           "latest",
 			dgst:          digest.Digest("test"),
 			expectedError: "invalid checksum digest format",
+		},
+		{
+			name:          "missing tag and digest",
+			registry:      "example.com",
+			repository:    "foo/bar",
+			tag:           "",
+			dgst:          "",
+			expectedError: "either tag or digest has to be set",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -65,7 +65,7 @@ func TestStore(t *testing.T) {
 		_, err = imageStore.Create(ctx, cImg)
 		require.NoError(t, err)
 
-		img, err := ParseImageRequireDigest(k, desc.Digest)
+		img, err := ParseImage(k, WithStrict(), WithDigest(desc.Digest))
 		require.NoError(t, err)
 		memoryStore.AddImage(img)
 	}
@@ -275,7 +275,7 @@ func TestStore(t *testing.T) {
 				t.Run(tt.imageName, func(t *testing.T) {
 					t.Parallel()
 
-					img, err := ParseImageRequireDigest(tt.imageName, digest.Digest(tt.imageDigest))
+					img, err := ParseImage(tt.imageName, WithStrict(), WithDigest(digest.Digest(tt.imageDigest)))
 					require.NoError(t, err)
 					dgsts, err := WalkImage(ctx, ociStore, img)
 					require.NoError(t, err)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -52,7 +52,7 @@ func TestTrack(t *testing.T) {
 		require.NoError(t, err)
 		dgst := digest.NewDigest(digest.SHA256, hash)
 		ociStore.Write(ocispec.Descriptor{Digest: dgst}, b)
-		img, err := oci.ParseImageRequireDigest(imageStr, dgst)
+		img, err := oci.ParseImage(imageStr, oci.WithStrict(), oci.WithDigest(dgst))
 		require.NoError(t, err)
 		ociStore.AddImage(img)
 


### PR DESCRIPTION
Refactor parse image into a single function that takes an option to enforce strict digest checking.