### PR TITLE
Refactor to use shared reference in image and distribution path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1025](https://github.com/spegel-org/spegel/pull/1025) Add unit tests for serving manifests through mirror.
 - [#1026](https://github.com/spegel-org/spegel/pull/1026) Switch to using a generic functional options package.
 - [#1031](https://github.com/spegel-org/spegel/pull/1031) Report errors on debug web view.
+- [#1034](https://github.com/spegel-org/spegel/pull/1034) Refactor to use shared reference in image and distribution path.
   
 ### Deprecated
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -158,7 +158,7 @@ func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
 
 	// Resolve peers for the given image.
 	resolveStart := time.Now()
-	peerCh, err := w.router.Resolve(req.Context(), img.Reference(), 0)
+	peerCh, err := w.router.Resolve(req.Context(), img.Identifier(), 0)
 	if err != nil {
 		rw.WriteError(http.StatusInternalServerError, NewHTMLResponseError(err))
 		return

--- a/pkg/oci/distribution_test.go
+++ b/pkg/oci/distribution_test.go
@@ -78,10 +78,10 @@ func TestParseDistributionPath(t *testing.T) {
 			}
 			dist, err := ParseDistributionPath(u)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedName, dist.Name)
+			require.Equal(t, tt.expectedName, dist.Repository)
 			require.Equal(t, tt.expectedDgst, dist.Digest)
 			require.Equal(t, tt.expectedTag, dist.Tag)
-			require.Equal(t, tt.expectedRef, dist.Reference())
+			require.Equal(t, tt.expectedRef, dist.Identifier())
 			require.Equal(t, tt.expectedKind, dist.Kind)
 			require.Equal(t, tt.registry, dist.Registry)
 			require.Equal(t, tt.path, dist.URL().Path)

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -165,7 +165,7 @@ func TestNewImageErrors(t *testing.T) {
 			repository:    "foo/bar",
 			tag:           "latest",
 			dgst:          digest.Digest("sha256:ec4306b243d98cce7c3b1f994f2dae660059ef521b2b24588cfdc950bd816d4c"),
-			expectedError: "image needs to contain a registry",
+			expectedError: "reference needs to contain a registry",
 		},
 		{
 			name:          "missing repository",
@@ -173,7 +173,7 @@ func TestNewImageErrors(t *testing.T) {
 			repository:    "",
 			tag:           "latest",
 			dgst:          digest.Digest("sha256:ec4306b243d98cce7c3b1f994f2dae660059ef521b2b24588cfdc950bd816d4c"),
-			expectedError: "image needs to contain a repository",
+			expectedError: "reference needs to contain a repository",
 		},
 		{
 			name:          "invalid digest",

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -105,11 +105,8 @@ func TestStore(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			noPlatformImg := Image{
-				Registry:   "example.com",
-				Repository: "org/no-platform",
-				Tag:        "test",
-			}
+			noPlatformImg, err := ParseImage("example.com/org/no-platform:test", AllowTagOnly())
+			require.NoError(t, err)
 			tagName, ok := noPlatformImg.TagName()
 			require.True(t, ok)
 			dgst, err := ociStore.Resolve(ctx, tagName)

--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -1,0 +1,48 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// Reference represents the lowest level of reference to OCI content.
+type Reference struct {
+	Registry   string
+	Repository string
+	Tag        string
+	Digest     digest.Digest
+}
+
+// Validate checks that the contents of the reference is valid.
+func (r Reference) Validate() error {
+	if r.Registry == "" {
+		return errors.New("reference needs to contain a registry")
+	}
+	if r.Repository == "" {
+		return errors.New("reference needs to contain a repository")
+	}
+	if r.Digest != "" {
+		if err := r.Digest.Validate(); err != nil {
+			return err
+		}
+	}
+	if r.Digest == "" && r.Tag == "" {
+		return errors.New("either tag or digest has to be set")
+	}
+	return nil
+}
+
+// Identifier returns the digest if set or alternatively if not the full image reference with the tag.
+func (r Reference) Identifier() string {
+	if r.Digest != "" {
+		return r.Digest.String()
+	}
+	return fmt.Sprintf("%s/%s:%s", r.Registry, r.Repository, r.Tag)
+}
+
+// IsLatestTag returns true if the tag has the value latest.
+func (r Reference) IsLatestTag() bool {
+	return r.Tag == "latest"
+}


### PR DESCRIPTION
This change merges the shared functionality of DistributionPath and Image into a single struct. This makes conversions simpler and also removes some duplicate code.