### PR TITLE
Refactor filters to support more than only regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1034](https://github.com/spegel-org/spegel/pull/1034) Refactor to use shared reference in image and distribution path.
 - [#1037](https://github.com/spegel-org/spegel/pull/1037) Change to returning balancer from router lookups.
 - [#1039](https://github.com/spegel-org/spegel/pull/1039) Add caching for balancers to reduce duplicate queries.
+- [#1049](https://github.com/spegel-org/spegel/pull/1049) Refactor filters to support more than only regex.
   
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -139,14 +139,18 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	if err != nil {
 		return err
 	}
+	filters := []oci.Filter{}
+	for _, r := range args.RegistryFilters {
+		filters = append(filters, oci.RegexFilter{Regex: r})
+	}
 	if !args.ResolveLatestTag {
 		log.Error(errors.New("deprecated argument"), "Resolve latest tag is replaced by registry filter which offers more customizable behavior. Use the filter `:latest$` to achieve the same behavior.")
 		//nolint: gocritic // We want to avoid panics and instead return errors.
-		latestFilter, err := regexp.Compile(`:latest$`)
+		r, err := regexp.Compile(`:latest$`)
 		if err != nil {
 			return err
 		}
-		args.RegistryFilters = append(args.RegistryFilters, latestFilter)
+		filters = append(filters, oci.RegexFilter{Regex: r})
 	}
 
 	// OCI Store
@@ -181,7 +185,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 
 	// State tracking
 	g.Go(func() error {
-		err := state.Track(ctx, ociStore, router, state.WithRegistryFilters(args.RegistryFilters))
+		err := state.Track(ctx, ociStore, router, state.WithRegistryFilters(filters))
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return err
 		}
@@ -190,7 +194,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 
 	// Registry
 	registryOpts := []registry.RegistryOption{
-		registry.WithRegistryFilters(args.RegistryFilters),
+		registry.WithRegistryFilters(filters),
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
 		registry.WithBasicAuth(username, password),
 	}

--- a/pkg/oci/filter.go
+++ b/pkg/oci/filter.go
@@ -4,15 +4,32 @@ import (
 	"regexp"
 )
 
-// MatchesFilter returns true if the reference matches any of the regexes.
-// The reference if converted to a string in the format of registry/repository[:tag].
-func MatchesFilter(ref Reference, filters []*regexp.Regexp) bool {
+type Filter interface {
+	Matches(ref Reference) bool
+}
+
+var _ Filter = RegexFilter{}
+
+type RegexFilter struct {
+	Regex *regexp.Regexp
+}
+
+func (f RegexFilter) Matches(ref Reference) bool {
+	// The reference if converted to a string in the format of registry/repository[:tag].
 	str := ref.Registry + "/" + ref.Repository
 	if ref.Tag != "" {
 		str += ":" + ref.Tag
 	}
+	if f.Regex.MatchString(str) {
+		return true
+	}
+	return false
+}
+
+// MatchesFilter returns true if the reference matches any of the regexes.
+func MatchesFilter(ref Reference, filters []Filter) bool {
 	for _, f := range filters {
-		if f.MatchString(str) {
+		if f.Matches(ref) {
 			return true
 		}
 	}

--- a/pkg/oci/filter_test.go
+++ b/pkg/oci/filter_test.go
@@ -13,7 +13,7 @@ func TestMatchesFilter(t *testing.T) {
 	tests := []struct {
 		name     string
 		ref      Reference
-		filters  []*regexp.Regexp
+		filters  []Filter
 		expected bool
 	}{
 		{
@@ -22,7 +22,7 @@ func TestMatchesFilter(t *testing.T) {
 				Registry:   "docker.io",
 				Repository: "library/ubuntu",
 			},
-			filters:  []*regexp.Regexp{regexp.MustCompile("^docker.io")},
+			filters:  []Filter{RegexFilter{regexp.MustCompile("^docker.io")}},
 			expected: true,
 		},
 		{
@@ -31,7 +31,7 @@ func TestMatchesFilter(t *testing.T) {
 				Registry:   "docker.io",
 				Repository: "library/ubuntu",
 			},
-			filters:  []*regexp.Regexp{regexp.MustCompile("^ghcr.io")},
+			filters:  []Filter{RegexFilter{regexp.MustCompile("^ghcr.io")}},
 			expected: false,
 		},
 		{
@@ -41,7 +41,7 @@ func TestMatchesFilter(t *testing.T) {
 				Repository: "library/ubuntu",
 				Tag:        "latest",
 			},
-			filters:  []*regexp.Regexp{regexp.MustCompile(":latest$")},
+			filters:  []Filter{RegexFilter{regexp.MustCompile(":latest$")}},
 			expected: true,
 		},
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -32,7 +31,7 @@ type RegistryConfig struct {
 	Transport      http.RoundTripper
 	Username       string
 	Password       string
-	Filters        []*regexp.Regexp
+	Filters        []oci.Filter
 	ResolveTimeout time.Duration
 	ResolveRetries int
 }
@@ -46,7 +45,7 @@ func WithResolveRetries(resolveRetries int) RegistryOption {
 	}
 }
 
-func WithRegistryFilters(filters []*regexp.Regexp) RegistryOption {
+func WithRegistryFilters(filters []oci.Filter) RegistryOption {
 	return func(cfg *RegistryConfig) error {
 		cfg.Filters = filters
 		return nil
@@ -82,7 +81,7 @@ type Registry struct {
 	router         routing.Router
 	username       string
 	password       string
-	filters        []*regexp.Regexp
+	filters        []oci.Filter
 	resolveTimeout time.Duration
 	resolveRetries int
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -25,9 +25,9 @@ func TestRegistryOptions(t *testing.T) {
 	t.Parallel()
 
 	transport := &http.Transport{}
-	filters := []*regexp.Regexp{
-		regexp.MustCompile(`^docker.io/`),
-		regexp.MustCompile(`^gcr.io/`),
+	filters := []oci.Filter{
+		oci.RegexFilter{Regex: regexp.MustCompile(`^docker.io/`)},
+		oci.RegexFilter{Regex: regexp.MustCompile(`^gcr.io/`)},
 	}
 
 	opts := []RegistryOption{
@@ -203,7 +203,7 @@ func TestRegistryHandler(t *testing.T) {
 		"sha256:ac73670af3abed54ac6fb4695131f4099be9fbe39d6076c5d0264a6bbdae9d83": {goodAddrPort},
 	}
 	router := routing.NewMemoryRouter(resolver, netip.AddrPort{})
-	reg, err := NewRegistry(oci.NewMemory(), router, WithRegistryFilters([]*regexp.Regexp{regexp.MustCompile(`:latest$`)}))
+	reg, err := NewRegistry(oci.NewMemory(), router, WithRegistryFilters([]oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`:latest$`)}}))
 	require.NoError(t, err)
 	handler := reg.Handler(logr.Discard())
 

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -63,27 +63,27 @@ func TestTrack(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		registryFilters []*regexp.Regexp
+		registryFilters []oci.Filter
 		expectedImages  []string
 	}{
 		{
 			name:            "no filters",
-			registryFilters: []*regexp.Regexp{},
+			registryFilters: []oci.Filter{},
 			expectedImages:  []string{"docker.io/library/ubuntu:latest", "ghcr.io/spegel-org/spegel:v0.0.9", "quay.io/namespace/repo:latest", "localhost:5000/test:latest"},
 		},
 		{
 			name:            "filter docker.io only",
-			registryFilters: []*regexp.Regexp{regexp.MustCompile(`^docker\.io/`)},
+			registryFilters: []oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`^docker\.io/`)}},
 			expectedImages:  []string{"ghcr.io/spegel-org/spegel:v0.0.9", "quay.io/namespace/repo:latest", "localhost:5000/test:latest"},
 		},
 		{
 			name:            "filter multiple registries",
-			registryFilters: []*regexp.Regexp{regexp.MustCompile(`^docker\.io/`), regexp.MustCompile(`^ghcr\.io/`)},
+			registryFilters: []oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`^docker\.io/`)}, oci.RegexFilter{Regex: regexp.MustCompile(`^ghcr\.io/`)}},
 			expectedImages:  []string{"quay.io/namespace/repo:latest", "localhost:5000/test:latest"},
 		},
 		{
 			name:            "filter latest tags",
-			registryFilters: []*regexp.Regexp{regexp.MustCompile(`:latest$`)},
+			registryFilters: []oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`:latest$`)}},
 			expectedImages:  []string{"ghcr.io/spegel-org/spegel:v0.0.9"},
 		},
 	}


### PR DESCRIPTION
Adds a new Filter interface to allow for more than just regex filters. This is needed for #1047 so that a registry while list filter can be implemented. The reason for this is that especially in Go negative look back is not supported for Regex. So any negative filter would be hard to implement.