### PR TITLE
Fix dependabot by ignore broken go-libp2p version

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,6 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+    ignore:
+      - dependency-name: "github.com/libp2p/go-libp2p"
+        versions: ["v6.0.23+incompatible"]


### PR DESCRIPTION
This is an attempt to fix the issues described in https://github.com/libp2p/go-libp2p/issues/3423.