### PR TITLE
Refactor and rename fingerprint media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1015](https://github.com/spegel-org/spegel/pull/1015) Remove explicit GOMAXPROCS
 - [#1017](https://github.com/spegel-org/spegel/pull/1017) Use prefer same node traffic distribution.
 - [#1018](https://github.com/spegel-org/spegel/pull/1018) Add optional default values when parting image reference.
+- [#1022](https://github.com/spegel-org/spegel/pull/1022) Refactor and rename fingerprint media type.
 
 ### Deprecated
 

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -378,7 +378,7 @@ func (c *Containerd) GetManifest(ctx context.Context, dgst digest.Digest) ([]byt
 	if err != nil {
 		return nil, "", err
 	}
-	mt, err := DetermineMediaType(b)
+	mt, err := FingerprintMediaType(bytes.NewReader(b))
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd/v2/client"
@@ -286,7 +287,7 @@ func TestStore(t *testing.T) {
 	}
 }
 
-func TestDetermineMediaType(t *testing.T) {
+func TestFingerprintMediaType(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -324,15 +325,16 @@ func TestDetermineMediaType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b, err := os.ReadFile(filepath.Join("testdata", "blobs", tt.dgst.Algorithm().String(), tt.dgst.Encoded()))
+			f, err := os.Open(filepath.Join("testdata", "blobs", tt.dgst.Algorithm().String(), tt.dgst.Encoded()))
 			require.NoError(t, err)
-			mt, err := DetermineMediaType(b)
+			defer f.Close()
+			mt, err := FingerprintMediaType(f)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedMediaType, mt)
 		})
 	}
 
-	mt, err := DetermineMediaType([]byte("{}"))
-	require.EqualError(t, err, "not able to determine media type")
+	mt, err := FingerprintMediaType(strings.NewReader("{}"))
+	require.EqualError(t, err, "could not determine media type")
 	require.Empty(t, mt)
 }


### PR DESCRIPTION
This change renames determine media type to fingerprint media type and also changes the implementation to be streaming based instead of requiring to read all the content.