### PR TITLE
Change to returning balancer from router lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1026](https://github.com/spegel-org/spegel/pull/1026) Switch to using a generic functional options package.
 - [#1031](https://github.com/spegel-org/spegel/pull/1031) Report errors on debug web view.
 - [#1034](https://github.com/spegel-org/spegel/pull/1034) Refactor to use shared reference in image and distribution path.
+- [#1037](https://github.com/spegel-org/spegel/pull/1037) Change to returning balancer from router lookups.
   
 ### Deprecated
 

--- a/internal/web/templates/measure.html
+++ b/internal/web/templates/measure.html
@@ -1,5 +1,5 @@
-{{ if .PeerResults }}
-<h3>Resolved Peers</h3>
+{{ if .LookupResults }}
+<h3>Lookup Result</h3>
 <div style="margin-bottom: 10px;">
   <strong>Duration:</strong> {{ .PeerDuration | formatDuration }}
 </div>
@@ -10,7 +10,7 @@
       <th style="width: 50%;">Duration</th>
     </tr>
 
-    {{ range .PeerResults }}
+    {{ range .LookupResults }}
     <tr>
       <td>{{ .Peer.Addr }}</td>
       <td>{{ .Duration | formatDuration }}</td>
@@ -19,7 +19,7 @@
   </table>
 </div>
 
-<h3>Result</h3>
+<h3>Pull Result</h3>
 <div style="margin-bottom: 10px;">
   <strong>Duration:</strong> {{ .PullDuration | formatDuration }}
   <strong>Size:</strong> {{ .PullSize | formatBytes }}

--- a/pkg/routing/balancer.go
+++ b/pkg/routing/balancer.go
@@ -1,0 +1,130 @@
+package routing
+
+import (
+	"errors"
+	"net/netip"
+	"slices"
+	"sync"
+)
+
+var ErrNoNext = errors.New("no peers available for selection")
+
+// Balancer defines how peers looked up are returned.
+type Balancer interface {
+	// Next returns the next peer.
+	Next() (netip.AddrPort, error)
+	// Add adds a peer to the balancer.
+	Add(netip.AddrPort)
+	// Remove removes the peer from the balancer.
+	Remove(netip.AddrPort)
+}
+
+var _ Balancer = &RoundRobin{}
+
+type RoundRobin struct {
+	peers   []netip.AddrPort
+	nextIdx int
+	peerMx  sync.Mutex
+}
+
+func NewRoundRobin() *RoundRobin {
+	return &RoundRobin{}
+}
+
+func (rr *RoundRobin) Size() int {
+	return len(rr.peers)
+}
+
+func (rr *RoundRobin) Add(item netip.AddrPort) {
+	rr.peerMx.Lock()
+	defer rr.peerMx.Unlock()
+
+	if slices.Contains(rr.peers, item) {
+		return
+	}
+	rr.peers = append(rr.peers, item)
+}
+
+func (rr *RoundRobin) Remove(item netip.AddrPort) {
+	rr.peerMx.Lock()
+	defer rr.peerMx.Unlock()
+
+	for i, v := range rr.peers {
+		if v == item {
+			rr.peers = append(rr.peers[:i], rr.peers[i+1:]...)
+			if rr.nextIdx > i {
+				rr.nextIdx--
+			} else if rr.nextIdx >= len(rr.peers) {
+				rr.nextIdx = 0
+			}
+			return
+		}
+	}
+}
+
+func (rr *RoundRobin) Next() (netip.AddrPort, error) {
+	rr.peerMx.Lock()
+	defer rr.peerMx.Unlock()
+
+	if len(rr.peers) == 0 {
+		return netip.AddrPort{}, ErrNoNext
+	}
+	item := rr.peers[rr.nextIdx]
+	rr.nextIdx = (rr.nextIdx + 1) % len(rr.peers)
+	return item, nil
+}
+
+var _ Balancer = &ClosableBalancer{}
+
+type ClosableBalancer struct {
+	Balancer
+	closed    chan any
+	waiters   []chan any
+	waitersMx sync.Mutex
+}
+
+func NewClosableBalancer(balancer Balancer) *ClosableBalancer {
+	return &ClosableBalancer{
+		Balancer: balancer,
+		closed:   make(chan any),
+	}
+}
+
+func (cb *ClosableBalancer) Add(item netip.AddrPort) {
+	cb.Balancer.Add(item)
+
+	cb.waitersMx.Lock()
+	for _, ch := range cb.waiters {
+		close(ch)
+	}
+	cb.waiters = nil
+	cb.waitersMx.Unlock()
+}
+
+func (cb *ClosableBalancer) Next() (netip.AddrPort, error) {
+	for {
+		cb.waitersMx.Lock()
+		peer, err := cb.Balancer.Next()
+		if errors.Is(err, ErrNoNext) {
+			ch := make(chan any)
+			cb.waiters = append(cb.waiters, ch)
+			cb.waitersMx.Unlock()
+
+			select {
+			case <-cb.closed:
+				return netip.AddrPort{}, ErrNoNext
+			case <-ch:
+				continue
+			}
+		}
+		cb.waitersMx.Unlock()
+		if err != nil {
+			return netip.AddrPort{}, err
+		}
+		return peer, nil
+	}
+}
+
+func (cb *ClosableBalancer) Close() {
+	close(cb.closed)
+}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -2,15 +2,14 @@ package routing
 
 import (
 	"context"
-	"net/netip"
 )
 
 // Router implements the discovery of content.
 type Router interface {
 	// Ready returns true when the router is ready.
 	Ready(ctx context.Context) (bool, error)
-	// Resolve asynchronously discovers addresses that can serve the content defined by the give key.
-	Resolve(ctx context.Context, key string, count int) (<-chan netip.AddrPort, error)
+	// Lookup discovers peers with the given key and returns a balancer with the peers.
+	Lookup(ctx context.Context, key string, count int) (Balancer, error)
 	// Advertise broadcasts that the current router can serve the content.
 	Advertise(ctx context.Context, keys []string) error
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -104,7 +104,7 @@ func TestTrack(t *testing.T) {
 
 			// Check that all images are advertised by digest (this should always happen)
 			for _, img := range imgs {
-				peers, ok := router.Lookup(img.Digest.String())
+				peers, ok := router.Get(img.Digest.String())
 				require.True(t, ok, "Image digest %s should be advertised", img.Digest.String())
 				require.Len(t, peers, 1)
 			}
@@ -115,7 +115,7 @@ func TestTrack(t *testing.T) {
 				if !ok {
 					continue
 				}
-				peers, ok := router.Lookup(tagName)
+				peers, ok := router.Get(tagName)
 				shouldBeAdvertised := slices.Contains(tt.expectedImages, tagName)
 				if shouldBeAdvertised {
 					require.True(t, ok, "Image %s should be advertised", tagName)


### PR DESCRIPTION
This change renames resolve to lookup and refactors the implementation to return a balancer instead of a channel. This expands the functionality that can be implemented while also enabling caching when the same query is run in bursts.