### PR TITLE
Fix support for dual stack networking

### DIFF
--- a/main.go
+++ b/main.go
@@ -301,7 +301,7 @@ func cleanupWaitCommand(ctx context.Context, args *CleanupWaitCmd) error {
 func getBootstrapper(cfg BootstrapConfig) (routing.Bootstrapper, error) { //nolint: ireturn // Return type can be different structs.
 	switch cfg.BootstrapKind {
 	case "dns":
-		return routing.NewDNSBootstrapper(cfg.DNSBootstrapDomain, 10), nil
+		return routing.NewDNSBootstrapper(cfg.DNSBootstrapDomain), nil
 	case "http":
 		return routing.NewHTTPBootstrapper(cfg.HTTPBootstrapAddr, cfg.HTTPBootstrapPeer), nil
 	case "static":

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -76,7 +76,7 @@ func TestDNSBootstrap(t *testing.T) {
 		return srv.Shutdown()
 	})
 
-	bs := NewDNSBootstrapper("peers", 10)
+	bs := NewDNSBootstrapper("peers")
 	bs.resolver = &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {

--- a/pkg/web/templates/stats.html
+++ b/pkg/web/templates/stats.html
@@ -1,9 +1,11 @@
 <div>
   <div class="stat-container">
+    {{- range .LocalAddresses }}
     <div class="stat-box" style="background-color: #64B5F6;">
       <div class="stat-title">Local Address</div>
-      <div class="stat-value" style="word-break: break-all;">{{ .LocalAddress }}</div>
+      <div class="stat-value" style="word-break: break-all;">{{ . }}</div>
     </div>
+    {{- end }}
     <div class="stat-box" style="background-color: {{if .MirrorLastSuccess}}#81C784{{else}}#FAA93B{{end}};">
       <div class="stat-title">Last Mirror Success</div>
       {{- if .MirrorLastSuccess }}
@@ -28,13 +30,13 @@
     <div class="table-container">
       <table>
         <tr>
-          <th style="width: 30%;">Address</th>
-          <th style="width: 70%;">ID</th>
+          <th style="width: 60%;">ID</th>
+          <th style="width: 40%;">Addresses</th>
         </tr>
         {{ range .Peers }}
         <tr>
-          <td>{{ .Address }}</td>
           <td>{{ .ID }}</td>
+          <td>{{ join .Addresses ", " }}</td>
         </tr>
         {{ end }}
       </table>

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -68,6 +69,7 @@ func NewWeb(router *routing.P2PRouter, ociStore oci.Store, reg *registry.Registr
 	}
 
 	funcs := template.FuncMap{
+		"join":           strings.Join,
 		"formatBytes":    formatBytes,
 		"formatDuration": formatDuration,
 	}
@@ -104,7 +106,7 @@ func (w *Web) indexHandler(rw httpx.ResponseWriter, req *http.Request) {
 
 func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 	data := struct {
-		LocalAddress      string
+		LocalAddresses    []string
 		Images            []oci.Image
 		Peers             []routing.Peer
 		MirrorLastSuccess time.Duration
@@ -128,7 +130,7 @@ func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 		data.MirrorLastSuccess = time.Since(time.Unix(mirrorLastSuccess, 0))
 	}
 
-	data.LocalAddress = w.router.LocalAddress()
+	data.LocalAddresses = w.router.LocalAddresses()
 	peers, err := w.router.ListPeers()
 	if err != nil {
 		rw.WriteError(http.StatusInternalServerError, err)

--- a/test/integration/kubernetes/kubernetes_test.go
+++ b/test/integration/kubernetes/kubernetes_test.go
@@ -81,9 +81,9 @@ func TestKubernetes(t *testing.T) {
 		v1alpha4.IPVSProxyMode,
 	}
 	ipFamilies := []v1alpha4.ClusterIPFamily{
+		v1alpha4.DualStackFamily,
 		v1alpha4.IPv4Family,
 		v1alpha4.IPv6Family,
-		v1alpha4.DualStackFamily,
 	}
 	switch testStrategy {
 	case "all":


### PR DESCRIPTION
This change fixes proper support for dual stack Kubernetes clusters. It detects the local stack that is supported and will prioritize returning ip6 addresses first. The bootstrapper has also been updated to make separate lookups for ip4 and ip6 addresses.

Fixes #709
Fixes #619 
Superseeds #968 