### PR TITLE
Implement filtering of content in state tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1032](https://github.com/spegel-org/spegel/pull/1032) Fix measuring pulls in debug web view with non default registry address configured.
 - [#1035](https://github.com/spegel-org/spegel/pull/1035) Implement single registry filter using reference.
 - [#1040](https://github.com/spegel-org/spegel/pull/1040) Fix distribution regex to support consecutive dashes and underscores.
+- [#1048](https://github.com/spegel-org/spegel/pull/1048) Implement filtering of content in state tracking.
 
 ### Security
 

--- a/pkg/oci/memory.go
+++ b/pkg/oci/memory.go
@@ -50,13 +50,13 @@ func (m *Memory) ListImages(ctx context.Context) ([]Image, error) {
 	return m.images, nil
 }
 
-func (m *Memory) ListContents(ctx context.Context) ([]Content, error) {
+func (m *Memory) ListContent(ctx context.Context) ([][]Reference, error) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
 
-	contents := []Content{}
+	contents := [][]Reference{}
 	for k := range m.blobs {
-		contents = append(contents, Content{Digest: k})
+		contents = append(contents, []Reference{{Digest: k}})
 	}
 	return contents, nil
 }

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -35,11 +35,6 @@ type OCIEvent struct {
 	Key  string
 }
 
-type Content struct {
-	Digest     digest.Digest
-	Registires []string
-}
-
 type Store interface {
 	// Name returns the name of the store implementation.
 	Name() string
@@ -53,8 +48,8 @@ type Store interface {
 	// ListImages returns a list of all local images.
 	ListImages(ctx context.Context) ([]Image, error)
 
-	// ListContents returns a list of all the contents.
-	ListContents(ctx context.Context) ([]Content, error)
+	// ListContent returns a list of references for all the content.
+	ListContent(ctx context.Context) ([][]Reference, error)
 
 	// Resolve returns the digest for the tagged image name reference.
 	// The ref is expected to be in the format `registry/name:tag`.


### PR DESCRIPTION
This change implements filtering of content when listed. It uses the registry filter in the same way as images are filtered. Listing content now returns a slice of references, to represent if some blob is linked to multiple images with different repositories or registries.