### PR TITLE
Switch to using a generic functional options package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1022](https://github.com/spegel-org/spegel/pull/1022) Refactor and rename fingerprint media type.
 - [#1024](https://github.com/spegel-org/spegel/pull/1024) Refactor OCI store to use descriptor.
 - [#1025](https://github.com/spegel-org/spegel/pull/1025) Add unit tests for serving manifests through mirror.
+- [#1026](https://github.com/spegel-org/spegel/pull/1026) Switch to using a generic functional options package.
 
 ### Deprecated
 

--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -1,0 +1,16 @@
+package option
+
+type Option[T any] func(*T) error
+
+func Apply[T any](cfg *T, opts ...Option[T]) error {
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		err := opt(cfg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/option/option_test.go
+++ b/internal/option/option_test.go
@@ -1,0 +1,46 @@
+package option
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	t.Parallel()
+
+	type TestConfig struct {
+		Data string
+	}
+	type TestOption = Option[TestConfig]
+	withData := func(data string) TestOption {
+		return func(cfg *TestConfig) error {
+			cfg.Data = data
+			return nil
+		}
+	}
+	withError := func(err error) TestOption {
+		return func(cfg *TestConfig) error {
+			return err
+		}
+	}
+
+	cfg := TestConfig{}
+	err := Apply(&cfg)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Data)
+
+	err = Apply(&cfg, nil)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Data)
+
+	cfgErr := errors.New("hello world")
+	err = Apply(&cfg, withError(cfgErr))
+	require.Error(t, err)
+	require.Equal(t, cfgErr, err)
+
+	err = Apply(&cfg, withData("foo bar"))
+	require.NoError(t, err)
+	require.Equal(t, "foo bar", cfg.Data)
+}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/httpx"
 )
 
@@ -48,19 +49,7 @@ type FetchConfig struct {
 	Password string
 }
 
-func (cfg *FetchConfig) Apply(opts ...FetchOption) error {
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type FetchOption func(cfg *FetchConfig) error
+type FetchOption = option.Option[FetchConfig]
 
 func WithFetchMirror(mirror *url.URL) FetchOption {
 	return func(cfg *FetchConfig) error {
@@ -209,7 +198,7 @@ func (c *Client) Get(ctx context.Context, dist DistributionPath, br *httpx.Range
 
 func (c *Client) fetch(ctx context.Context, method string, dist DistributionPath, br *httpx.Range, opts ...FetchOption) (io.ReadCloser, ocispec.Descriptor, error) {
 	cfg := FetchConfig{}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return nil, ocispec.Descriptor{}, err
 	}

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -29,6 +29,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pelletier/go-toml/v2"
 	tomlu "github.com/pelletier/go-toml/v2/unstable"
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"google.golang.org/grpc"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
@@ -70,19 +71,7 @@ type ContainerdConfig struct {
 	ContentPath string
 }
 
-func (cfg *ContainerdConfig) Apply(opts ...ContainerdOption) error {
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type ContainerdOption func(*ContainerdConfig) error
+type ContainerdOption = option.Option[ContainerdConfig]
 
 func WithContentPath(path string) ContainerdOption {
 	return func(c *ContainerdConfig) error {
@@ -106,8 +95,8 @@ type Containerd struct {
 }
 
 func NewContainerd(sock, namespace, registryConfigPath string, mirroredRegistries []string, opts ...ContainerdOption) (*Containerd, error) {
-	cfg := &ContainerdConfig{}
-	err := cfg.Apply(opts...)
+	cfg := ContainerdConfig{}
+	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	digest "github.com/opencontainers/go-digest"
+	"github.com/spegel-org/spegel/internal/option"
 )
 
 const (
@@ -74,19 +75,7 @@ type ParseImageConfig struct {
 	Strict        bool
 }
 
-func (cfg *ParseImageConfig) Apply(opts ...ParseImageOption) error {
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type ParseImageOption func(cfg *ParseImageConfig) error
+type ParseImageOption = option.Option[ParseImageConfig]
 
 // WithDigest adds an additional digest outside of the parsed string.
 func WithDigest(dgst digest.Digest) ParseImageOption {
@@ -118,7 +107,7 @@ func ParseImage(s string, opts ...ParseImageOption) (Image, error) {
 		RequireDigest: true,
 		Strict:        true,
 	}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return Image{}, err
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/metrics"
 	"github.com/spegel-org/spegel/pkg/oci"
@@ -37,19 +38,7 @@ type RegistryConfig struct {
 	ResolveRetries   int
 }
 
-func (cfg *RegistryConfig) Apply(opts ...RegistryOption) error {
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type RegistryOption func(cfg *RegistryConfig) error
+type RegistryOption = option.Option[RegistryConfig]
 
 func WithResolveRetries(resolveRetries int) RegistryOption {
 	return func(cfg *RegistryConfig) error {
@@ -114,7 +103,7 @@ func NewRegistry(ociStore oci.Store, router routing.Router, opts ...RegistryOpti
 		ResolveLatestTag: true,
 		ResolveTimeout:   20 * time.Millisecond,
 	}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -15,6 +15,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
@@ -41,7 +42,7 @@ func TestRegistryOptions(t *testing.T) {
 		WithBasicAuth("foo", "bar"),
 	}
 	cfg := RegistryConfig{}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	require.NoError(t, err)
 	require.Equal(t, 5, cfg.ResolveRetries)
 	require.Equal(t, filters, cfg.Filters)

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -31,6 +31,7 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/metrics"
 )
 
@@ -41,19 +42,7 @@ type P2PRouterConfig struct {
 	Libp2pOpts []libp2p.Option
 }
 
-func (cfg *P2PRouterConfig) Apply(opts ...P2PRouterOption) error {
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type P2PRouterOption func(cfg *P2PRouterConfig) error
+type P2PRouterOption = option.Option[P2PRouterConfig]
 
 func WithLibP2POptions(opts ...libp2p.Option) P2PRouterOption {
 	return func(cfg *P2PRouterConfig) error {
@@ -81,7 +70,7 @@ type P2PRouter struct {
 
 func NewP2PRouter(ctx context.Context, addr string, bs Bootstrapper, registryPortStr string, opts ...P2PRouterOption) (*P2PRouter, error) {
 	cfg := P2PRouterConfig{}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -28,7 +29,7 @@ func TestP2PRouterOptions(t *testing.T) {
 		WithDataDir("foobar"),
 	}
 	cfg := P2PRouterConfig{}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	require.NoError(t, err)
 	require.Equal(t, libp2pOpts, cfg.Libp2pOpts)
 	require.Equal(t, "foobar", cfg.DataDir)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/spegel-org/spegel/internal/channel"
+	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/metrics"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
@@ -19,19 +20,7 @@ type TrackerConfig struct {
 	ResolveLatestTag bool
 }
 
-func (cfg *TrackerConfig) Apply(opts ...TrackerOption) error {
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		if err := opt(cfg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type TrackerOption func(t *TrackerConfig) error
+type TrackerOption = option.Option[TrackerConfig]
 
 // Deprecated: Resolve latest tag is replaced by registry filter which offers more customizable behavior. Use the filter `:latest$` to achieve the same behavior.
 func WithResolveLatestTag(resolveLatestTag bool) TrackerOption {
@@ -52,7 +41,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, opts 
 	cfg := TrackerConfig{
 		ResolveLatestTag: true,
 	}
-	err := cfg.Apply(opts...)
+	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change cleans up a lot of code using functional options pattern while also increasing the testing of the apply function which was duplicated everywhere.