### PR TITLE
Fix range request handling and add tests for range requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1019](https://github.com/spegel-org/spegel/pull/1019) Fix media type strings to use constants.
 - [#1027](https://github.com/spegel-org/spegel/pull/1027) Fix OCI client to take range requests for HEAD requests.
+- [#1029](https://github.com/spegel-org/spegel/pull/1029) Fix range request handling and add tests for range requests.
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-image: build
 	docker build -t ${IMG_REF} .
 
 test-unit:
-	go test ./...
+	go test ./... -race
 
 test-e2e: build-image
 	IMG_REF=${IMG_REF} \


### PR DESCRIPTION
This change fixes a lot of stupid problems implemented during my last refactor of the mirror to use the OCI client. There were a bunch of edge cases that were missed and then not caught due to the lack of unit tests. This change adds unit tests to define when the expected response headers and data should look like when conforming to the HTTP spec, and fixes these problems.

The majority of users will not experience these problems unless their client makes range requests, which is opt in for Containerd right now. Either way the addition of unit tests will protect against any future regression.