### PR TITLE
Fix media type strings to use constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1019](https://github.com/spegel-org/spegel/pull/1019) Fix media type strings to use constants.
+
 ### Security
 
 ## v0.4.0

--- a/pkg/httpx/header.go
+++ b/pkg/httpx/header.go
@@ -16,8 +16,11 @@ const (
 )
 
 const (
+	ContentTypeText   = "text/plain"
+	ContentTypeHTML   = "text/html"
 	ContentTypeBinary = "application/octet-stream"
 	ContentTypeJSON   = "application/json"
+	ContentTypeXML    = "application/xml"
 )
 
 // CopyHeader copies header from source to destination.

--- a/pkg/httpx/range.go
+++ b/pkg/httpx/range.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const rangeUnit = "bytes"
+const RangeUnit = "bytes"
 
 type Range struct {
 	Start int64 `json:"start"`
@@ -15,7 +15,7 @@ type Range struct {
 }
 
 func (rng Range) String() string {
-	return fmt.Sprintf("%s=%d-%d", rangeUnit, rng.Start, rng.End)
+	return fmt.Sprintf("%s=%d-%d", RangeUnit, rng.Start, rng.End)
 }
 
 func (rng Range) Size() int64 {
@@ -26,7 +26,7 @@ func ParseRangeHeader(h string, size int64) (Range, error) {
 	if size <= 0 {
 		return Range{}, fmt.Errorf("size %d cannot be equal or less than zero", size)
 	}
-	rangeUnitPrefix := rangeUnit + "="
+	rangeUnitPrefix := RangeUnit + "="
 	if !strings.HasPrefix(h, rangeUnitPrefix) {
 		return Range{}, errors.New("invalid range unit")
 	}
@@ -100,5 +100,5 @@ func ContentRangeFromRange(rng Range, size int64) ContentRange {
 }
 
 func (crng ContentRange) String() string {
-	return fmt.Sprintf("%s %d-%d/%d", rangeUnit, crng.Start, crng.End, crng.Size)
+	return fmt.Sprintf("%s %d-%d/%d", RangeUnit, crng.Start, crng.End, crng.Size)
 }

--- a/pkg/httpx/status.go
+++ b/pkg/httpx/status.go
@@ -48,10 +48,10 @@ func getErrorMessage(resp *http.Response) (string, error) {
 		return "", nil
 	}
 	contentTypes := []string{
-		"text/plain",
-		"text/html",
-		"application/json",
-		"application/xml",
+		ContentTypeText,
+		ContentTypeHTML,
+		ContentTypeJSON,
+		ContentTypeXML,
 	}
 	if !slices.Contains(contentTypes, resp.Header.Get(HeaderContentType)) {
 		return "", nil

--- a/pkg/httpx/status_test.go
+++ b/pkg/httpx/status_test.go
@@ -24,7 +24,7 @@ func TestStatusError(t *testing.T) {
 	}{
 		{
 			name:          "status code matches one of expected",
-			contentType:   "text/plain",
+			contentType:   ContentTypeText,
 			body:          "Hello World",
 			statusCode:    http.StatusOK,
 			expectedCodes: []int{http.StatusNotFound, http.StatusOK},
@@ -33,14 +33,14 @@ func TestStatusError(t *testing.T) {
 		},
 		{
 			name:          "no expected status codes",
-			contentType:   "text/plain",
+			contentType:   ContentTypeText,
 			statusCode:    http.StatusOK,
 			expectedCodes: []int{},
 			expectedError: "expected codes cannot be empty",
 		},
 		{
 			name:          "wrong code with text content and GET request",
-			contentType:   "text/plain",
+			contentType:   ContentTypeText,
 			body:          "Hello World",
 			statusCode:    http.StatusNotFound,
 			expectedCodes: []int{http.StatusOK},
@@ -49,7 +49,7 @@ func TestStatusError(t *testing.T) {
 		},
 		{
 			name:          "wrong code with text content and HEAD request",
-			contentType:   "text/plain",
+			contentType:   ContentTypeText,
 			body:          "Hello World",
 			statusCode:    http.StatusNotFound,
 			expectedCodes: []int{http.StatusOK, http.StatusPartialContent},
@@ -58,7 +58,7 @@ func TestStatusError(t *testing.T) {
 		},
 		{
 			name:          "wrong code with text content and GET request but octet stream",
-			contentType:   "application/octet-stream",
+			contentType:   ContentTypeBinary,
 			body:          "Hello World",
 			statusCode:    http.StatusNotFound,
 			expectedCodes: []int{http.StatusOK},

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -234,10 +234,10 @@ func (c *Client) fetch(ctx context.Context, method string, dist DistributionPath
 		httpx.CopyHeader(req.Header, cfg.Header)
 		req.SetBasicAuth(cfg.Username, cfg.Password)
 		req.Header.Set(httpx.HeaderUserAgent, "spegel")
-		req.Header.Add(httpx.HeaderAccept, "application/vnd.oci.image.manifest.v1+json")
-		req.Header.Add(httpx.HeaderAccept, "application/vnd.docker.distribution.manifest.v2+json")
-		req.Header.Add(httpx.HeaderAccept, "application/vnd.oci.image.index.v1+json")
-		req.Header.Add(httpx.HeaderAccept, "application/vnd.docker.distribution.manifest.list.v2+json")
+		req.Header.Add(httpx.HeaderAccept, ocispec.MediaTypeImageManifest)
+		req.Header.Add(httpx.HeaderAccept, images.MediaTypeDockerSchema2Manifest)
+		req.Header.Add(httpx.HeaderAccept, ocispec.MediaTypeImageIndex)
+		req.Header.Add(httpx.HeaderAccept, images.MediaTypeDockerSchema2ManifestList)
 		if br != nil {
 			req.Header.Add(httpx.HeaderRange, br.String())
 		}

--- a/pkg/oci/client_test.go
+++ b/pkg/oci/client_test.go
@@ -27,12 +27,12 @@ func TestClient(t *testing.T) {
 	mem := ocimem.New()
 	blobs := []ocispec.Descriptor{
 		{
-			MediaType: "application/vnd.oci.image.config.v1+json",
+			MediaType: ocispec.MediaTypeImageConfig,
 			Digest:    digest.Digest("sha256:68b8a989a3e08ddbdb3a0077d35c0d0e59c9ecf23d0634584def8bdbb7d6824f"),
 			Size:      529,
 		},
 		{
-			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+			MediaType: ocispec.MediaTypeImageLayerGzip,
 			Digest:    digest.Digest("sha256:3caa2469de2a23cbcc209dd0b9d01cd78ff9a0f88741655991d36baede5b0996"),
 			Size:      118,
 		},
@@ -46,7 +46,7 @@ func TestClient(t *testing.T) {
 	}
 	manifests := []ocispec.Descriptor{
 		{
-			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			MediaType: ocispec.MediaTypeImageManifest,
 			Digest:    digest.Digest("sha256:b6d6089ca6c395fd563c2084f5dd7bc56a2f5e6a81413558c5be0083287a77e9"),
 		},
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -459,8 +459,8 @@ func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist 
 		return
 	}
 
-	rw.Header().Set(httpx.HeaderAcceptRanges, "bytes")
-	rw.Header().Set(httpx.HeaderContentType, "application/octet-stream")
+	rw.Header().Set(httpx.HeaderAcceptRanges, httpx.RangeUnit)
+	rw.Header().Set(httpx.HeaderContentType, httpx.ContentTypeBinary)
 	rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(size, 10))
 	rw.Header().Set(oci.HeaderDockerDigest, dist.Digest.String())
 	if req.Method == http.MethodHead {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -223,7 +223,7 @@ func TestRegistryHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedBody:   []byte("first peer"),
 			expectedHeaders: http.Header{
-				httpx.HeaderContentType:   {"application/octet-stream"},
+				httpx.HeaderContentType:   {httpx.ContentTypeBinary},
 				httpx.HeaderContentLength: {"10"},
 				oci.HeaderDockerDigest:    {"sha256:0b7e0ac6364af64af017531f137a95f3a5b12ea38be0e74a860004d3e5760a67"},
 			},
@@ -234,7 +234,7 @@ func TestRegistryHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedBody:   []byte("second peer"),
 			expectedHeaders: http.Header{
-				httpx.HeaderContentType:   {"application/octet-stream"},
+				httpx.HeaderContentType:   {httpx.ContentTypeBinary},
 				httpx.HeaderContentLength: {"11"},
 				oci.HeaderDockerDigest:    {"sha256:431491e49ba5fa61930417a46b24c03b6df0b426b90009405457741ac52f44b2"},
 			},
@@ -245,7 +245,7 @@ func TestRegistryHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedBody:   []byte("last peer working"),
 			expectedHeaders: http.Header{
-				httpx.HeaderContentType:   {"application/octet-stream"},
+				httpx.HeaderContentType:   {httpx.ContentTypeBinary},
 				httpx.HeaderContentLength: {"17"},
 				oci.HeaderDockerDigest:    {"sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba"},
 			},


### PR DESCRIPTION
This change just fixes a bunch of hard coded media type strings to use constants instead.