### PR TITLE
Split bootstrap self check to check address after port addition

### DIFF
--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -219,91 +219,49 @@ func TestCreateCid(t *testing.T) {
 	require.Equal(t, "bafkreigdvoh7cnza5cwzar65hfdgwpejotszfqx2ha6uuolaofgk54ge6i", c.String())
 }
 
-func TestAddrInfoMatches(t *testing.T) {
+func TestAddrsEqual(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
-		a        peer.AddrInfo
-		b        peer.AddrInfo
+		a        []ma.Multiaddr
+		b        []ma.Multiaddr
 		expected bool
 	}{
 		{
-			name: "ID match",
-			a: peer.AddrInfo{
-				ID:    "foo",
-				Addrs: []ma.Multiaddr{},
-			},
-			b: peer.AddrInfo{
-				ID:    "foo",
-				Addrs: []ma.Multiaddr{},
-			},
-			expected: true,
-		},
-		{
-			name: "ID do not match",
-			a: peer.AddrInfo{
-				ID:    "foo",
-				Addrs: []ma.Multiaddr{},
-			},
-			b: peer.AddrInfo{
-				ID:    "bar",
-				Addrs: []ma.Multiaddr{},
-			},
+			name:     "empty addresses",
+			a:        []ma.Multiaddr{},
+			b:        []ma.Multiaddr{},
 			expected: false,
 		},
 		{
-			name: "IP4 match",
-			a: peer.AddrInfo{
-				ID:    "",
-				Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
-			},
-			b: peer.AddrInfo{
-				ID:    "",
-				Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
-			},
+			name:     "IP4 match",
+			a:        []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
+			b:        []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
 			expected: true,
 		},
 		{
-			name: "IP4 do not match",
-			a: peer.AddrInfo{
-				ID:    "",
-				Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
-			},
-			b: peer.AddrInfo{
-				ID:    "",
-				Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.2")},
-			},
+			name:     "IP4 do not match",
+			a:        []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
+			b:        []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.2")},
 			expected: false,
 		},
 		{
 			name: "IP6 match",
-			a: peer.AddrInfo{
-				ID:    "",
-				Addrs: []ma.Multiaddr{ma.StringCast("/ip6/c3c9:152b:73d1:dad0:e2f9:a521:6356:88ba")},
-			},
-			b: peer.AddrInfo{
-				ID: "",
-				Addrs: []ma.Multiaddr{
-					ma.StringCast("/ip4/192.168.1.1"),
-					ma.StringCast("/ip6/c3c9:152b:73d1:dad0:e2f9:a521:6356:88ba"),
-				},
+			a:    []ma.Multiaddr{ma.StringCast("/ip6/c3c9:152b:73d1:dad0:e2f9:a521:6356:88ba")},
+			b: []ma.Multiaddr{
+				ma.StringCast("/ip4/192.168.1.1"),
+				ma.StringCast("/ip6/c3c9:152b:73d1:dad0:e2f9:a521:6356:88ba"),
 			},
 			expected: true,
 		},
 		{
 			name: "non IP address",
-			a: peer.AddrInfo{
-				ID: "",
-				Addrs: []ma.Multiaddr{
-					ma.StringCast("/tcp/5000"),
-					ma.StringCast("/ip4/192.168.1.1"),
-				},
+			a: []ma.Multiaddr{
+				ma.StringCast("/tcp/5000"),
+				ma.StringCast("/ip4/192.168.1.1"),
 			},
-			b: peer.AddrInfo{
-				ID:    "",
-				Addrs: []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
-			},
+			b:        []ma.Multiaddr{ma.StringCast("/ip4/192.168.1.1")},
 			expected: true,
 		},
 	}
@@ -311,7 +269,7 @@ func TestAddrInfoMatches(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			matches := addrInfoMatches(tt.a, tt.b)
+			matches := addrsEqual(tt.a, tt.b)
 			require.Equal(t, tt.expected, matches)
 		})
 	}


### PR DESCRIPTION
The self check should primarily consider the id and then check the address afterwards. This would break bootstrap when testing to Spegel instances on localhost.