### PR TITLE
Add optional default values when parting image reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1013](https://github.com/spegel-org/spegel/pull/1013) Refactor image parsing to include options.
 - [#1015](https://github.com/spegel-org/spegel/pull/1015) Remove explicit GOMAXPROCS
 - [#1017](https://github.com/spegel-org/spegel/pull/1017) Use prefer same node traffic distribution.
+- [#1018](https://github.com/spegel-org/spegel/pull/1018) Add optional default values when parting image reference.
 
 ### Deprecated
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -141,7 +141,7 @@ func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
 		rw.WriteError(http.StatusBadRequest, errors.New("image name cannot be empty"))
 		return
 	}
-	img, err := oci.ParseImage(imgName)
+	img, err := oci.ParseImage(imgName, oci.AllowDefaults(), oci.AllowTagOnly())
 	if err != nil {
 		rw.WriteError(http.StatusBadRequest, err)
 		return

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -350,7 +350,7 @@ dial_timeout = '200ms'`,
 		{
 			name:               "default is explicitly set",
 			resolveTags:        true,
-			mirroredRegistries: []string{defaultRegistry},
+			mirroredRegistries: []string{wildcardRegistryMirror},
 			mirrorTargets:      []string{"http://127.0.0.1:5000"},
 			prependExisting:    false,
 			expectedFiles: map[string]string{

--- a/pkg/oci/distribution.go
+++ b/pkg/oci/distribution.go
@@ -13,11 +13,13 @@ import (
 )
 
 var (
-	nameRegex           = regexp.MustCompile(`([a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*)`)
-	tagRegex            = regexp.MustCompile(`([a-zA-Z0-9_][a-zA-Z0-9._-]{0,127})`)
-	manifestRegexTag    = regexp.MustCompile(`/v2/` + nameRegex.String() + `/manifests/` + tagRegex.String() + `$`)
-	manifestRegexDigest = regexp.MustCompile(`/v2/` + nameRegex.String() + `/manifests/(.*)`)
-	blobsRegexDigest    = regexp.MustCompile(`/v2/` + nameRegex.String() + `/blobs/(.*)`)
+	nameRegexStr        = `([a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*)`
+	tagRegexStr         = `([a-zA-Z0-9_][a-zA-Z0-9._-]{0,127})`
+	nameRegex           = regexp.MustCompile(`^` + nameRegexStr + `$`)
+	tagRegex            = regexp.MustCompile(`^` + tagRegexStr + `$`)
+	manifestRegexTag    = regexp.MustCompile(`/v2/` + nameRegexStr + `/manifests/` + tagRegexStr + `$`)
+	manifestRegexDigest = regexp.MustCompile(`/v2/` + nameRegexStr + `/manifests/(.*)`)
+	blobsRegexDigest    = regexp.MustCompile(`/v2/` + nameRegexStr + `/blobs/(.*)`)
 )
 
 // DistributionKind represents the kind of content.

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -65,7 +65,7 @@ func TestStore(t *testing.T) {
 		_, err = imageStore.Create(ctx, cImg)
 		require.NoError(t, err)
 
-		img, err := ParseImage(k, WithStrict(), WithDigest(desc.Digest))
+		img, err := ParseImage(k, WithDigest(desc.Digest))
 		require.NoError(t, err)
 		memoryStore.AddImage(img)
 	}
@@ -275,7 +275,7 @@ func TestStore(t *testing.T) {
 				t.Run(tt.imageName, func(t *testing.T) {
 					t.Parallel()
 
-					img, err := ParseImage(tt.imageName, WithStrict(), WithDigest(digest.Digest(tt.imageDigest)))
+					img, err := ParseImage(tt.imageName, WithDigest(digest.Digest(tt.imageDigest)))
 					require.NoError(t, err)
 					dgsts, err := WalkImage(ctx, ociStore, img)
 					require.NoError(t, err)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -52,7 +52,7 @@ func TestTrack(t *testing.T) {
 		require.NoError(t, err)
 		dgst := digest.NewDigest(digest.SHA256, hash)
 		ociStore.Write(ocispec.Descriptor{Digest: dgst}, b)
-		img, err := oci.ParseImage(imageStr, oci.WithStrict(), oci.WithDigest(dgst))
+		img, err := oci.ParseImage(imageStr, oci.WithDigest(dgst))
 		require.NoError(t, err)
 		ociStore.AddImage(img)
 


### PR DESCRIPTION
This change enables parse image to allow references missing the registry and optional library namespace. Strict parsing is still the default and removing the requirement for digests and appending default values have to opted in. We want to encourage proper references, but there are situations where we cant control that the registry is not set.