### PR TITLE
Implement single registry filter using reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1030](https://github.com/spegel-org/spegel/pull/1030) Fix panic in debug web view when metrics are not set yet.
 - [#1033](https://github.com/spegel-org/spegel/pull/1033) Fix measuring pulls using digests in debug web view.
 - [#1032](https://github.com/spegel-org/spegel/pull/1032) Fix measuring pulls in debug web view with non default registry address configured.
+- [#1035](https://github.com/spegel-org/spegel/pull/1035) Implement single registry filter using reference.
 
 ### Security
 

--- a/pkg/oci/filter.go
+++ b/pkg/oci/filter.go
@@ -1,0 +1,20 @@
+package oci
+
+import (
+	"regexp"
+)
+
+// MatchesFilter returns true if the reference matches any of the regexes.
+// The reference if converted to a string in the format of registry/repository[:tag].
+func MatchesFilter(ref Reference, filters []*regexp.Regexp) bool {
+	str := ref.Registry + "/" + ref.Repository
+	if ref.Tag != "" {
+		str += ":" + ref.Tag
+	}
+	for _, f := range filters {
+		if f.MatchString(str) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/oci/filter_test.go
+++ b/pkg/oci/filter_test.go
@@ -1,0 +1,55 @@
+package oci
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchesFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ref      Reference
+		filters  []*regexp.Regexp
+		expected bool
+	}{
+		{
+			name: "filters out docker.io",
+			ref: Reference{
+				Registry:   "docker.io",
+				Repository: "library/ubuntu",
+			},
+			filters:  []*regexp.Regexp{regexp.MustCompile("^docker.io")},
+			expected: true,
+		},
+		{
+			name: "does not filter out docker.io",
+			ref: Reference{
+				Registry:   "docker.io",
+				Repository: "library/ubuntu",
+			},
+			filters:  []*regexp.Regexp{regexp.MustCompile("^ghcr.io")},
+			expected: false,
+		},
+		{
+			name: "filters out latest tag",
+			ref: Reference{
+				Registry:   "docker.io",
+				Repository: "library/ubuntu",
+				Tag:        "latest",
+			},
+			filters:  []*regexp.Regexp{regexp.MustCompile(":latest$")},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, MatchesFilter(tt.ref, tt.filters))
+		})
+	}
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -202,12 +202,9 @@ func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {
 		rw.SetAttrs(RegistryAttrKey, dist.Registry)
 	}
 
-	// Apply registry filters to determine if the request should be mirrored.
-	for _, f := range r.filters {
-		if f.MatchString(dist.Identifier()) {
-			rw.WriteError(http.StatusNotFound, fmt.Errorf("request %s is filtered out by registry filters", dist.Identifier()))
-			return
-		}
+	if oci.MatchesFilter(dist.Reference, r.filters) {
+		rw.WriteError(http.StatusNotFound, fmt.Errorf("request %s is filtered out by registry filters", dist.String()))
+		return
 	}
 
 	// Request with mirror header are proxied.

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -100,15 +100,7 @@ func tick(ctx context.Context, ociStore oci.Store, router routing.Router, regist
 			continue
 		}
 
-		// Do not advertise images that match registry filter.
-		filtered := false
-		for _, f := range registryFilters {
-			if f.MatchString(img.String()) {
-				filtered = true
-				break
-			}
-		}
-		if filtered {
+		if oci.MatchesFilter(img.Reference, registryFilters) {
 			continue
 		}
 


### PR DESCRIPTION
This change standardizes the string format used for registry filtering. There were some issues when applying it to both DistributionPaths and Images. Having a single function that takes a Reference instead makes it  clear what the rules for the filtering all.