### PR TITLE
Add unit tests for serving manifests through mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1018](https://github.com/spegel-org/spegel/pull/1018) Add optional default values when parting image reference.
 - [#1022](https://github.com/spegel-org/spegel/pull/1022) Refactor and rename fingerprint media type.
 - [#1024](https://github.com/spegel-org/spegel/pull/1024) Refactor OCI store to use descriptor.
+- [#1025](https://github.com/spegel-org/spegel/pull/1025) Add unit tests for serving manifests through mirror.
 
 ### Deprecated
 

--- a/pkg/httpx/error.go
+++ b/pkg/httpx/error.go
@@ -2,5 +2,25 @@ package httpx
 
 type ResponseError interface {
 	error
-	ResponseBody() ([]byte, error)
+	ResponseBody() ([]byte, string, error)
+}
+
+var _ ResponseError = &BasicResponseError{}
+
+type BasicResponseError struct {
+	Body string
+}
+
+func NewBasicResponseError(body string) *BasicResponseError {
+	return &BasicResponseError{
+		Body: body,
+	}
+}
+
+func (e *BasicResponseError) Error() string {
+	return e.Body
+}
+
+func (e *BasicResponseError) ResponseBody() ([]byte, string, error) {
+	return []byte(e.Body), ContentTypeText, nil
 }

--- a/pkg/oci/distribution.go
+++ b/pkg/oci/distribution.go
@@ -154,7 +154,7 @@ func (e *DistributionError) Error() string {
 	return fmt.Sprintf("%s %s", e.Code, e.Message)
 }
 
-func (e *DistributionError) ResponseBody() ([]byte, error) {
+func (e *DistributionError) ResponseBody() ([]byte, string, error) {
 	errResp := struct {
 		Errors []DistributionError `json:"errors"`
 	}{
@@ -162,7 +162,7 @@ func (e *DistributionError) ResponseBody() ([]byte, error) {
 	}
 	b, err := json.Marshal(errResp)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return b, nil
+	return b, httpx.ContentTypeJSON, nil
 }

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -70,7 +70,6 @@ type Store interface {
 // FingerprintMediaType attempts to determine the media type based on the json structure.
 func FingerprintMediaType(r io.Reader) (string, error) {
 	dec := json.NewDecoder(r)
-	dec.DisallowUnknownFields()
 	tok, err := dec.Token()
 	var syntaxErr *json.SyntaxError
 	if errors.As(err, &syntaxErr) {
@@ -167,6 +166,18 @@ func FingerprintMediaType(r io.Reader) (string, error) {
 		return ocispec.MediaTypeImageConfig, nil
 	}
 	return "", errors.New("could not determine media type")
+}
+
+func IsManifestsMediatype(mt string) bool {
+	switch mt {
+	case ocispec.MediaTypeImageIndex,
+		ocispec.MediaTypeImageManifest,
+		images.MediaTypeDockerSchema2ManifestList,
+		images.MediaTypeDockerSchema2Manifest:
+		return true
+	default:
+		return false
+	}
 }
 
 func WalkImage(ctx context.Context, store Store, img Image) ([]digest.Digest, error) {

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -328,3 +328,41 @@ func TestFingerprintMediaType(t *testing.T) {
 	require.EqualError(t, err, "could not determine media type")
 	require.Empty(t, mt)
 }
+
+func TestIsManifestMediatype(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mt       string
+		expected bool
+	}{
+		{
+			mt:       ocispec.MediaTypeImageIndex,
+			expected: true,
+		},
+		{
+			mt:       ocispec.MediaTypeImageManifest,
+			expected: true,
+		},
+		{
+			mt:       images.MediaTypeDockerSchema2ManifestList,
+			expected: true,
+		},
+		{
+			mt:       images.MediaTypeDockerSchema2Manifest,
+			expected: true,
+		},
+		{
+			mt:       "foo",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mt, func(t *testing.T) {
+			t.Parallel()
+
+			ok := IsManifestsMediatype(tt.mt)
+			require.Equal(t, tt.expected, ok)
+		})
+	}
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -175,6 +175,8 @@ func TestRegistryHandler(t *testing.T) {
 	require.NoError(t, err)
 	err = memStore.Write(ocispec.Descriptor{Digest: digest.Digest("sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba"), MediaType: "dummy"}, []byte("last peer working"))
 	require.NoError(t, err)
+	err = memStore.Write(ocispec.Descriptor{Digest: digest.Digest("sha256:ef3a5e9aba91d942f5f888b4e855e785395387aab0f122a6e49d0eaea215e98d"), MediaType: "application/vnd.oci.image.index.v1+json"}, []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`))
+	require.NoError(t, err)
 	goodReg, err := NewRegistry(memStore, routing.NewMemoryRouter(map[string][]netip.AddrPort{}, netip.AddrPort{}))
 	require.NoError(t, err)
 	goodSvr := httptest.NewServer(goodReg.Handler(logr.Discard()))
@@ -186,46 +188,59 @@ func TestRegistryHandler(t *testing.T) {
 	unreachableAddrPort := netip.MustParseAddrPort("127.0.0.1:0")
 
 	resolver := map[string][]netip.AddrPort{
-		// No working peers
+		// No working peers.
 		"sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6": {badAddrPort, unreachableAddrPort, badAddrPort},
-		// First peer
+		// First peer.
 		"sha256:0b7e0ac6364af64af017531f137a95f3a5b12ea38be0e74a860004d3e5760a67": {goodAddrPort, badAddrPort, badAddrPort},
-		// Second peer
+		// Second peer.
 		"sha256:431491e49ba5fa61930417a46b24c03b6df0b426b90009405457741ac52f44b2": {unreachableAddrPort, goodAddrPort},
-		// Last peer working
+		// Last peer working.
 		"sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba": {badAddrPort, badAddrPort, goodAddrPort},
+		// Valid manifest.
+		"sha256:ef3a5e9aba91d942f5f888b4e855e785395387aab0f122a6e49d0eaea215e98d": {goodAddrPort},
 	}
 	router := routing.NewMemoryRouter(resolver, netip.AddrPort{})
-	reg, err := NewRegistry(oci.NewMemory(), router)
+	reg, err := NewRegistry(oci.NewMemory(), router, WithRegistryFilters([]*regexp.Regexp{regexp.MustCompile(`:latest$`)}))
 	require.NoError(t, err)
 	handler := reg.Handler(logr.Discard())
 
+	//nolint: govet // Prioritize readability in tests.
 	tests := []struct {
-		expectedHeaders http.Header
-		name            string
-		key             string
-		expectedBody    []byte
-		expectedStatus  int
+		name             string
+		key              string
+		distributionKind oci.DistributionKind
+		expectedStatus   int
+		expectedHeaders  http.Header
+		expectedBody     []byte
 	}{
 		{
-			name:            "request should timeout when no peers exists",
-			key:             "sha256:03ffdf45276dd38ffac79b0e9c6c14d89d9113ad783d5922580f4c66a3305591",
-			expectedStatus:  http.StatusNotFound,
-			expectedBody:    []byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","detail":{"attempts":0},"message":"mirror with image component sha256:03ffdf45276dd38ffac79b0e9c6c14d89d9113ad783d5922580f4c66a3305591 could not be found"}]}`),
-			expectedHeaders: nil,
+			name:             "request should timeout when no peers exists",
+			key:              "sha256:03ffdf45276dd38ffac79b0e9c6c14d89d9113ad783d5922580f4c66a3305591",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusNotFound,
+			expectedBody:     []byte(`{"errors":[{"code":"BLOB_UNKNOWN","detail":{"attempts":0},"message":"mirror with image component sha256:03ffdf45276dd38ffac79b0e9c6c14d89d9113ad783d5922580f4c66a3305591 could not be found"}]}`),
+			expectedHeaders: http.Header{
+				httpx.HeaderContentType:   {httpx.ContentTypeJSON},
+				httpx.HeaderContentLength: {"191"},
+			},
 		},
 		{
-			name:            "request should not timeout and give 404 if all peers fail",
-			key:             "sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6",
-			expectedStatus:  http.StatusNotFound,
-			expectedBody:    []byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","detail":{"attempts":3},"message":"mirror with image component sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6 could not be found requests to 3 mirrors failed, all attempts have been exhausted or timeout has been reached"}]}`),
-			expectedHeaders: nil,
+			name:             "request should not timeout and give 404 if all peers fail",
+			key:              "sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusNotFound,
+			expectedBody:     []byte(`{"errors":[{"code":"BLOB_UNKNOWN","detail":{"attempts":3},"message":"mirror with image component sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6 could not be found requests to 3 mirrors failed, all attempts have been exhausted or timeout has been reached"}]}`),
+			expectedHeaders: http.Header{
+				httpx.HeaderContentType:   {httpx.ContentTypeJSON},
+				httpx.HeaderContentLength: {"282"},
+			},
 		},
 		{
-			name:           "request should work when first peer responds",
-			key:            "sha256:0b7e0ac6364af64af017531f137a95f3a5b12ea38be0e74a860004d3e5760a67",
-			expectedStatus: http.StatusOK,
-			expectedBody:   []byte("first peer"),
+			name:             "request should work when first peer responds",
+			key:              "sha256:0b7e0ac6364af64af017531f137a95f3a5b12ea38be0e74a860004d3e5760a67",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusOK,
+			expectedBody:     []byte("first peer"),
 			expectedHeaders: http.Header{
 				httpx.HeaderContentType:   {httpx.ContentTypeBinary},
 				httpx.HeaderContentLength: {"10"},
@@ -233,10 +248,11 @@ func TestRegistryHandler(t *testing.T) {
 			},
 		},
 		{
-			name:           "second peer should respond when first gives error",
-			key:            "sha256:431491e49ba5fa61930417a46b24c03b6df0b426b90009405457741ac52f44b2",
-			expectedStatus: http.StatusOK,
-			expectedBody:   []byte("second peer"),
+			name:             "second peer should respond when first gives error",
+			key:              "sha256:431491e49ba5fa61930417a46b24c03b6df0b426b90009405457741ac52f44b2",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusOK,
+			expectedBody:     []byte("second peer"),
 			expectedHeaders: http.Header{
 				httpx.HeaderContentType:   {httpx.ContentTypeBinary},
 				httpx.HeaderContentLength: {"11"},
@@ -244,14 +260,57 @@ func TestRegistryHandler(t *testing.T) {
 			},
 		},
 		{
-			name:           "last peer should respond when two first fail",
-			key:            "sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba",
-			expectedStatus: http.StatusOK,
-			expectedBody:   []byte("last peer working"),
+			name:             "last peer should respond when two first fail",
+			key:              "sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusOK,
+			expectedBody:     []byte("last peer working"),
 			expectedHeaders: http.Header{
 				httpx.HeaderContentType:   {httpx.ContentTypeBinary},
 				httpx.HeaderContentLength: {"17"},
 				oci.HeaderDockerDigest:    {"sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba"},
+			},
+		},
+		{
+			name:             "latest tag is supposed to be filtered",
+			key:              "latest",
+			distributionKind: oci.DistributionKindManifest,
+			expectedStatus:   http.StatusNotFound,
+			expectedBody:     []byte{},
+			expectedHeaders: http.Header{
+				httpx.HeaderContentLength: {"0"},
+			},
+		},
+		{
+			name:             "path is invalid and cant be parsed",
+			key:              "sha256:7d66cda2ba857d07e5530e53565b7d56b10ab80d16b6883fff8478327a49b4ba",
+			distributionKind: "invalid",
+			expectedStatus:   http.StatusNotFound,
+			expectedBody:     []byte{},
+			expectedHeaders: http.Header{
+				httpx.HeaderContentLength: {"0"},
+			},
+		},
+		{
+			name:             "manifest requested as blob should not be found",
+			key:              "sha256:ef3a5e9aba91d942f5f888b4e855e785395387aab0f122a6e49d0eaea215e98d",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusNotFound,
+			expectedBody:     []byte(`{"errors":[{"code":"BLOB_UNKNOWN","detail":{"attempts":1},"message":"mirror with image component sha256:ef3a5e9aba91d942f5f888b4e855e785395387aab0f122a6e49d0eaea215e98d could not be found requests to 1 mirrors failed, all attempts have been exhausted or timeout has been reached"}]}`),
+			expectedHeaders: http.Header{
+				httpx.HeaderContentType:   {httpx.ContentTypeJSON},
+				httpx.HeaderContentLength: {"282"},
+			},
+		},
+		{
+			name:             "existing manifest should be found",
+			key:              "sha256:ef3a5e9aba91d942f5f888b4e855e785395387aab0f122a6e49d0eaea215e98d",
+			distributionKind: oci.DistributionKindManifest,
+			expectedStatus:   http.StatusOK,
+			expectedBody:     []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`),
+			expectedHeaders: http.Header{
+				httpx.HeaderContentType:   {"application/vnd.oci.image.index.v1+json"},
+				httpx.HeaderContentLength: {"88"},
 			},
 		},
 	}
@@ -260,7 +319,7 @@ func TestRegistryHandler(t *testing.T) {
 			t.Run(fmt.Sprintf("%s-%s", method, tt.name), func(t *testing.T) {
 				t.Parallel()
 
-				target := fmt.Sprintf("http://example.com/v2/foo/bar/blobs/%s", tt.key)
+				target := fmt.Sprintf("http://example.com/v2/foo/bar/%s/%s?ns=docker.io", tt.distributionKind, tt.key)
 				rw := httptest.NewRecorder()
 				req := httptest.NewRequest(method, target, nil)
 				handler.ServeHTTP(rw, req)
@@ -289,5 +348,4 @@ func TestRegistryHandler(t *testing.T) {
 			})
 		}
 	}
-
 }


### PR DESCRIPTION
This expands the registry handler tests to include tests for manifests. It also adds a media type check to the content being served so that only manifests are served over the manifests endpoint. This is a stepping stone to fix range requests for blobs and verify that all endpoints respond with the expected status codes and headers.