### PR TITLE
Fix empty json media type

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -73,6 +73,16 @@ func FingerprintMediaType(r io.Reader) (string, error) {
 		return "", errors.New("expected object start")
 	}
 
+	if !dec.More() {
+		b, err := io.ReadAll(dec.Buffered())
+		if err != nil {
+			return "", err
+		}
+		if len(b)+int(dec.InputOffset()) == 2 {
+			return ocispec.MediaTypeEmptyJSON, nil
+		}
+	}
+
 	schemaVersion := 0
 	mediaType := ""
 

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,8 +61,20 @@ func TestFingerprintMediaType(t *testing.T) {
 	}
 
 	mt, err := FingerprintMediaType(strings.NewReader("{}"))
+	require.NoError(t, err)
+	require.Equal(t, ocispec.MediaTypeEmptyJSON, mt)
+
+	_, err = FingerprintMediaType(strings.NewReader(" "))
+	require.ErrorIs(t, err, io.EOF)
+
+	_, err = FingerprintMediaType(strings.NewReader(" { } "))
 	require.EqualError(t, err, "could not determine media type")
-	require.Empty(t, mt)
+
+	_, err = FingerprintMediaType(strings.NewReader("{ }"))
+	require.EqualError(t, err, "could not determine media type")
+
+	_, err = FingerprintMediaType(strings.NewReader("{\"unexpected\":\"value\"}"))
+	require.EqualError(t, err, "could not determine media type")
 }
 
 func TestIsManifestMediatype(t *testing.T) {


### PR DESCRIPTION
# Problem

Spegel doesn't work with [ORAS](https://oras.land/) OCI images.

If the content of a blob is an empty json ("{}"), which is the default behavior for the config layer in ORAS generated images (see [here](https://oras.land/docs/how_to_guides/manifest_config/#empty-config-file)), serving the blob fails with 
> could not determine media type

The media type is not correctly detected for `application/vnd.oci.empty.v1+json` blobs.

This was introduced in 0.5.0,  registry#blobHandler now [calls](https://github.com/spegel-org/spegel/blob/v0.5.0/pkg/registry/registry.go#L432) ociStore.Descriptor, which tries to infer the media type. That was not the case before.

# Solution

In `FingerprintMediaType()`, return `application/vnd.oci.empty.v1+json` if the content is an empty json.