### PR TITLE
Remove is latest check in favor of registry filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#1036](https://github.com/spegel-org/spegel/pull/1036) Remove is latest check in favor of registry filter.
+
 ### Fixed
 
 - [#1019](https://github.com/spegel-org/spegel/pull/1019) Fix media type strings to use constants.

--- a/main.go
+++ b/main.go
@@ -191,7 +191,6 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	// Registry
 	registryOpts := []registry.RegistryOption{
 		registry.WithRegistryFilters(args.RegistryFilters),
-		registry.WithResolveRetries(args.MirrorResolveRetries),
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
 		registry.WithBasicAuth(username, password),
 	}

--- a/pkg/oci/distribution_test.go
+++ b/pkg/oci/distribution_test.go
@@ -13,59 +13,44 @@ func TestParseDistributionPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                string
-		registry            string
-		path                string
-		expectedName        string
-		expectedDgst        digest.Digest
-		expectedTag         string
-		expectedRef         string
-		expectedKind        DistributionKind
-		execptedIsLatestTag bool
+		name         string
+		registry     string
+		path         string
+		expectedName string
+		expectedDgst digest.Digest
+		expectedTag  string
+		expectedRef  string
+		expectedKind DistributionKind
 	}{
 		{
-			name:                "manifest tag",
-			registry:            "example.com",
-			path:                "/v2/foo/bar/manifests/hello-world",
-			expectedName:        "foo/bar",
-			expectedDgst:        "",
-			expectedTag:         "hello-world",
-			expectedRef:         "example.com/foo/bar:hello-world",
-			expectedKind:        DistributionKindManifest,
-			execptedIsLatestTag: false,
+			name:         "manifest tag",
+			registry:     "example.com",
+			path:         "/v2/foo/bar/manifests/hello-world",
+			expectedName: "foo/bar",
+			expectedDgst: "",
+			expectedTag:  "hello-world",
+			expectedRef:  "example.com/foo/bar:hello-world",
+			expectedKind: DistributionKindManifest,
 		},
 		{
-			name:                "manifest with latest tag",
-			registry:            "example.com",
-			path:                "/v2/test/manifests/latest",
-			expectedName:        "test",
-			expectedDgst:        "",
-			expectedTag:         "latest",
-			expectedRef:         "example.com/test:latest",
-			expectedKind:        DistributionKindManifest,
-			execptedIsLatestTag: true,
+			name:         "manifest digest",
+			registry:     "docker.io",
+			path:         "/v2/library/nginx/manifests/sha256:0a404ca8e119d061cdb2dceee824c914cdc69b31bc7b5956ef5a520436a80d39",
+			expectedName: "library/nginx",
+			expectedDgst: digest.Digest("sha256:0a404ca8e119d061cdb2dceee824c914cdc69b31bc7b5956ef5a520436a80d39"),
+			expectedTag:  "",
+			expectedRef:  "sha256:0a404ca8e119d061cdb2dceee824c914cdc69b31bc7b5956ef5a520436a80d39",
+			expectedKind: DistributionKindManifest,
 		},
 		{
-			name:                "manifest digest",
-			registry:            "docker.io",
-			path:                "/v2/library/nginx/manifests/sha256:0a404ca8e119d061cdb2dceee824c914cdc69b31bc7b5956ef5a520436a80d39",
-			expectedName:        "library/nginx",
-			expectedDgst:        digest.Digest("sha256:0a404ca8e119d061cdb2dceee824c914cdc69b31bc7b5956ef5a520436a80d39"),
-			expectedTag:         "",
-			expectedRef:         "sha256:0a404ca8e119d061cdb2dceee824c914cdc69b31bc7b5956ef5a520436a80d39",
-			expectedKind:        DistributionKindManifest,
-			execptedIsLatestTag: false,
-		},
-		{
-			name:                "blob digest",
-			registry:            "docker.io",
-			path:                "/v2/library/nginx/blobs/sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369",
-			expectedName:        "library/nginx",
-			expectedDgst:        digest.Digest("sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369"),
-			expectedTag:         "",
-			expectedRef:         "sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369",
-			expectedKind:        DistributionKindBlob,
-			execptedIsLatestTag: false,
+			name:         "blob digest",
+			registry:     "docker.io",
+			path:         "/v2/library/nginx/blobs/sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369",
+			expectedName: "library/nginx",
+			expectedDgst: digest.Digest("sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369"),
+			expectedTag:  "",
+			expectedRef:  "sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369",
+			expectedKind: DistributionKindBlob,
 		},
 	}
 	for _, tt := range tests {
@@ -86,7 +71,6 @@ func TestParseDistributionPath(t *testing.T) {
 			require.Equal(t, tt.registry, dist.Registry)
 			require.Equal(t, tt.path, dist.URL().Path)
 			require.Equal(t, tt.registry, dist.URL().Query().Get("ns"))
-			require.Equal(t, tt.execptedIsLatestTag, dist.IsLatestTag())
 		})
 	}
 }

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -18,19 +18,8 @@ func TestParseImageStrict(t *testing.T) {
 		expectedTag        string
 		expectedString     string
 		expectedDigest     digest.Digest
-		expectedIsLatest   bool
 		digestInImage      bool
 	}{
-		{
-			name:               "Latest tag",
-			image:              "library/ubuntu:latest",
-			digestInImage:      false,
-			expectedRepository: "library/ubuntu",
-			expectedTag:        "latest",
-			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
-			expectedIsLatest:   true,
-			expectedString:     "library/ubuntu:latest@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
-		},
 		{
 			name:               "Only tag",
 			image:              "library/alpine:3.18.0",
@@ -38,7 +27,6 @@ func TestParseImageStrict(t *testing.T) {
 			expectedRepository: "library/alpine",
 			expectedTag:        "3.18.0",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
-			expectedIsLatest:   false,
 			expectedString:     "library/alpine:3.18.0@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
 		},
 		{
@@ -48,7 +36,6 @@ func TestParseImageStrict(t *testing.T) {
 			expectedRepository: "jetstack/cert-manager-controller",
 			expectedTag:        "3.18.0",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
-			expectedIsLatest:   false,
 			expectedString:     "jetstack/cert-manager-controller:3.18.0@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
 		},
 		{
@@ -58,7 +45,6 @@ func TestParseImageStrict(t *testing.T) {
 			expectedRepository: "fluxcd/helm-controller",
 			expectedTag:        "",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
-			expectedIsLatest:   false,
 			expectedString:     "fluxcd/helm-controller@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
 		},
 		{
@@ -67,7 +53,6 @@ func TestParseImageStrict(t *testing.T) {
 			digestInImage:      false,
 			expectedRepository: "foo/bar",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
-			expectedIsLatest:   false,
 			expectedString:     "foo/bar@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
 		},
 	}
@@ -88,7 +73,6 @@ func TestParseImageStrict(t *testing.T) {
 					require.Equal(t, tt.expectedRepository, img.Repository)
 					require.Equal(t, tt.expectedTag, img.Tag)
 					require.Equal(t, tt.expectedDigest, img.Digest)
-					require.Equal(t, tt.expectedIsLatest, img.IsLatestTag())
 					tagName, ok := img.TagName()
 					if tt.expectedTag == "" {
 						require.False(t, ok)

--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -41,8 +41,3 @@ func (r Reference) Identifier() string {
 	}
 	return fmt.Sprintf("%s/%s:%s", r.Registry, r.Repository, r.Tag)
 }
-
-// IsLatestTag returns true if the tag has the value latest.
-func (r Reference) IsLatestTag() bool {
-	return r.Tag == "latest"
-}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -25,18 +25,14 @@ func TestRegistryOptions(t *testing.T) {
 	t.Parallel()
 
 	transport := &http.Transport{}
-	filterStrings := []string{"^docker\\.io/", "^gcr\\.io/"}
-	// Compile regex patterns
-	var filters []*regexp.Regexp
-	for _, pattern := range filterStrings {
-		if compiled, err := regexp.Compile(pattern); err == nil {
-			filters = append(filters, compiled)
-		}
+	filters := []*regexp.Regexp{
+		regexp.MustCompile(`^docker.io/`),
+		regexp.MustCompile(`^gcr.io/`),
 	}
+
 	opts := []RegistryOption{
 		WithResolveRetries(5),
 		WithRegistryFilters(filters),
-		WithResolveLatestTag(true),
 		WithResolveTimeout(10 * time.Minute),
 		WithTransport(transport),
 		WithBasicAuth("foo", "bar"),
@@ -46,7 +42,6 @@ func TestRegistryOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 5, cfg.ResolveRetries)
 	require.Equal(t, filters, cfg.Filters)
-	require.True(t, cfg.ResolveLatestTag)
 	require.Equal(t, 10*time.Minute, cfg.ResolveTimeout)
 	require.Equal(t, transport, cfg.Transport)
 	require.Equal(t, "foo", cfg.Username)


### PR DESCRIPTION
This change removes the is latest check from both the state and registry. It leaves the flag which will instead add a filter. The flag will also be removed after the next release.