### PR TITLE
Replace client getter in Containerd with a single client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1049](https://github.com/spegel-org/spegel/pull/1049) Refactor filters to support more than only regex.
 - [#1047](https://github.com/spegel-org/spegel/pull/1047) Refactor mirrored registries to be applied with registry filters.
 - [#1051](https://github.com/spegel-org/spegel/pull/1051) Refactor readiness probe and bootstrap to be separate.
+- [#1052](https://github.com/spegel-org/spegel/pull/1052) Replace client getter in Containerd with a single client.
   
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -162,11 +162,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	}
 
 	// OCI Store
-	ociStore, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, oci.WithContentPath(args.ContainerdContentPath))
-	if err != nil {
-		return err
-	}
-	err = ociStore.Verify(ctx)
+	ociStore, err := oci.NewContainerd(ctx, args.ContainerdSock, args.ContainerdNamespace, args.ContainerdRegistryConfigPath, oci.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -15,20 +15,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func TestNewContainerd(t *testing.T) {
-	t.Parallel()
-
-	c, err := NewContainerd("socket", "namespace", "foo", nil)
-	require.NoError(t, err)
-	require.Empty(t, c.contentPath)
-	require.Nil(t, c.client)
-	require.Equal(t, "foo", c.registryConfigPath)
-
-	c, err = NewContainerd("socket", "namespace", "foo", nil, WithContentPath("local"))
-	require.NoError(t, err)
-	require.Equal(t, "local", c.contentPath)
-}
-
 func TestVerifyStatusResponse(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -39,9 +39,6 @@ type Store interface {
 	// Name returns the name of the store implementation.
 	Name() string
 
-	// Verify checks that all expected configuration is set.
-	Verify(ctx context.Context) error
-
 	// Subscribe will notify for any image events ocuring in the store backend.
 	Subscribe(ctx context.Context) (<-chan OCIEvent, error)
 

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins/content/local"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
@@ -43,13 +44,19 @@ func TestStore(t *testing.T) {
 	ctx := namespaces.WithNamespace(t.Context(), "k8s.io")
 	containerdClient, err := client.New("", client.WithServices(client.WithImageStore(imageStore), client.WithContentStore(contentStore)))
 	require.NoError(t, err)
-	remoteContainerd, err := NewContainerd("", "", "", nil)
+	remoteMtCache, err := lru.New[digest.Digest, string](100)
 	require.NoError(t, err)
-	remoteContainerd.client = containerdClient
-	localContainerd, err := NewContainerd("", "", "", nil)
+	remoteContainerd := &Containerd{
+		mtCache: remoteMtCache,
+		client:  containerdClient,
+	}
+	localMtCache, err := lru.New[digest.Digest, string](100)
 	require.NoError(t, err)
-	localContainerd.contentPath = contentPath
-	localContainerd.client = containerdClient
+	localContainerd := &Containerd{
+		mtCache:     localMtCache,
+		client:      containerdClient,
+		contentPath: contentPath,
+	}
 
 	memoryStore := NewMemory()
 


### PR DESCRIPTION
This change makes sure the client can be created during the creation of the Containerd store rather than defering the creation until after the client is accessed. This was initially implemented to help with support for RKE2 but we have found another work around for this, so the additional complexity is no longer needed.