### PR TITLE
Fix panic in debug web view when metrics are not set yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1019](https://github.com/spegel-org/spegel/pull/1019) Fix media type strings to use constants.
 - [#1027](https://github.com/spegel-org/spegel/pull/1027) Fix OCI client to take range requests for HEAD requests.
 - [#1029](https://github.com/spegel-org/spegel/pull/1029) Fix range request handling and add tests for range requests.
+- [#1030](https://github.com/spegel-org/spegel/pull/1030) Fix panic in debug web view when metrics are not set yet.
 
 ### Security
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -91,11 +91,15 @@ func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 		ImageCount        int64
 		LayerCount        int64
 	}{}
-	for _, metric := range metricFamilies["spegel_advertised_images"].Metric {
-		data.ImageCount += int64(*metric.Gauge.Value)
+	if family, ok := metricFamilies["spegel_advertised_images"]; ok {
+		for _, metric := range family.Metric {
+			data.ImageCount += int64(*metric.Gauge.Value)
+		}
 	}
-	for _, metric := range metricFamilies["spegel_advertised_keys"].Metric {
-		data.LayerCount += int64(*metric.Gauge.Value)
+	if family, ok := metricFamilies["spegel_advertised_keys"]; ok {
+		for _, metric := range family.Metric {
+			data.LayerCount += int64(*metric.Gauge.Value)
+		}
 	}
 	mirrorLastSuccess := int64(*metricFamilies["spegel_mirror_last_success_timestamp_seconds"].Metric[0].Gauge.Value)
 	if mirrorLastSuccess > 0 {


### PR DESCRIPTION
Fix a panic in `internal/web.(*Web).statsHandler()` when metrics are not (yet?) present.

```
{"time":"xxx","level":"INFO","source":{"function":"github.com/spegel-org/spegel/pkg/httpx.(*ServeMux).Handle.func1.1","file":"/wd/spegel/pkg/httpx/mux.go","line":78},"msg":"","path":"/debug/web/stats","status":200,"method":"GET","latency":"9.334169ms","ip":"127.0.0.1"}
2025/10/01 17:04:40 http: panic serving 127.0.0.1:57489: runtime error: invalid memory address or nil pointer dereference
goroutine 504 [running]:
net/http.(*conn).serve.func1()
	/go/src/net/http/server.go:1943 +0x14b
panic({0x1e23d00?, 0x2f7e770?})
	/go/src/runtime/panic.go:783 +0x136
github.com/spegel-org/spegel/internal/web.(*Web).statsHandler(0xc0006bd080, {0x245f5c0, 0xc000822d20}, 0xc00037c3c0)
	/wd/spegel/internal/web/web.go:94 +0x63b
github.com/spegel-org/spegel/pkg/httpx.(*ServeMux).Handle.func1({0x244da30, 0xc00027b590}, 0xc00037c140)
	/wd/spegel/pkg/httpx/mux.go:86 +0x41b
net/http.HandlerFunc.ServeHTTP(0xc0006bd110, {0x244da30, 0xc00027b590}, 0xc00037c140)
	/go/src/net/http/server.go:2322 +0x33
github.com/spegel-org/spegel/pkg/httpx.(*ServeMux).ServeHTTP(0xc0006c20a0, {0x244da30, 0xc00027b590}, 0xc00037c140)
	/wd/spegel/pkg/httpx/mux.go:42 +0x498
net/http.(*ServeMux).ServeHTTP(0xc0006a6240, {0x244da30, 0xc00027b590}, 0xc00037c140)
	/go/src/net/http/server.go:2861 +0x3c2
net/http.serverHandler.ServeHTTP({0xc000683c00}, {0x244da30, 0xc00027b590}, 0xc00037c140)
	/go/src/net/http/server.go:3340 +0x257
net/http.(*conn).serve(0xc00071c5a0, {0x2451288, 0xc000822c80})
	/go/src/net/http/server.go:2109 +0x1ca5
created by net/http.(*Server).Serve in goroutine 165
	/go/src/net/http/server.go:3493 +0x9d0
```

Edit: this happened while debugging with my local containerd within an empty namespace. This should never happens in real life scenarios, and the panic is recovered.

Also fixed in #988. 