### PR TITLE
Fix so that Spegel does not crash on parse error in Containerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#1080](https://github.com/spegel-org/spegel/pull/1080) Fix image parsing to allow localhost without port and enforce proper IPV6 addresses.
+- [#1081](https://github.com/spegel-org/spegel/pull/1081) Fix so that Spegel does not crash on parse error in Containerd.
 
 ### Security
 

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -270,8 +270,8 @@ func (c *Containerd) Subscribe(ctx context.Context) (<-chan OCIEvent, error) {
 	for _, cImg := range cImgs {
 		img, err := ParseImage(cImg.Name, WithDigest(cImg.Target.Digest))
 		if err != nil {
-			subCancel()
-			return nil, err
+			log.Error(err, "skipping image that cannot be parsed", "image", img.String())
+			continue
 		}
 		refs := []Reference{}
 		handler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
@@ -292,8 +292,8 @@ func (c *Containerd) Subscribe(ctx context.Context) (<-chan OCIEvent, error) {
 		})
 		err = images.Walk(ctx, handler, cImg.Target)
 		if err != nil {
-			subCancel()
-			return nil, err
+			log.Error(err, "skipping image that cannot be walked", "image", img.String())
+			continue
 		}
 		contentIdx[cImg.Target.Digest] = refs
 	}


### PR DESCRIPTION
If there is some issue when parsing the image or walking the image during the initial index, we do not want to crash all of Spegel. It is better to log the issue and keep running.

Fixes #1077