### PR TITLE
Add caching for balancers to reduce duplicate queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1031](https://github.com/spegel-org/spegel/pull/1031) Report errors on debug web view.
 - [#1034](https://github.com/spegel-org/spegel/pull/1034) Refactor to use shared reference in image and distribution path.
 - [#1037](https://github.com/spegel-org/spegel/pull/1037) Change to returning balancer from router lookups.
+- [#1039](https://github.com/spegel-org/spegel/pull/1039) Add caching for balancers to reduce duplicate queries.
   
 ### Deprecated
 

--- a/pkg/routing/balancer_test.go
+++ b/pkg/routing/balancer_test.go
@@ -1,0 +1,13 @@
+package routing
+
+import "testing"
+
+func TestClosableBalancer(t *testing.T) {
+	t.Parallel()
+
+	// Test that we can call close multiple times.
+	cb := NewClosableBalancer(NewRoundRobin())
+	for range 3 {
+		cb.Close()
+	}
+}


### PR DESCRIPTION
This change enables reuse of balancers so that multiple queries for the same key returns the same balancer. It also adds a TTL cache to enable more reuse to avoid running update queries if the single flight is missed.

This feature is mostly needed when used in combination with multipart fetching enabled in Containerd. This will trigger multiple requests for the same digests, for different ranges. In this scenario we do not want to run the same query multiple times. Adding a TTL cache means that the peers can be reused.