### PR TITLE
Remove unused routing discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - [#1036](https://github.com/spegel-org/spegel/pull/1036) Remove is latest check in favor of registry filter.
+- [#1044](https://github.com/spegel-org/spegel/pull/1044) Remove unused routing discovery.
 
 ### Fixed
 


### PR DESCRIPTION
The routing discovery features were never really used, as we would call the DHT functions anyways. I am not sure why it was included in the p2p router in the first place. This change removes it as it was never used and could cause confusion in the future.