### PR TITLE
Immediately get features when creating Containerd store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1047](https://github.com/spegel-org/spegel/pull/1047) Refactor mirrored registries to be applied with registry filters.
 - [#1051](https://github.com/spegel-org/spegel/pull/1051) Refactor readiness probe and bootstrap to be separate.
 - [#1052](https://github.com/spegel-org/spegel/pull/1052) Replace client getter in Containerd with a single client.
+- [#1055](https://github.com/spegel-org/spegel/pull/1055) Immediately get features when creating Containerd store.
   
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	}
 
 	// OCI Store
-	ociStore, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, oci.WithContentPath(args.ContainerdContentPath))
+	ociStore, err := oci.NewContainerd(ctx, args.ContainerdSock, args.ContainerdNamespace, oci.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -47,15 +47,15 @@ func TestStore(t *testing.T) {
 	remoteMtCache, err := lru.New[digest.Digest, string](100)
 	require.NoError(t, err)
 	remoteContainerd := &Containerd{
-		mtCache: remoteMtCache,
-		client:  containerdClient,
+		mediaTypeIdx: remoteMtCache,
+		client:       containerdClient,
 	}
 	localMtCache, err := lru.New[digest.Digest, string](100)
 	require.NoError(t, err)
 	localContainerd := &Containerd{
-		mtCache:     localMtCache,
-		client:      containerdClient,
-		contentPath: contentPath,
+		mediaTypeIdx: localMtCache,
+		client:       containerdClient,
+		contentPath:  contentPath,
 	}
 
 	memoryStore := NewMemory()


### PR DESCRIPTION
This change will resolve the Containerd features once instead of doing it multiple times. It also does some cleanup in the store logic.