### PR TITLE
Fix integration codecov by running fast version coverage on PR

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,3 +34,22 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
+  integration-containerd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c #v6.1.0
+        with:
+          go-version-file: ./test/integration/containerd/go.mod
+          cache-dependency-path: ./test/integration/containerd/go.sum
+      - name: Run tests
+        run: TEST_CONTAINERD_VERSION="fast" go test -race -coverprofile=coverage.txt -coverpkg=github.com/spegel-org/spegel/... -covermode=atomic ./...
+        working-directory: ./test/integration/containerd
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration-containerd
+          directory: ./test/integration/containerd

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,19 +9,17 @@ defaults:
   run:
     shell: bash
 jobs:
-  containerd:
+  integration-containerd:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c #v6.1.0
+        working-directory: ./test/integration/containerd
         with:
-          go-version-file: go.mod
+          go-version-file: ./test/integration/containerd/go.mod
+          cache-dependency-path: ./test/integration/containerd/go.sum
       - name: Run tests
-        run: cd ./test/integration/containerd && go test -race -coverprofile=coverage.txt -coverpkg=github.com/spegel-org/spegel/... -covermode=atomic ./...
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: integration-containerd
+        run: go test -race ./...
+        working-directory: ./test/integration/containerd

--- a/test/integration/containerd/containerd_test.go
+++ b/test/integration/containerd/containerd_test.go
@@ -24,19 +24,37 @@ import (
 func TestContainerdPull(t *testing.T) {
 	t.Parallel()
 
+	containerdVersions := []string{
+		"2.2.0",
+		"2.1.5",
+		"2.0.7",
+		"1.7.29",
+	}
+	testContainerdVersion := os.Getenv("TEST_CONTAINERD_VERSION")
+	if testContainerdVersion == "" {
+		testContainerdVersion = "all"
+	}
+	t.Log("testing Containerd with version setting", testContainerdVersion)
+	switch testContainerdVersion {
+	case "all":
+		break
+	case "fast":
+		containerdVersions = []string{
+			containerdVersions[0],
+			containerdVersions[3],
+		}
+	case "latest":
+		containerdVersions = containerdVersions[:1]
+	default:
+		t.Fatal("unknown TEST_CONTAINERD_VERSION", testContainerdVersion)
+	}
+
 	cli, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 	require.NoError(t, err)
 	defer func() {
 		err := cli.Close()
 		assert.NoError(t, err)
 	}()
-
-	containerdVersions := []string{
-		"1.7.29",
-		"2.0.7",
-		"2.1.5",
-		"2.2.0",
-	}
 	for _, containerdVersion := range containerdVersions {
 		t.Run(containerdVersion, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This change removes codecov upload from nightly builds and moves it to just run it on PRs.