### PR TITLE
Don't filter ContentCreate events with no labels

### DIFF
--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -444,7 +444,7 @@ func (c *Containerd) convertEvent(ctx context.Context, envelope events.Envelope)
 		if err != nil {
 			return nil, err
 		}
-		if !filter.Match(content.AdaptInfo(info)) {
+		if len(info.Labels) != 0 && !filter.Match(content.AdaptInfo(info)) {
 			return nil, nil
 		}
 		return []OCIEvent{{Type: CreateEvent, Key: e.GetDigest()}}, nil


### PR DESCRIPTION
Fixes the issue with ContentCreate filtering preventing blobs from being advertised until the next tracker scan interval, as discussed at https://github.com/spegel-org/spegel/pull/1018#issuecomment-3321798056