### PR TITLE
Collect advertise errors instead of immediately returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1040](https://github.com/spegel-org/spegel/pull/1040) Fix distribution regex to support consecutive dashes and underscores.
 - [#1048](https://github.com/spegel-org/spegel/pull/1048) Implement filtering of content in state tracking.
 - [#1059](https://github.com/spegel-org/spegel/pull/1059) Fix missing error return on Verify() failure in registry path.
+- [#1073](https://github.com/spegel-org/spegel/pull/1073) Collect advertise errors instead of immediately returning.
 
 ### Security
 


### PR DESCRIPTION
If we do not have any peers the advertisement would immediately stop. We do not want to do this as we want to put it in our own provider. Instead we collect all the errors and return it in the end.