### PR TITLE
Refactor readiness probe and bootstrap to be separate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1039](https://github.com/spegel-org/spegel/pull/1039) Add caching for balancers to reduce duplicate queries.
 - [#1049](https://github.com/spegel-org/spegel/pull/1049) Refactor filters to support more than only regex.
 - [#1047](https://github.com/spegel-org/spegel/pull/1047) Refactor mirrored registries to be applied with registry filters.
+- [#1051](https://github.com/spegel-org/spegel/pull/1051) Refactor readiness probe and bootstrap to be separate.
   
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.1
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20250530080122-d0efc28a5723
 	github.com/alexflint/go-arg v1.6.0
+	github.com/avast/retry-go/v4 v4.7.0
 	github.com/containerd/containerd/api v1.9.0
 	github.com/containerd/containerd/v2 v2.1.4
 	github.com/containerd/errdefs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/alexflint/go-arg v1.6.0/go.mod h1:A7vTJzvjoaSTypg4biM5uYNTkJ27SkNTArt
 github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
 github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
+github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/main.go
+++ b/main.go
@@ -188,7 +188,11 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		return err
 	}
 	g.Go(func() error {
-		return router.Run(ctx)
+		err := router.Run(ctx)
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 
 	// State tracking


### PR DESCRIPTION
This change refactors the way that bootstrap is triggered. Instead of running when ready is called or during the internal libp2p ticker. It will now run on its own ticker. This has some advantages, one of them being that we will have a lot more control over failure conditions.

The other reason for doing this is to simplify the implementation of #1042. The provider already has a connectivity solution that we hope to expose in the future. The behavior of the connectivity package is very similar to what is implemented here. So any future changes should not be too large.

Changing this also means that we can reattempt bootstrapping a lot more frequent when the routing table is empty, and then trigger it less often when it isn't empty.