### PR TITLE
Refactor mirrored registries to be applied with registry filters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,6 @@ linters:
     - govet
     - importas
     - ineffassign
-    - ireturn
     - misspell
     - nolintlint
     - paralleltest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1037](https://github.com/spegel-org/spegel/pull/1037) Change to returning balancer from router lookups.
 - [#1039](https://github.com/spegel-org/spegel/pull/1039) Add caching for balancers to reduce duplicate queries.
 - [#1049](https://github.com/spegel-org/spegel/pull/1049) Refactor filters to support more than only regex.
+- [#1047](https://github.com/spegel-org/spegel/pull/1047) Refactor mirrored registries to be applied with registry filters.
   
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -139,7 +139,15 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	if err != nil {
 		return err
 	}
+
 	filters := []oci.Filter{}
+	regFilter, err := oci.FilterForMirroredRegistries(args.MirroredRegistries)
+	if err != nil {
+		return err
+	}
+	if regFilter != nil {
+		filters = append(filters, *regFilter)
+	}
 	for _, r := range args.RegistryFilters {
 		filters = append(filters, oci.RegexFilter{Regex: r})
 	}
@@ -154,7 +162,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	}
 
 	// OCI Store
-	ociStore, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, args.MirroredRegistries, oci.WithContentPath(args.ContainerdContentPath))
+	ociStore, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, oci.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"slices"
 	"strings"
 	"text/template"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/events"
-	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
@@ -39,10 +37,6 @@ import (
 
 const (
 	backupDir = "_backup"
-)
-
-var (
-	wildcardRegistryMirrors = []string{"_default", "*"}
 )
 
 type Feature uint32
@@ -87,29 +81,20 @@ func WithContentPath(path string) ContainerdOption {
 var _ Store = &Containerd{}
 
 type Containerd struct {
-	contentPath        string
-	registryConfigPath string
 	client             *client.Client
 	clientGetter       func() (*client.Client, error)
 	mtCache            *lru.Cache[digest.Digest, string]
 	features           *Feature
-	imageFilter        []string
-	eventFilter        []string
-	contentFilter      []string
+	contentPath        string
+	registryConfigPath string
 }
 
-func NewContainerd(sock, namespace, registryConfigPath string, mirroredRegistries []string, opts ...ContainerdOption) (*Containerd, error) {
+func NewContainerd(sock, namespace, registryConfigPath string, opts ...ContainerdOption) (*Containerd, error) {
 	cfg := ContainerdConfig{}
 	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return nil, err
 	}
-
-	parsedMirroredRegistries, err := parseMirroredRegistries(mirroredRegistries)
-	if err != nil {
-		return nil, err
-	}
-	imageFilter, eventFilter, contentFilter := createFilters(parsedMirroredRegistries)
 
 	mtCache, err := lru.New[digest.Digest, string](100)
 	if err != nil {
@@ -121,9 +106,6 @@ func NewContainerd(sock, namespace, registryConfigPath string, mirroredRegistrie
 		clientGetter: func() (*client.Client, error) {
 			return client.New(sock, client.WithDefaultNamespace(namespace))
 		},
-		imageFilter:        imageFilter,
-		eventFilter:        eventFilter,
-		contentFilter:      contentFilter,
 		registryConfigPath: registryConfigPath,
 		mtCache:            mtCache,
 	}
@@ -271,7 +253,8 @@ func (c *Containerd) Subscribe(ctx context.Context) (<-chan OCIEvent, error) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	eventCh := make(chan OCIEvent)
-	envelopeCh, cErrCh := client.EventService().Subscribe(ctx, c.eventFilter...)
+	eventFilters := []string{`topic~="/images/create|/images/delete",event.name~="^.+/"`, `topic~="/content/create"`}
+	envelopeCh, cErrCh := client.EventService().Subscribe(ctx, eventFilters...)
 	go func() {
 		defer close(eventCh)
 		for {
@@ -305,7 +288,9 @@ func (c *Containerd) ListImages(ctx context.Context) ([]Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	cImgs, err := client.ListImages(ctx, c.imageFilter...)
+	// Filter out image names that are just sha sums.
+	imageFilter := `name~="^.+/"`
+	cImgs, err := client.ListImages(ctx, imageFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +319,7 @@ func (c *Containerd) ListContent(ctx context.Context) ([][]Reference, error) {
 		}
 		contents = append(contents, refs)
 		return nil
-	}, c.contentFilter...)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -430,11 +415,6 @@ func (c *Containerd) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekC
 }
 
 func (c *Containerd) convertEvent(ctx context.Context, envelope events.Envelope) ([]OCIEvent, error) {
-	client, err := c.Client()
-	if err != nil {
-		return nil, err
-	}
-
 	if envelope.Event == nil {
 		return nil, errors.New("envelope event cannot be nil")
 	}
@@ -444,21 +424,6 @@ func (c *Containerd) convertEvent(ctx context.Context, envelope events.Envelope)
 	}
 	switch e := evt.(type) {
 	case *eventtypes.ContentCreate:
-		filter, err := filters.ParseAll(c.contentFilter...)
-		if err != nil {
-			return nil, err
-		}
-		dgst, err := digest.Parse(e.GetDigest())
-		if err != nil {
-			return nil, err
-		}
-		info, err := client.ContentStore().Info(ctx, dgst)
-		if err != nil {
-			return nil, err
-		}
-		if !filter.Match(content.AdaptInfo(info)) {
-			return nil, nil
-		}
 		return []OCIEvent{{Type: CreateEvent, Key: e.GetDigest()}}, nil
 	case *eventtypes.ImageCreate:
 		img, err := ParseImage(e.GetName(), AllowTagOnly())
@@ -512,25 +477,6 @@ func contentLabelsToReferences(l map[string]string, dgst digest.Digest) ([]Refer
 	return refs, nil
 }
 
-func createFilters(parsedMirroredRegistries []url.URL) ([]string, []string, []string) {
-	registryHosts := []string{}
-	for _, registry := range parsedMirroredRegistries {
-		registryHosts = append(registryHosts, strings.ReplaceAll(registry.Host, `.`, `\\.`))
-	}
-	imageFilter := fmt.Sprintf(`name~="^(%s)/"`, strings.Join(registryHosts, "|"))
-	if len(registryHosts) == 0 {
-		// Filter images that do not have a registry in it's reference,
-		// as we cant mirror images without registries.
-		imageFilter = `name~="^.+/"`
-	}
-	eventFilter := fmt.Sprintf(`topic~="/images/create|/images/delete",event.%s`, imageFilter)
-	contentFilters := []string{}
-	for _, registry := range parsedMirroredRegistries {
-		contentFilters = append(contentFilters, fmt.Sprintf(`labels."%s.%s"~="^."`, labels.LabelDistributionSource, registry.Host))
-	}
-	return []string{imageFilter}, []string{eventFilter, `topic~="/content/create"`}, contentFilters
-}
-
 // Refer to containerd registry configuration documentation for more information about required configuration.
 // https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 // https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples
@@ -538,14 +484,11 @@ func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegi
 	log := logr.FromContextOrDiscard(ctx)
 
 	// Parse and verify mirror urls.
-	if len(mirroredRegistries) == 0 {
-		mirroredRegistries = append(mirroredRegistries, wildcardRegistryMirrors[0])
-	}
-	parsedMirroredRegistries, err := parseMirroredRegistries(mirroredRegistries)
+	parsedMirroredRegistries, err := parseRegistries(mirroredRegistries, true)
 	if err != nil {
 		return err
 	}
-	parsedMirrorTargets, err := parseMirrorTargets(mirrorTargets)
+	parsedMirrorTargets, err := parseRegistries(mirrorTargets, false)
 	if err != nil {
 		return err
 	}
@@ -642,59 +585,6 @@ func CleanupMirrorConfiguration(ctx context.Context, configPath string) error {
 	return nil
 }
 
-func parseMirroredRegistries(mirroredRegistries []string) ([]url.URL, error) {
-	mru := []url.URL{}
-	for _, s := range mirroredRegistries {
-		if slices.Contains(wildcardRegistryMirrors, s) {
-			mru = append(mru, url.URL{Host: wildcardRegistryMirrors[0]})
-			continue
-		}
-		u, err := url.Parse(s)
-		if err != nil {
-			return nil, err
-		}
-		err = validateRegistry(u)
-		if err != nil {
-			return nil, err
-		}
-		mru = append(mru, *u)
-	}
-	return mru, nil
-}
-
-func parseMirrorTargets(mirroredTargets []string) ([]url.URL, error) {
-	mru := []url.URL{}
-	for _, s := range mirroredTargets {
-		u, err := url.Parse(s)
-		if err != nil {
-			return nil, err
-		}
-		err = validateRegistry(u)
-		if err != nil {
-			return nil, err
-		}
-		mru = append(mru, *u)
-	}
-	return mru, nil
-}
-
-func validateRegistry(u *url.URL) error {
-	errs := []error{}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		errs = append(errs, fmt.Errorf("invalid registry url scheme must be http or https: %s", u.String()))
-	}
-	if u.Path != "" {
-		errs = append(errs, fmt.Errorf("invalid registry url path has to be empty: %s", u.String()))
-	}
-	if len(u.Query()) != 0 {
-		errs = append(errs, fmt.Errorf("invalid registry url query has to be empty: %s", u.String()))
-	}
-	if u.User != nil {
-		errs = append(errs, fmt.Errorf("invalid registry url user has to be empty: %s", u.String()))
-	}
-	return errors.Join(errs...)
-}
-
 func backupConfig(log logr.Logger, configPath string) error {
 	backupDirPath := path.Join(configPath, backupDir)
 	ok, err := dirExists(backupDirPath)
@@ -747,7 +637,7 @@ func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, 
 	if parsedMirrorRegistry.String() == "https://docker.io" {
 		server = "https://registry-1.docker.io"
 	}
-	if slices.Contains(wildcardRegistryMirrors, parsedMirrorRegistry.Host) {
+	if parsedMirrorRegistry == wildcardRegistryURL {
 		server = ""
 	}
 

--- a/pkg/oci/filter.go
+++ b/pkg/oci/filter.go
@@ -1,7 +1,16 @@
 package oci
 
 import (
+	"errors"
+	"fmt"
+	"net/url"
 	"regexp"
+	"slices"
+)
+
+var (
+	wildcardRegistries  = []string{"_default", "*"}
+	wildcardRegistryURL = url.URL{Host: wildcardRegistries[0]}
 )
 
 type Filter interface {
@@ -26,6 +35,14 @@ func (f RegexFilter) Matches(ref Reference) bool {
 	return false
 }
 
+type RegistryWhitelistFilter struct {
+	Whitelist []string
+}
+
+func (f RegistryWhitelistFilter) Matches(ref Reference) bool {
+	return !slices.Contains(f.Whitelist, ref.Registry)
+}
+
 // MatchesFilter returns true if the reference matches any of the regexes.
 func MatchesFilter(ref Reference, filters []Filter) bool {
 	for _, f := range filters {
@@ -34,4 +51,73 @@ func MatchesFilter(ref Reference, filters []Filter) bool {
 		}
 	}
 	return false
+}
+
+// FilterForMirroredRegistries returns a filter that matches only to the registries that have been configured to be mirrored.
+// If the slice is empty or contains a wildcard registry nil will be returned as no registry should be filtered.
+func FilterForMirroredRegistries(mirroredRegistries []string) (*RegistryWhitelistFilter, error) {
+	if len(mirroredRegistries) == 0 {
+		return nil, nil
+	}
+	rus, err := parseRegistries(mirroredRegistries, true)
+	if err != nil {
+		return nil, err
+	}
+	registryHosts := []string{}
+	for _, ru := range rus {
+		// No registry filter when wildcard is part of mirrored registries.
+		if ru == wildcardRegistryURL {
+			return nil, nil
+		}
+		registryHosts = append(registryHosts, ru.Host)
+	}
+	return &RegistryWhitelistFilter{Whitelist: registryHosts}, nil
+}
+
+func parseRegistries(registries []string, allowWildcard bool) ([]url.URL, error) {
+	if len(registries) == 0 && allowWildcard {
+		return []url.URL{wildcardRegistryURL}, nil
+	}
+	rus := []url.URL{}
+	hasWildcard := false
+	for _, s := range registries {
+		if slices.Contains(wildcardRegistries, s) {
+			if !allowWildcard {
+				return nil, errors.New("wildcard registries are not allowed")
+			}
+			if hasWildcard {
+				return nil, errors.New("registries should not contain two wildcards")
+			}
+			hasWildcard = true
+			rus = append(rus, wildcardRegistryURL)
+			continue
+		}
+		u, err := url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+		err = validateRegistryURL(u)
+		if err != nil {
+			return nil, err
+		}
+		rus = append(rus, *u)
+	}
+	return rus, nil
+}
+
+func validateRegistryURL(u *url.URL) error {
+	errs := []error{}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		errs = append(errs, fmt.Errorf("invalid registry url scheme must be http or https: %s", u.String()))
+	}
+	if u.Path != "" {
+		errs = append(errs, fmt.Errorf("invalid registry url path has to be empty: %s", u.String()))
+	}
+	if len(u.Query()) != 0 {
+		errs = append(errs, fmt.Errorf("invalid registry url query has to be empty: %s", u.String()))
+	}
+	if u.User != nil {
+		errs = append(errs, fmt.Errorf("invalid registry url user has to be empty: %s", u.String()))
+	}
+	return errors.Join(errs...)
 }

--- a/pkg/oci/filter_test.go
+++ b/pkg/oci/filter_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"net/url"
 	"regexp"
 	"testing"
 
@@ -52,4 +53,145 @@ func TestMatchesFilter(t *testing.T) {
 			require.Equal(t, tt.expected, MatchesFilter(tt.ref, tt.filters))
 		})
 	}
+}
+
+func TestFilterForMirroredRegistries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		registries []string
+	}{
+		{
+			name:       "empty mirrored registries",
+			registries: []string{},
+		},
+		{
+			name:       "wildcard registries",
+			registries: []string{"https://docker.io", "*"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter, err := FilterForMirroredRegistries(tt.registries)
+			require.NoError(t, err)
+			require.Nil(t, filter)
+		})
+	}
+
+	registries := []string{"https://docker.io", "https://quay.io", "http://localhost:5000"}
+	filter, err := FilterForMirroredRegistries(registries)
+	require.NoError(t, err)
+	expected := []string{"docker.io", "quay.io", "localhost:5000"}
+	require.Equal(t, expected, filter.Whitelist)
+
+	ref := Reference{
+		Registry:   "localhost:6000",
+		Repository: "foo",
+		Tag:        "bar",
+	}
+	matches := MatchesFilter(ref, []Filter{filter})
+	require.True(t, matches)
+
+	ref = Reference{
+		Registry:   "localhost:5000",
+		Repository: "foo",
+		Tag:        "bar",
+	}
+	matches = MatchesFilter(ref, []Filter{filter})
+	require.False(t, matches)
+
+	ref = Reference{
+		Registry:   "docker.io",
+		Repository: "foo",
+		Tag:        "bar",
+	}
+	matches = MatchesFilter(ref, []Filter{filter})
+	require.False(t, matches)
+}
+
+func TestParseRegistries(t *testing.T) {
+	t.Parallel()
+
+	registries := []string{"https://docker.io", "_default", "http://localhost:9090"}
+	rus, err := parseRegistries(registries, true)
+	require.NoError(t, err)
+	strs := []string{}
+	for _, ru := range rus {
+		strs = append(strs, ru.String())
+	}
+	expected := []string{"https://docker.io", "//_default", "http://localhost:9090"}
+	require.Equal(t, expected, strs)
+
+	//nolint: govet // Prioritize readability in tests.
+	fail := []struct {
+		name          string
+		registries    []string
+		allowWildcard bool
+		expected      string
+	}{
+		{
+			name:          "two wildcards",
+			registries:    []string{"*", "_default"},
+			allowWildcard: true,
+			expected:      "registries should not contain two wildcards",
+		},
+		{
+			name:          "wildcard when not allowed",
+			registries:    []string{"*"},
+			allowWildcard: false,
+			expected:      "wildcard registries are not allowed",
+		},
+	}
+	for _, tt := range fail {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseRegistries(tt.registries, tt.allowWildcard)
+			require.EqualError(t, err, tt.expected)
+		})
+	}
+}
+
+func TestValidateRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		urlStr   string
+		expected string
+	}{
+		{
+			urlStr:   "ftp://docker.io",
+			expected: "invalid registry url scheme must be http or https: ftp://docker.io",
+		},
+		{
+			urlStr:   "https://docker.io/foo/bar",
+			expected: "invalid registry url path has to be empty: https://docker.io/foo/bar",
+		},
+		{
+			urlStr:   "https://docker.io?foo=bar",
+			expected: "invalid registry url query has to be empty: https://docker.io?foo=bar",
+		},
+		{
+			urlStr:   "https://foo@docker.io",
+			expected: "invalid registry url user has to be empty: https://foo@docker.io",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.urlStr, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tt.urlStr)
+			require.NoError(t, err)
+			err = validateRegistryURL(u)
+			require.EqualError(t, err, tt.expected)
+		})
+	}
+
+	u, err := url.Parse("https://docker.io")
+	require.NoError(t, err)
+	err = validateRegistryURL(u)
+	require.NoError(t, err)
 }

--- a/pkg/routing/memory.go
+++ b/pkg/routing/memory.go
@@ -29,7 +29,7 @@ func (m *MemoryRouter) Ready(ctx context.Context) (bool, error) {
 	return len(m.resolver) > 0, nil
 }
 
-func (m *MemoryRouter) Lookup(ctx context.Context, key string, count int) (Balancer, error) { //nolint: ireturn // Ignore.
+func (m *MemoryRouter) Lookup(ctx context.Context, key string, count int) (Balancer, error) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
 

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -195,7 +195,7 @@ func (r *P2PRouter) Ready(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (r *P2PRouter) Lookup(ctx context.Context, key string, count int) (Balancer, error) { //nolint: ireturn // Ignore.
+func (r *P2PRouter) Lookup(ctx context.Context, key string, count int) (Balancer, error) {
 	log := logr.FromContextOrDiscard(ctx).WithValues("host", r.host.ID().String(), "key", key)
 	c, err := createCid(key)
 	if err != nil {


### PR DESCRIPTION
This change moves all responsibility for registry filtering from the OCI store into the recently added registry filter. Using a single filter allows us to apply filtering in a standardized manner no matter that OCI store backend. It also makes filtering a lot more consistent so that the registry applies the same filters that are applied when advertising content.