### PR TITLE
chore: remove explicit GOMAXPROCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#1013](https://github.com/spegel-org/spegel/pull/1013) Refactor image parsing to include options.
+- [#1015](https://github.com/spegel-org/spegel/pull/1015) Remove explicit GOMAXPROCS
 
 ### Deprecated
 

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -115,13 +115,6 @@ spec:
         env:
         - name: DATA_DIR
           value: ""
-        {{- if ((.Values.resources).limits).cpu }}
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: 1
-        {{- end }}
         {{- if ((.Values.resources).limits).memory }}
         - name: GOMEMLIMIT
           valueFrom:


### PR DESCRIPTION
This is now done automatically in Go 1.25.

https://go.dev/blog/container-aware-gomaxprocs