### PR TITLE
Fix image parsing to allow localhost without port and enforce proper IPV6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1080](https://github.com/spegel-org/spegel/pull/1080) Fix image parsing to allow localhost without port and enforce proper IPV6 addresses.
+
 ### Security
 
 # v0.5.0


### PR DESCRIPTION
Fixes issues described in #1077 related to parsing localhost without a port. This also brought up some other issues related to parsing IPV6 addresses.