### PR TITLE
Replace transport with option to set OCI client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1052](https://github.com/spegel-org/spegel/pull/1052) Replace client getter in Containerd with a single client.
 - [#1055](https://github.com/spegel-org/spegel/pull/1055) Immediately get features when creating Containerd store.
 - [#1061](https://github.com/spegel-org/spegel/pull/1061) Change OCI events to use references instead of key string.
+- [#1063](https://github.com/spegel-org/spegel/pull/1063) Replace transport with option to set OCI client.
   
 ### Deprecated
 

--- a/main.go
+++ b/main.go
@@ -139,6 +139,10 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	if err != nil {
 		return err
 	}
+	ociClient, err := oci.NewClient()
+	if err != nil {
+		return err
+	}
 
 	filters := []oci.Filter{}
 	regFilter, err := oci.FilterForMirroredRegistries(args.MirroredRegistries)
@@ -210,6 +214,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		registry.WithRegistryFilters(filters),
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
 		registry.WithBasicAuth(username, password),
+		registry.WithOCIClient(ociClient),
 	}
 	reg, err := registry.NewRegistry(ociStore, router, registryOpts...)
 	if err != nil {
@@ -247,7 +252,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
 	if args.DebugWebEnabled {
-		web, err := web.NewWeb(router, oci.NewClient(nil), ociStore, args.RegistryAddr)
+		web, err := web.NewWeb(router, ociClient, ociStore, args.RegistryAddr)
 		if err != nil {
 			return err
 		}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -24,26 +24,27 @@ import (
 func TestRegistryOptions(t *testing.T) {
 	t.Parallel()
 
-	transport := &http.Transport{}
 	filters := []oci.Filter{
 		oci.RegexFilter{Regex: regexp.MustCompile(`^docker.io/`)},
 		oci.RegexFilter{Regex: regexp.MustCompile(`^gcr.io/`)},
 	}
+	ociClient, err := oci.NewClient()
+	require.NoError(t, err)
 
 	opts := []RegistryOption{
 		WithResolveRetries(5),
 		WithRegistryFilters(filters),
 		WithResolveTimeout(10 * time.Minute),
-		WithTransport(transport),
 		WithBasicAuth("foo", "bar"),
+		WithOCIClient(ociClient),
 	}
 	cfg := RegistryConfig{}
-	err := option.Apply(&cfg, opts...)
+	err = option.Apply(&cfg, opts...)
 	require.NoError(t, err)
 	require.Equal(t, 5, cfg.ResolveRetries)
 	require.Equal(t, filters, cfg.Filters)
 	require.Equal(t, 10*time.Minute, cfg.ResolveTimeout)
-	require.Equal(t, transport, cfg.Transport)
+	require.Equal(t, ociClient, cfg.OCIClient)
 	require.Equal(t, "foo", cfg.Username)
 	require.Equal(t, "bar", cfg.Password)
 }


### PR DESCRIPTION
This change removes the transport option and replaces it with a configurable OCI client. If we are using some custom CA or mTLS for authentication this now needs to be set in the OCI client, then we pass the client around.

This means that we get better reuse of connections while also having the configuration set in a single location, as the debug web also needs the client configuration.