### PR TITLE
Send delete events for content by keeping content index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1056](https://github.com/spegel-org/spegel/pull/1056) Send delete events for content by keeping content index.
+
 ### Changed
 
 - [#1013](https://github.com/spegel-org/spegel/pull/1013) Refactor image parsing to include options.

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -39,9 +39,6 @@ type Store interface {
 	// Name returns the name of the store implementation.
 	Name() string
 
-	// Subscribe will notify for any image events ocuring in the store backend.
-	Subscribe(ctx context.Context) (<-chan OCIEvent, error)
-
 	// ListImages returns a list of all local images.
 	ListImages(ctx context.Context) ([]Image, error)
 
@@ -57,6 +54,9 @@ type Store interface {
 
 	// Open returns the streamable content for the given digest.
 	Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekCloser, error)
+
+	// Subscribe will notify for any image events ocuring in the store backend.
+	Subscribe(ctx context.Context) (<-chan OCIEvent, error)
 }
 
 // FingerprintMediaType attempts to determine the media type based on the json structure.


### PR DESCRIPTION
By keeping track of content for images we can send delete events for when images are being deleted. This will be useful for #1042. Eventually these events should be sent by Containerd, but until then this is a good work around.