### PR TITLE
Fix distribution regex to support consecutive dashes and underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1033](https://github.com/spegel-org/spegel/pull/1033) Fix measuring pulls using digests in debug web view.
 - [#1032](https://github.com/spegel-org/spegel/pull/1032) Fix measuring pulls in debug web view with non default registry address configured.
 - [#1035](https://github.com/spegel-org/spegel/pull/1035) Implement single registry filter using reference.
+- [#1040](https://github.com/spegel-org/spegel/pull/1040) Fix distribution regex to support consecutive dashes and underscores.
 
 ### Security
 

--- a/pkg/oci/distribution_test.go
+++ b/pkg/oci/distribution_test.go
@@ -52,6 +52,26 @@ func TestParseDistributionPath(t *testing.T) {
 			expectedRef:  "sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369",
 			expectedKind: DistributionKindBlob,
 		},
+		{
+			name:         "manifest with consecutive dashes",
+			registry:     "example.com",
+			path:         "/v2/hello-static-empty--0ix3q/manifests/latest",
+			expectedName: "hello-static-empty--0ix3q",
+			expectedDgst: "",
+			expectedTag:  "latest",
+			expectedRef:  "example.com/hello-static-empty--0ix3q:latest",
+			expectedKind: DistributionKindManifest,
+		},
+		{
+			name:         "manifest with consecutive dashes and underscores",
+			registry:     "example.com",
+			path:         "/v2/test/foo__bar------test_baz/manifests/latest",
+			expectedName: "test/foo__bar------test_baz",
+			expectedDgst: "",
+			expectedTag:  "latest",
+			expectedRef:  "example.com/test/foo__bar------test_baz:latest",
+			expectedKind: DistributionKindManifest,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -120,6 +140,13 @@ func TestParseDistributionPathErrors(t *testing.T) {
 				Path: "/v2/spegel-org/spegel/manifests/sha253:foobar",
 			},
 			expectedError: "unsupported digest algorithm",
+		},
+		{
+			name: "manifest with more than two underscores",
+			url: &url.URL{
+				Path: "/v2/foo___bar/manifests/dev",
+			},
+			expectedError: "distribution path could not be parsed",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -182,7 +182,7 @@ func parseImage(s string) (string, string, string, digest.Digest, error) {
 	comps[len(comps)-1] = last
 
 	repository := strings.Join(comps, "/")
-	if !nameRegex.MatchString(repository) {
+	if !repoRegex.MatchString(repository) {
 		return "", "", "", "", fmt.Errorf("repository %s is invalid", repository)
 	}
 


### PR DESCRIPTION
There have been some changes in the allowed patterns for repository names in the distribution path. This change adds tests for paths with multiple dashses and underscores and updates the regex to support them. To make future updates easier and to clean things up I also updated some groups to be non capturing as we dont need the values from the captured pattern.

Fixes #1038