### PR TITLE
Switch to auto generating release notes with PR labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,11 +5,15 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 15
+    labels:
+      - "changelog/ignore"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 15
+    labels:
+      - "changelog/dependencies"
     groups:
       k8s:
         patterns:

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,25 @@
+changelog:
+  exclude-labels:
+    - changelog/ignore
+  categories:
+    - title: Added
+      labels:
+        - changelog/added
+    - title: Changed
+      labels:
+        - changelog/changed
+    - title: Fixed
+      labels:
+        - changelog/fixed
+    - title: Deprecated
+      labels:
+        - changelog/deprecated
+    - title: Removed
+      labels:
+        - changelog/removed
+    - title: Security
+      labels:
+        - changelog/security
+    - title: Dependencies
+      labels:
+        - changelog/dependencies

--- a/.github/workflows/changelog-labels.yaml
+++ b/.github/workflows/changelog-labels.yaml
@@ -1,0 +1,20 @@
+name: changelog
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+permissions:
+  contents: read
+defaults:
+  run:
+    shell: bash   
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check changelog label
+        uses: mheap/github-action-required-labels@8afbe8ae6ab7647d0c9f0cfa7c2f939650d22509 #v5.5.1
+        with:
+          mode: exactly
+          count: 1
+          use_regex: true
+          labels: "changelog/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Added
-
-### Changed
-  
-### Deprecated
-
-### Removed
-
-- [#1075](https://github.com/spegel-org/spegel/pull/1075) Remove deprecated resolve latest.
-
-### Fixed
-
-- [#1080](https://github.com/spegel-org/spegel/pull/1080) Fix image parsing to allow localhost without port and enforce proper IPV6 addresses.
-- [#1081](https://github.com/spegel-org/spegel/pull/1081) Fix so that Spegel does not crash on parse error in Containerd.
-
-### Security
-
 # v0.5.0
 
 ### Added


### PR DESCRIPTION
Keeping track of a Changelog is difficult especially if we are going to do release branches. This is why switching to label enforcement and auto generating release notes will be a lot easier.