### PR TITLE
Explicitly add key to provider store on advertise

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - proxy-mode: iptables


### PR DESCRIPTION
This change moves the behavior of the p2p router closer to what it was before the provider store refactor. A change in the provider store is that local add is not called until the provider is online. This does mean that we will write twice when online, but the operation is relatively cheap and worth doing for stability reasons.