### PR TITLE
Pass registry address to debug web instead of using hard coded localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1027](https://github.com/spegel-org/spegel/pull/1027) Fix OCI client to take range requests for HEAD requests.
 - [#1029](https://github.com/spegel-org/spegel/pull/1029) Fix range request handling and add tests for range requests.
 - [#1030](https://github.com/spegel-org/spegel/pull/1030) Fix panic in debug web view when metrics are not set yet.
+- [#1032](https://github.com/spegel-org/spegel/pull/1032) Fix measuring pulls in debug web view with non default registry address configured.
 
 ### Security
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -25,13 +25,14 @@ import (
 var templatesFS embed.FS
 
 type Web struct {
-	router     routing.Router
-	ociClient  *oci.Client
-	httpClient *http.Client
-	tmpls      *template.Template
+	router          routing.Router
+	ociClient       *oci.Client
+	httpClient      *http.Client
+	tmpls           *template.Template
+	registryAddress string
 }
 
-func NewWeb(router routing.Router, ociClient *oci.Client) (*Web, error) {
+func NewWeb(router routing.Router, ociClient *oci.Client, registryAddr string) (*Web, error) {
 	funcs := template.FuncMap{
 		"formatBytes":    formatBytes,
 		"formatDuration": formatDuration,
@@ -41,10 +42,11 @@ func NewWeb(router routing.Router, ociClient *oci.Client) (*Web, error) {
 		return nil, err
 	}
 	return &Web{
-		router:     router,
-		ociClient:  ociClient,
-		httpClient: httpx.BaseClient(),
-		tmpls:      tmpls,
+		router:          router,
+		ociClient:       ociClient,
+		httpClient:      httpx.BaseClient(),
+		tmpls:           tmpls,
+		registryAddress: registryAddr,
 	}, nil
 }
 
@@ -136,7 +138,7 @@ type pullResult struct {
 func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
 	mirror := &url.URL{
 		Scheme: "http",
-		Host:   "localhost:5000",
+		Host:   w.registryAddress,
 	}
 
 	// Parse image name.

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -10,7 +10,7 @@ import (
 func TestWeb(t *testing.T) {
 	t.Parallel()
 
-	w, err := NewWeb(nil, nil)
+	w, err := NewWeb(nil, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, w.tmpls)
 }

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
 	if args.DebugWebEnabled {
-		web, err := web.NewWeb(router, oci.NewClient(nil))
+		web, err := web.NewWeb(router, oci.NewClient(nil), args.RegistryAddr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Debug UI use a hard-coded value (`localhost:5000`) for registry address instead of the one configured.
This PR use the value from configuration.

Also fixed in #988.