### PR TITLE
feat: use prefer same node traffic distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1013](https://github.com/spegel-org/spegel/pull/1013) Refactor image parsing to include options.
 - [#1015](https://github.com/spegel-org/spegel/pull/1015) Remove explicit GOMAXPROCS
+- [#1017](https://github.com/spegel-org/spegel/pull/1017) Use prefer same node traffic distribution.
 
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -22,7 +22,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | image.repository | string | `"ghcr.io/spegel-org/spegel"` | Image repository. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image Pull Secrets |
-| livenessProbe.enabled | bool | `false` | When enabled a liveness probe will be added to the registry.  |
+| livenessProbe.enabled | bool | `false` | When enabled a liveness probe will be added to the registry. |
 | nameOverride | string | `""` | Overrides the name of the chart. |
 | namespaceOverride | string | `""` | Overrides the namespace where spegel resources are installed. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for pod assignment. |
@@ -43,6 +43,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | service.registry.nodePort | int | `30021` | Node port to expose the registry via the service. |
 | service.registry.port | int | `5000` | Port to expose the registry via the service. |
 | service.registry.topologyAwareHintsEnabled | bool | `true` | If true adds topology aware hints annotation to node port service. |
+| service.registry.usePreferSameNodeTrafficDistribution | bool | `false` | Use PreferSameNode traffic distribution on the node port service instead of using an additional mirror registry on a container host port. |
 | service.router.port | int | `5001` | Port to expose the router via the service. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -53,7 +53,9 @@ spec:
           {{- end }}
           {{- end }}
           - --mirror-targets
+          {{- if not .Values.service.registry.usePreferSameNodeTrafficDistribution }}
           - http://$(NODE_IP):{{ .Values.service.registry.hostPort }}
+          {{- end }}
           - http://$(NODE_IP):{{ .Values.service.registry.nodePort }}
           {{- with .Values.spegel.additionalMirrorTargets }}
           {{- range . }}
@@ -127,7 +129,9 @@ spec:
         ports:
           - name: registry
             containerPort: {{ .Values.service.registry.port }}
+            {{- if not .Values.service.registry.usePreferSameNodeTrafficDistribution }}
             hostPort: {{ .Values.service.registry.hostPort }}
+            {{- end }}
             protocol: TCP
           - name: router
             containerPort: {{ .Values.service.router.port }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -27,9 +27,9 @@ metadata:
   namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
-  {{- if or .Values.service.registry.topologyAwareHintsEnabled .Values.service.registry.annotations }}
+  {{- if or (and (not .Values.service.registry.usePreferSameNodeTrafficDistribution) .Values.service.registry.topologyAwareHintsEnabled) .Values.service.registry.annotations }}
   annotations:
-    {{- if .Values.service.registry.topologyAwareHintsEnabled }}
+    {{- if and (not .Values.service.registry.usePreferSameNodeTrafficDistribution) .Values.service.registry.topologyAwareHintsEnabled }}
     service.kubernetes.io/topology-mode: "auto"
     {{- end }}
     {{- with .Values.service.registry.annotations }}
@@ -47,6 +47,9 @@ spec:
       targetPort: registry
       nodePort: {{ .Values.service.registry.nodePort }}
       protocol: TCP
+  {{- if .Values.service.registry.usePreferSameNodeTrafficDistribution }}
+  trafficDistribution: PreferSameNode
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -35,7 +35,7 @@ podSecurityContext: {}
 revisionHistoryLimit: 10
 
 # -- Security context for the Spegel container.
-securityContext: 
+securityContext:
   readOnlyRootFilesystem: true
 
 service:
@@ -52,6 +52,10 @@ service:
     topologyAwareHintsEnabled: true
     # -- Annotations to add to the registry service
     annotations: {}
+    # -- Use PreferSameNode traffic distribution on the node port service
+    # instead of using an additional mirror registry on a container host port.
+    usePreferSameNodeTrafficDistribution: false
+
   router:
     # -- Port to expose the router via the service.
     port: 5001
@@ -207,5 +211,5 @@ verticalPodAutoscaler:
     updateMode: Auto
 
 livenessProbe:
-  # -- When enabled a liveness probe will be added to the registry. 
+  # -- When enabled a liveness probe will be added to the registry.
   enabled: false


### PR DESCRIPTION
Instead of using a host port, and specifying multiple mirrors, we can instead take advantage of the new PreferSameNode traffic distribution introduced in Kubernetes v1.34.

Fixes: #1016