### PR TITLE
Change OCI events to use references instead of key string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1051](https://github.com/spegel-org/spegel/pull/1051) Refactor readiness probe and bootstrap to be separate.
 - [#1052](https://github.com/spegel-org/spegel/pull/1052) Replace client getter in Containerd with a single client.
 - [#1055](https://github.com/spegel-org/spegel/pull/1055) Immediately get features when creating Containerd store.
+- [#1061](https://github.com/spegel-org/spegel/pull/1061) Change OCI events to use references instead of key string.
   
 ### Deprecated
 

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -36,18 +36,6 @@ func NewImage(registry, repository, tag string, dgst digest.Digest) (Image, erro
 	}, nil
 }
 
-func (i Image) String() string {
-	tag := ""
-	if i.Tag != "" {
-		tag = ":" + i.Tag
-	}
-	digest := ""
-	if i.Digest != "" {
-		digest = "@" + i.Digest.String()
-	}
-	return fmt.Sprintf("%s/%s%s%s", i.Registry, i.Repository, tag, digest)
-}
-
 // TagName returns the full tag reference string if tag is set.
 func (i Image) TagName() (string, bool) {
 	if i.Tag == "" {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -31,8 +31,8 @@ const (
 )
 
 type OCIEvent struct {
-	Type EventType
-	Key  string
+	Type      EventType
+	Reference Reference
 }
 
 type Store interface {

--- a/pkg/oci/reference.go
+++ b/pkg/oci/reference.go
@@ -15,6 +15,18 @@ type Reference struct {
 	Digest     digest.Digest
 }
 
+func (r Reference) String() string {
+	tag := ""
+	if r.Tag != "" {
+		tag = ":" + r.Tag
+	}
+	digest := ""
+	if r.Digest != "" {
+		digest = "@" + r.Digest.String()
+	}
+	return fmt.Sprintf("%s/%s%s%s", r.Registry, r.Repository, tag, digest)
+}
+
 // Validate checks that the contents of the reference is valid.
 func (r Reference) Validate() error {
 	if r.Registry == "" {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -60,7 +60,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, opts 
 			if !ok {
 				return errors.New("event channel closed")
 			}
-			log.Info("OCI event", "key", event.Key, "type", event.Type)
+			log.Info("OCI event", "ref", event.Reference.String(), "type", event.Type)
 			err := handle(ctx, router, event)
 			if err != nil {
 				log.Error(err, "could not handle event")
@@ -135,7 +135,7 @@ func handle(ctx context.Context, router routing.Router, event oci.OCIEvent) erro
 	if event.Type != oci.CreateEvent {
 		return nil
 	}
-	err := router.Advertise(ctx, []string{event.Key})
+	err := router.Advertise(ctx, []string{event.Reference.Identifier()})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change uses reference instead of key in OCI events. Doing this will make filtering and other more complex functionality a lot easier in the future.