### PR TITLE
Remove deprecated resolve latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#1075](https://github.com/spegel-org/spegel/pull/1075) Remove deprecated resolve latest.
+
 ### Fixed
 
 ### Security

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -71,7 +71,6 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | spegel.mirroredRegistries | list | `[]` | Registries for which mirror configuration will be created. Empty means all registires will be mirrored. |
 | spegel.prependExisting | bool | `false` | When true existing mirror configuration will be kept and Spegel will prepend it's configuration. |
 | spegel.registryFilters | list | `[]` | Regular expressions to filter out tags/registries. If empty, all registries/tags are resolved. |
-| spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | spegel.resolveTags | bool | `true` | When true Spegel will resolve tags to digests. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |
 | updateStrategy | object | `{}` | An update strategy to replace existing pods with new pods. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -107,7 +107,6 @@ spec:
           - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
           - --bootstrap-kind=dns
           - --dns-bootstrap-domain={{ include "spegel.fullname" . }}-bootstrap.{{ include "spegel.namespace" . }}.svc.{{ .Values.clusterDomain }}
-          - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
           {{- with .Values.spegel.registryFilters }}
           - --registry-filters
           {{- range . }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -179,8 +179,6 @@ spegel:
   containerdMirrorAdd: true
   # -- When true Spegel will resolve tags to digests.
   resolveTags: true
-  # -- When true latest tags will be resolved to digests.
-  resolveLatestTag: true
   # -- Regular expressions to filter out tags/registries. If empty, all registries/tags are resolved.
   registryFilters: []
     # - ".*:latest$"

--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ type RegistryCmd struct {
 	MirrorResolveTimeout         time.Duration    `arg:"--mirror-resolve-timeout,env:MIRROR_RESOLVE_TIMEOUT" default:"20ms" help:"Max duration spent finding a mirror."`
 	MirrorResolveRetries         int              `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
 	DebugWebEnabled              bool             `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"true" help:"When true enables debug web page."`
-	ResolveLatestTag             bool             `arg:"--resolve-latest-tag,env:RESOLVE_LATEST_TAG" default:"true" help:"When true latest tags will be resolved to digests."`
 }
 
 type CleanupCmd struct {
@@ -154,15 +153,6 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		filters = append(filters, *regFilter)
 	}
 	for _, r := range args.RegistryFilters {
-		filters = append(filters, oci.RegexFilter{Regex: r})
-	}
-	if !args.ResolveLatestTag {
-		log.Error(errors.New("deprecated argument"), "Resolve latest tag is replaced by registry filter which offers more customizable behavior. Use the filter `:latest$` to achieve the same behavior.")
-		//nolint: gocritic // We want to avoid panics and instead return errors.
-		r, err := regexp.Compile(`:latest$`)
-		if err != nil {
-			return err
-		}
 		filters = append(filters, oci.RegexFilter{Regex: r})
 	}
 


### PR DESCRIPTION
This change removes the deprecated resolve latest flag. From now on if users want to disable resolve latest they need to add it to the filter.