### PR TITLE
Extend HTTP bootstrapper to accept external URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,15 +47,15 @@ type ConfigurationCmd struct {
 }
 
 type BootstrapConfig struct {
-	BootstrapKind           string   `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
-	DNSBootstrapDomain      string   `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
-	HTTPBootstrapAddr       string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
-	HTTPBootstrapPeer       string   `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
-	ExternalBootstrapURL    url.URL  `arg:"--external-bootstrap-url,env:EXTERNAL_BOOTSTRAP_URL" help:"External bootstrap URL."`
-	ExternalBootstrapCA     *string  `arg:"--external-bootstrap-ca,env:EXTERNAL_BOOTSTRAP_CA" help:"Path to external bootstrap CA."`
-	ExternalBootstrapTLSCrt *string  `arg:"--external-bootstrap-tls-crt,env:EXTERNAL_BOOTSTRAP_TLS_CRT" help:"Path to external bootstrap client TLS certificate."`
-	ExternalBootstrapTLSKey *string  `arg:"--external-bootstrap-tls-key,env:EXTERNAL_BOOTSTRAP_TLS_KEY" help:"Path to external bootstrap client TLS key."`
-	StaticBootstrapPeers    []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
+	BootstrapKind        string   `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
+	DNSBootstrapDomain   string   `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
+	HTTPBootstrapAddr    string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap at /id. Leave it empty to disable serving."`
+	HTTPBootstrapPeer    url.URL  `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Base URL of a peer to HTTP bootstrap with; /id is appended. Mutually exclusive with --http-bootstrap-url."`
+	HTTPBootstrapURL     url.URL  `arg:"--http-bootstrap-url,env:HTTP_BOOTSTRAP_URL" help:"Full URL of an HTTP bootstrap endpoint. Mutually exclusive with --http-bootstrap-peer."`
+	HTTPBootstrapCA      *string  `arg:"--http-bootstrap-ca,env:HTTP_BOOTSTRAP_CA" help:"Path to CA used to verify the HTTP bootstrap endpoint's TLS certificate."`
+	HTTPBootstrapTLSCrt  *string  `arg:"--http-bootstrap-tls-crt,env:HTTP_BOOTSTRAP_TLS_CRT" help:"Path to client TLS certificate used to authenticate to the HTTP bootstrap endpoint."`
+	HTTPBootstrapTLSKey  *string  `arg:"--http-bootstrap-tls-key,env:HTTP_BOOTSTRAP_TLS_KEY" help:"Path to client TLS key used to authenticate to the HTTP bootstrap endpoint."`
+	StaticBootstrapPeers []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
 }
 
 type RegistryCmd struct {
@@ -355,15 +355,13 @@ func getBootstrapper(cfg BootstrapConfig) (routing.Bootstrapper, error) { //noli
 	case "dns":
 		return routing.NewDNSBootstrapper(cfg.DNSBootstrapDomain), nil
 	case "http":
-		return routing.NewHTTPBootstrapper(cfg.HTTPBootstrapAddr, cfg.HTTPBootstrapPeer), nil
-	case "static":
-		return routing.NewStaticBootstrapperFromStrings(cfg.StaticBootstrapPeers)
-	case "external":
-		tlsCA, tlsCert, tlsKey, err := loadExternalBootstrapperCerts(cfg.ExternalBootstrapCA, cfg.ExternalBootstrapTLSCrt, cfg.ExternalBootstrapTLSKey)
+		tlsCA, tlsCert, tlsKey, err := loadHTTPBootstrapperCerts(cfg.HTTPBootstrapCA, cfg.HTTPBootstrapTLSCrt, cfg.HTTPBootstrapTLSKey)
 		if err != nil {
 			return nil, err
 		}
-		return routing.NewExternalBootstrapper(cfg.ExternalBootstrapURL, tlsCA, tlsCert, tlsKey)
+		return routing.NewHTTPBootstrapper(cfg.HTTPBootstrapAddr, cfg.HTTPBootstrapPeer, cfg.HTTPBootstrapURL, tlsCA, tlsCert, tlsKey)
+	case "static":
+		return routing.NewStaticBootstrapperFromStrings(cfg.StaticBootstrapPeers)
 	default:
 		return nil, fmt.Errorf("unknown bootstrap kind %s", cfg.BootstrapKind)
 	}
@@ -382,7 +380,7 @@ func loadBasicAuth() (string, string, error) {
 	return string(username), string(password), nil
 }
 
-func loadExternalBootstrapperCerts(tlsCAFile, tlsCertFile, tlsKeyFile *string) (tlsCA, tlsCert, tlsKey []byte, err error) {
+func loadHTTPBootstrapperCerts(tlsCAFile, tlsCertFile, tlsKeyFile *string) (tlsCA, tlsCert, tlsKey []byte, err error) {
 	if tlsCAFile != nil {
 		if tlsCA, err = os.ReadFile(filepath.Clean(*tlsCAFile)); err != nil {
 			err = fmt.Errorf("failed to read '%s' CA file: %w", filepath.Clean(*tlsCAFile), err)

--- a/main.go
+++ b/main.go
@@ -52,9 +52,9 @@ type BootstrapConfig struct {
 	HTTPBootstrapAddr       string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
 	HTTPBootstrapPeer       string   `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
 	ExternalBootstrapURL    url.URL  `arg:"--external-bootstrap-url,env:EXTERNAL_BOOTSTRAP_URL" help:"External bootstrap URL."`
-	ExternalBootstrapCA     string   `arg:"--external-bootstrap-ca,env:EXTERNAL_BOOTSTRAP_CA" help:"Path to external bootstrap CA."`
-	ExternalBootstrapTLSCrt string   `arg:"--external-bootstrap-tls-crt,env:EXTERNAL_BOOTSTRAP_TLS_CRT" help:"Path to external bootstrap client TLS certificate."`
-	ExternalBootstrapTLSKey string   `arg:"--external-bootstrap-tls-key,env:EXTERNAL_BOOTSTRAP_TLS_KEY" help:"Path to external bootstrap client TLS key."`
+	ExternalBootstrapCA     *string  `arg:"--external-bootstrap-ca,env:EXTERNAL_BOOTSTRAP_CA" help:"Path to external bootstrap CA."`
+	ExternalBootstrapTLSCrt *string  `arg:"--external-bootstrap-tls-crt,env:EXTERNAL_BOOTSTRAP_TLS_CRT" help:"Path to external bootstrap client TLS certificate."`
+	ExternalBootstrapTLSKey *string  `arg:"--external-bootstrap-tls-key,env:EXTERNAL_BOOTSTRAP_TLS_KEY" help:"Path to external bootstrap client TLS key."`
 	StaticBootstrapPeers    []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
 }
 
@@ -382,20 +382,22 @@ func loadBasicAuth() (string, string, error) {
 	return string(username), string(password), nil
 }
 
-func loadExternalBootstrapperCerts(tlsCAFile, tlsCertFile, tlsKeyFile string) (tlsCA, tlsCert, tlsKey []byte, err error) {
-	if tlsCAFile != "" {
-		if tlsCA, err = os.ReadFile(filepath.Clean(tlsCAFile)); err != nil {
-			err = fmt.Errorf("failed to read '%s' CA file: %w", filepath.Clean(tlsCAFile), err)
+func loadExternalBootstrapperCerts(tlsCAFile, tlsCertFile, tlsKeyFile *string) (tlsCA, tlsCert, tlsKey []byte, err error) {
+	if tlsCAFile != nil {
+		if tlsCA, err = os.ReadFile(filepath.Clean(*tlsCAFile)); err != nil {
+			err = fmt.Errorf("failed to read '%s' CA file: %w", filepath.Clean(*tlsCAFile), err)
 			return
 		}
 	}
-	if tlsCertFile != "" && tlsKeyFile != "" {
-		if tlsCert, err = os.ReadFile(filepath.Clean(tlsCertFile)); err != nil {
-			err = fmt.Errorf("failed to read '%s' client TLS certificate file: %w", filepath.Clean(tlsCertFile), err)
+	if tlsCertFile != nil {
+		if tlsCert, err = os.ReadFile(filepath.Clean(*tlsCertFile)); err != nil {
+			err = fmt.Errorf("failed to read '%s' client TLS certificate file: %w", filepath.Clean(*tlsCertFile), err)
 			return
 		}
-		if tlsKey, err = os.ReadFile(filepath.Clean(tlsKeyFile)); err != nil {
-			err = fmt.Errorf("failed to read '%s' client TLS key file: %w", filepath.Clean(tlsKeyFile), err)
+	}
+	if tlsKeyFile != nil {
+		if tlsKey, err = os.ReadFile(filepath.Clean(*tlsKeyFile)); err != nil {
+			err = fmt.Errorf("failed to read '%s' client TLS key file: %w", filepath.Clean(*tlsKeyFile), err)
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -47,11 +47,15 @@ type ConfigurationCmd struct {
 }
 
 type BootstrapConfig struct {
-	BootstrapKind        string   `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
-	DNSBootstrapDomain   string   `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
-	HTTPBootstrapAddr    string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
-	HTTPBootstrapPeer    string   `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
-	StaticBootstrapPeers []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
+	BootstrapKind           string   `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
+	DNSBootstrapDomain      string   `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
+	HTTPBootstrapAddr       string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap."`
+	HTTPBootstrapPeer       string   `arg:"--http-bootstrap-peer,env:HTTP_BOOTSTRAP_PEER" help:"Peer to HTTP bootstrap with."`
+	ExternalBootstrapURL    url.URL  `arg:"--external-bootstrap-url,env:EXTERNAL_BOOTSTRAP_URL" help:"External bootstrap URL."`
+	ExternalBootstrapCA     string   `arg:"--external-bootstrap-ca,env:EXTERNAL_BOOTSTRAP_CA" help:"Path to external bootstrap CA."`
+	ExternalBootstrapTLSCrt string   `arg:"--external-bootstrap-tls-crt,env:EXTERNAL_BOOTSTRAP_TLS_CRT" help:"Path to external bootstrap client TLS certificate."`
+	ExternalBootstrapTLSKey string   `arg:"--external-bootstrap-tls-key,env:EXTERNAL_BOOTSTRAP_TLS_KEY" help:"Path to external bootstrap client TLS key."`
+	StaticBootstrapPeers    []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
 }
 
 type RegistryCmd struct {
@@ -354,6 +358,12 @@ func getBootstrapper(cfg BootstrapConfig) (routing.Bootstrapper, error) { //noli
 		return routing.NewHTTPBootstrapper(cfg.HTTPBootstrapAddr, cfg.HTTPBootstrapPeer), nil
 	case "static":
 		return routing.NewStaticBootstrapperFromStrings(cfg.StaticBootstrapPeers)
+	case "external":
+		tlsCA, tlsCert, tlsKey, err := loadExternalBootstrapperCerts(cfg.ExternalBootstrapCA, cfg.ExternalBootstrapTLSCrt, cfg.ExternalBootstrapTLSKey)
+		if err != nil {
+			return nil, err
+		}
+		return routing.NewExternalBootstrapper(cfg.ExternalBootstrapURL, tlsCA, tlsCert, tlsKey)
 	default:
 		return nil, fmt.Errorf("unknown bootstrap kind %s", cfg.BootstrapKind)
 	}
@@ -370,4 +380,24 @@ func loadBasicAuth() (string, string, error) {
 		return "", "", err
 	}
 	return string(username), string(password), nil
+}
+
+func loadExternalBootstrapperCerts(tlsCAFile, tlsCertFile, tlsKeyFile string) (tlsCA, tlsCert, tlsKey []byte, err error) {
+	if tlsCAFile != "" {
+		if tlsCA, err = os.ReadFile(filepath.Clean(tlsCAFile)); err != nil {
+			err = fmt.Errorf("failed to read '%s' CA file: %w", filepath.Clean(tlsCAFile), err)
+			return
+		}
+	}
+	if tlsCertFile != "" && tlsKeyFile != "" {
+		if tlsCert, err = os.ReadFile(filepath.Clean(tlsCertFile)); err != nil {
+			err = fmt.Errorf("failed to read '%s' client TLS certificate file: %w", filepath.Clean(tlsCertFile), err)
+			return
+		}
+		if tlsKey, err = os.ReadFile(filepath.Clean(tlsKeyFile)); err != nil {
+			err = fmt.Errorf("failed to read '%s' client TLS key file: %w", filepath.Clean(tlsKeyFile), err)
+			return
+		}
+	}
+	return
 }

--- a/pkg/routing/bootstrap.go
+++ b/pkg/routing/bootstrap.go
@@ -213,22 +213,29 @@ type ExternalBootstrapper struct {
 
 func NewExternalBootstrapper(url url.URL, tlsCA, tlsCert, tlsKey []byte) (*ExternalBootstrapper, error) {
 	client := httpx.BaseClient()
+	var tlsConfig *tls.Config
 	if len(tlsCA) > 0 {
-		tlsConfig := &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
+		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(tlsCA) {
 			return nil, errors.New("failed to parse CA certificate")
 		}
 		tlsConfig.RootCAs = caCertPool
-		if len(tlsCert) > 0 && len(tlsKey) > 0 {
-			cert, err := tls.X509KeyPair(tlsCert, tlsKey)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse client certificate: %w", err)
-			}
-			tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	if len(tlsCert) > 0 || len(tlsKey) > 0 {
+		if len(tlsCert) == 0 || len(tlsKey) == 0 {
+			return nil, errors.New("both client TLS certificate and client TLS key must be provided")
 		}
+		cert, err := tls.X509KeyPair(tlsCert, tlsKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse client certificate: %w", err)
+		}
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	if tlsConfig != nil {
 		transport := httpx.BaseTransport()
 		transport.TLSClientConfig = tlsConfig
 		client.Transport = transport

--- a/pkg/routing/bootstrap.go
+++ b/pkg/routing/bootstrap.go
@@ -2,11 +2,16 @@ package routing
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"slices"
 	"sync"
 	"time"
@@ -197,4 +202,82 @@ func (bs *HTTPBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
 		return nil, err
 	}
 	return []peer.AddrInfo{*addrInfo}, nil
+}
+
+var _ Bootstrapper = &ExternalBootstrapper{}
+
+type ExternalBootstrapper struct {
+	httpClient *http.Client
+	url        url.URL
+}
+
+func NewExternalBootstrapper(url url.URL, tlsCA, tlsCert, tlsKey []byte) (*ExternalBootstrapper, error) {
+	client := httpx.BaseClient()
+	if len(tlsCA) > 0 {
+		tlsConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(tlsCA) {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+		if len(tlsCert) > 0 && len(tlsKey) > 0 {
+			cert, err := tls.X509KeyPair(tlsCert, tlsKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse client certificate: %w", err)
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+		transport := httpx.BaseTransport()
+		transport.TLSClientConfig = tlsConfig
+		client.Transport = transport
+	}
+	return &ExternalBootstrapper{
+		httpClient: client,
+		url:        url,
+	}, nil
+}
+
+func (eb *ExternalBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (eb *ExternalBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
+	limit := 3
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, eb.url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := eb.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer httpx.DrainAndClose(resp.Body)
+	err = httpx.CheckResponseStatus(resp, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var ipAddrs []netip.Addr
+	if err := json.Unmarshal(b, &ipAddrs); err != nil {
+		return nil, err
+	}
+	addrInfos := []peer.AddrInfo{}
+	for _, ipAddr := range ipAddrs[:min(len(ipAddrs), limit)] {
+		addr, err := manet.FromIPAndZone(ipAddr.AsSlice(), ipAddr.Zone())
+		if err != nil {
+			return nil, err
+		}
+		addrInfo := peer.AddrInfo{
+			ID:    "",
+			Addrs: []ma.Multiaddr{addr},
+		}
+		addrInfos = append(addrInfos, addrInfo)
+	}
+	return addrInfos, nil
 }

--- a/pkg/routing/bootstrap.go
+++ b/pkg/routing/bootstrap.go
@@ -146,7 +146,7 @@ type HTTPBootstrapper struct {
 
 // NewHTTPBootstrapper creates an HTTP bootstrapper.
 //
-// Self-serving identity at /id is enabled iff addr is non-empty.
+// Self-serving identity at /id is enabled if addr is non-empty.
 // The remote endpoint to fetch peer info from is given by either peer (a base URL; /id is appended) or url (used as is). Exactly one of the two must be set.
 // The tlsCA is an optional CA used to verify the bootstrap endpoint's TLS certificate, while the optional client tlsCert/tlsKey pair is used for mTLS authentication with the endpoint.
 func NewHTTPBootstrapper(addr string, peer, url url.URL, tlsCA, tlsCert, tlsKey []byte) (*HTTPBootstrapper, error) {
@@ -265,8 +265,8 @@ func (bs *HTTPBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
 // bootstrapPeerAddrInfo mirrors libp2p's peer.AddrInfo JSON shape but allows the ID to be omitted or empty.
 // libp2p's peer.AddrInfo.UnmarshalJSON rejects an empty ID, so we unmarshal into this struct and convert via fromBootstrapPeerAddrInfos.
 type bootstrapPeerAddrInfo struct {
-	ID    string
-	Addrs []string
+	ID    string   `json:"ID"`
+	Addrs []string `json:"Addrs"`
 }
 
 func fromBootstrapPeerAddrInfos(bootstrapPeerAddrInfos []bootstrapPeerAddrInfo) ([]peer.AddrInfo, error) {

--- a/pkg/routing/bootstrap.go
+++ b/pkg/routing/bootstrap.go
@@ -133,22 +133,74 @@ func (b *DNSBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
 
 var _ Bootstrapper = &HTTPBootstrapper{}
 
+// HTTPBootstrapper resolves bootstrap peers over HTTP. It can optionally also serve its own identity at /id so other Spegel nodes can bootstrap from it.
+//
+// The endpoint contract is a JSON array of libp2p peer.AddrInfo objects, with the relaxation that the ID field may be omitted or empty.
+// The embedded server always serves a single-element array containing its own identity, but external bootstrap servers may return multiple peers.
+// Any bootstrap server must respect the contract.
 type HTTPBootstrapper struct {
 	httpClient *http.Client
 	addr       string
-	peer       string
+	endpoint   string
 }
 
-func NewHTTPBootstrapper(addr, peer string) *HTTPBootstrapper {
-	return &HTTPBootstrapper{
-		httpClient: httpx.BaseClient(),
-		addr:       addr,
-		peer:       peer,
+// NewHTTPBootstrapper creates an HTTP bootstrapper.
+//
+// Self-serving identity at /id is enabled iff addr is non-empty.
+// The remote endpoint to fetch peer info from is given by either peer (a base URL; /id is appended) or url (used as is). Exactly one of the two must be set.
+// The tlsCA is an optional CA used to verify the bootstrap endpoint's TLS certificate, while the optional client tlsCert/tlsKey pair is used for mTLS authentication with the endpoint.
+func NewHTTPBootstrapper(addr string, peer, url url.URL, tlsCA, tlsCert, tlsKey []byte) (*HTTPBootstrapper, error) {
+	if peer.Host == "" && url.Host == "" {
+		return nil, errors.New("either peer or url must be set")
 	}
+	if peer.Host != "" && url.Host != "" {
+		return nil, errors.New("peer and url are mutually exclusive")
+	}
+	endpoint := url.String()
+	if peer.Host != "" {
+		endpoint = peer.String() + "/id"
+	}
+	client := httpx.BaseClient()
+	var tlsConfig *tls.Config
+	if len(tlsCA) > 0 {
+		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(tlsCA) {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+	if len(tlsCert) > 0 || len(tlsKey) > 0 {
+		if len(tlsCert) == 0 || len(tlsKey) == 0 {
+			return nil, errors.New("both client TLS certificate and client TLS key must be provided")
+		}
+		cert, err := tls.X509KeyPair(tlsCert, tlsKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse client certificate: %w", err)
+		}
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	if tlsConfig != nil {
+		transport := httpx.BaseTransport()
+		transport.TLSClientConfig = tlsConfig
+		client.Transport = transport
+	}
+	return &HTTPBootstrapper{
+		httpClient: client,
+		addr:       addr,
+		endpoint:   endpoint,
+	}, nil
 }
 
 func (bs *HTTPBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) error {
-	b, err := addrInfo.MarshalJSON()
+	if bs.addr == "" {
+		<-ctx.Done()
+		return nil
+	}
+	b, err := json.Marshal([]peer.AddrInfo{addrInfo})
 	if err != nil {
 		return err
 	}
@@ -179,7 +231,8 @@ func (bs *HTTPBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) err
 }
 
 func (bs *HTTPBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bs.peer+"/id", nil)
+	limit := 3
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bs.endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -196,95 +249,45 @@ func (bs *HTTPBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	addrInfo := &peer.AddrInfo{}
-	err = addrInfo.UnmarshalJSON(b)
+	bootstrapPeerAddrInfos := []bootstrapPeerAddrInfo{}
+	err = json.Unmarshal(b, &bootstrapPeerAddrInfos)
 	if err != nil {
 		return nil, err
 	}
-	return []peer.AddrInfo{*addrInfo}, nil
-}
-
-var _ Bootstrapper = &ExternalBootstrapper{}
-
-type ExternalBootstrapper struct {
-	httpClient *http.Client
-	url        url.URL
-}
-
-func NewExternalBootstrapper(url url.URL, tlsCA, tlsCert, tlsKey []byte) (*ExternalBootstrapper, error) {
-	client := httpx.BaseClient()
-	var tlsConfig *tls.Config
-	if len(tlsCA) > 0 {
-		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(tlsCA) {
-			return nil, errors.New("failed to parse CA certificate")
-		}
-		tlsConfig.RootCAs = caCertPool
-	}
-	if len(tlsCert) > 0 || len(tlsKey) > 0 {
-		if len(tlsCert) == 0 || len(tlsKey) == 0 {
-			return nil, errors.New("both client TLS certificate and client TLS key must be provided")
-		}
-		cert, err := tls.X509KeyPair(tlsCert, tlsKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse client certificate: %w", err)
-		}
-		if tlsConfig == nil {
-			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	}
-	if tlsConfig != nil {
-		transport := httpx.BaseTransport()
-		transport.TLSClientConfig = tlsConfig
-		client.Transport = transport
-	}
-	return &ExternalBootstrapper{
-		httpClient: client,
-		url:        url,
-	}, nil
-}
-
-func (eb *ExternalBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) error {
-	<-ctx.Done()
-	return nil
-}
-
-func (eb *ExternalBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
-	limit := 3
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, eb.url.String(), nil)
+	bootstrapPeerAddrInfos = bootstrapPeerAddrInfos[:min(len(bootstrapPeerAddrInfos), limit)]
+	addrInfos, err := fromBootstrapPeerAddrInfos(bootstrapPeerAddrInfos)
 	if err != nil {
 		return nil, err
-	}
-	resp, err := eb.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer httpx.DrainAndClose(resp.Body)
-	err = httpx.CheckResponseStatus(resp, http.StatusOK)
-	if err != nil {
-		return nil, err
-	}
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var ipAddrs []netip.Addr
-	if err := json.Unmarshal(b, &ipAddrs); err != nil {
-		return nil, err
-	}
-	addrInfos := []peer.AddrInfo{}
-	for _, ipAddr := range ipAddrs[:min(len(ipAddrs), limit)] {
-		addr, err := manet.FromIPAndZone(ipAddr.AsSlice(), ipAddr.Zone())
-		if err != nil {
-			return nil, err
-		}
-		addrInfo := peer.AddrInfo{
-			ID:    "",
-			Addrs: []ma.Multiaddr{addr},
-		}
-		addrInfos = append(addrInfos, addrInfo)
 	}
 	return addrInfos, nil
+}
+
+// bootstrapPeerAddrInfo mirrors libp2p's peer.AddrInfo JSON shape but allows the ID to be omitted or empty.
+// libp2p's peer.AddrInfo.UnmarshalJSON rejects an empty ID, so we unmarshal into this struct and convert via fromBootstrapPeerAddrInfos.
+type bootstrapPeerAddrInfo struct {
+	ID    string
+	Addrs []string
+}
+
+func fromBootstrapPeerAddrInfos(bootstrapPeerAddrInfos []bootstrapPeerAddrInfo) ([]peer.AddrInfo, error) {
+	out := make([]peer.AddrInfo, len(bootstrapPeerAddrInfos))
+	for i, bootstrapPeerAddrInfo := range bootstrapPeerAddrInfos {
+		addrs := make([]ma.Multiaddr, len(bootstrapPeerAddrInfo.Addrs))
+		for j, str := range bootstrapPeerAddrInfo.Addrs {
+			addr, err := ma.NewMultiaddr(str)
+			if err != nil {
+				return nil, err
+			}
+			addrs[j] = addr
+		}
+		out[i] = peer.AddrInfo{Addrs: addrs}
+		if bootstrapPeerAddrInfo.ID != "" {
+			id, err := peer.Decode(bootstrapPeerAddrInfo.ID)
+			if err != nil {
+				return nil, err
+			}
+			out[i].ID = id
+		}
+	}
+	return out, nil
 }

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -7,8 +7,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"math/big"
 	"net"
 	"net/http"
@@ -125,7 +125,10 @@ func TestHTTPBootstrap(t *testing.T) {
 		ID:    id,
 		Addrs: []ma.Multiaddr{parentAddr},
 	}
-	parentBs := NewHTTPBootstrapper(ln.Addr().String(), "")
+	peerURL, err := url.Parse("http://" + ln.Addr().String())
+	require.NoError(t, err)
+	parentBs, err := NewHTTPBootstrapper(ln.Addr().String(), *peerURL, url.URL{}, nil, nil, nil)
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(t.Context())
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -134,7 +137,8 @@ func TestHTTPBootstrap(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	childBs := NewHTTPBootstrapper(":", "http://"+ln.Addr().String())
+	childBs, err := NewHTTPBootstrapper("", *peerURL, url.URL{}, nil, nil, nil)
+	require.NoError(t, err)
 	addrInfos, err := childBs.Get(t.Context())
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
@@ -147,7 +151,7 @@ func TestHTTPBootstrap(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestExternalBootstrap(t *testing.T) {
+func TestHTTPBootstrapEndpoint(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -194,8 +198,14 @@ func TestExternalBootstrap(t *testing.T) {
 	clientBytes, err := x509.CreateCertificate(rand.Reader, clientCert, caCert, &clientPrivateKey.PublicKey, caPrivateKey)
 	require.NoError(t, err)
 
+	addr, err := ma.NewMultiaddr("/ip4/10.1.2.3")
+	require.NoError(t, err)
+	body, err := json.Marshal([]peer.AddrInfo{{Addrs: []ma.Multiaddr{addr}}})
+	require.NoError(t, err)
+
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `["10.1.2.3"]`)
+		//nolint:errcheck // ignore
+		w.Write(body)
 	}))
 	tlsCrt, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srvBytes}),
 		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(srvPrivateKey)}))
@@ -208,7 +218,8 @@ func TestExternalBootstrap(t *testing.T) {
 
 	srvUrl, err := url.Parse(srv.URL)
 	require.NoError(t, err)
-	bs, err := NewExternalBootstrapper(*srvUrl, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes}),
+	bs, err := NewHTTPBootstrapper("", url.URL{}, *srvUrl,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes}),
 		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientBytes}),
 		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientPrivateKey)}))
 	require.NoError(t, err)
@@ -226,4 +237,64 @@ func TestExternalBootstrap(t *testing.T) {
 	cancel()
 	err = g.Wait()
 	require.NoError(t, err)
+}
+
+func TestNewHTTPBootstrapperValidation(t *testing.T) {
+	t.Parallel()
+
+	someURL, err := url.Parse("http://10.1.2.3:1234")
+	require.NoError(t, err)
+	tests := []struct {
+		name    string
+		errMsg  string
+		peer    url.URL
+		url     url.URL
+		tlsCA   []byte
+		tlsCert []byte
+		tlsKey  []byte
+	}{
+		{
+			name:   "neither peer nor url set",
+			errMsg: "either peer or url must be set",
+		},
+		{
+			name:   "both peer and url set",
+			errMsg: "peer and url are mutually exclusive",
+			peer:   *someURL,
+			url:    *someURL,
+		},
+		{
+			name:   "malformed CA",
+			errMsg: "failed to parse CA certificate",
+			peer:   *someURL,
+			tlsCA:  []byte("not a pem"),
+		},
+		{
+			name:    "client cert without key",
+			errMsg:  "both client TLS certificate and client TLS key must be provided",
+			peer:    *someURL,
+			tlsCert: []byte("cert"),
+		},
+		{
+			name:   "client key without cert",
+			errMsg: "both client TLS certificate and client TLS key must be provided",
+			peer:   *someURL,
+			tlsKey: []byte("key"),
+		},
+		{
+			name:    "malformed client cert",
+			errMsg:  "failed to parse client certificate",
+			peer:    *someURL,
+			tlsCert: []byte("not a pem"),
+			tlsKey:  []byte("not a pem"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			bs, err := NewHTTPBootstrapper("", tt.peer, tt.url, tt.tlsCA, tt.tlsCert, tt.tlsKey)
+			require.ErrorContains(t, err, tt.errMsg)
+			require.Nil(t, bs)
+		})
+	}
 }

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -2,7 +2,18 @@ package routing
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -130,6 +141,87 @@ func TestHTTPBootstrap(t *testing.T) {
 	require.Len(t, addrInfos[0].Addrs, 1)
 	require.EqualT(t, parentAddrInfo.ID, addrInfos[0].ID)
 	require.EqualT(t, "{12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB: [/ip4/127.0.0.1/tcp/4001]}", addrInfos[0].String())
+
+	cancel()
+	err = g.Wait()
+	require.NoError(t, err)
+}
+
+func TestExternalBootstrap(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	g, gCtx := errgroup.WithContext(ctx)
+
+	caCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		IsCA:                  true,
+		Subject:               pkix.Name{CommonName: "ca", Organization: []string{"foo"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	caBytes, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caPrivateKey.PublicKey, caPrivateKey)
+	require.NoError(t, err)
+	svrCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "srv", Organization: []string{"foo"}},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	srvPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	srvBytes, err := x509.CreateCertificate(rand.Reader, svrCert, caCert, &srvPrivateKey.PublicKey, caPrivateKey)
+	require.NoError(t, err)
+	clientCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "bootstrap", Organization: []string{"foo"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	clientPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	clientBytes, err := x509.CreateCertificate(rand.Reader, clientCert, caCert, &clientPrivateKey.PublicKey, caPrivateKey)
+	require.NoError(t, err)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `["10.1.2.3"]`)
+	}))
+	tlsCrt, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srvBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(srvPrivateKey)}))
+	require.NoError(t, err)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{tlsCrt},
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	srvUrl, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	bs, err := NewExternalBootstrapper(*srvUrl, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientPrivateKey)}))
+	require.NoError(t, err)
+
+	g.Go(func() error {
+		return bs.Run(gCtx, peer.AddrInfo{})
+	})
+
+	addrInfos, err := bs.Get(ctx)
+	require.NoError(t, err)
+	require.Len(t, addrInfos, 1)
+	require.Len(t, addrInfos[0].Addrs, 1)
+	require.Equal(t, "{: [/ip4/10.1.2.3]}", addrInfos[0].String())
 
 	cancel()
 	err = g.Wait()


### PR DESCRIPTION
Spegel currently lacks a native bootstrap mechanism when running directly on a host, unlike Kubernetes deployments which rely on DNS bootstrapper.

This PR extends the HTTP bootstrapper so it can also be pointed at an external system that returns a set of bootstrap peers, enabling peer discovery in non-Kubernetes environments. It also includes optional mTLS support for secure communication with the external system.

The following flags are added:
- `--http-bootstrap-url` accepts a full URL of an external bootstrap endpoint (mutually exclusive with `--http-bootstrap-peer`, which keeps the existing peer-base-URL).
- `--http-bootstrap-ca`, `--http-bootstrap-tls-crt`, `--http-bootstrap-tls-key` add optional CA verification and mTLS for the bootstrap endpoint.

If `--http-bootstrap-addr` is omitted serving own `peer.AddrInfo` is disabled.

The HTTP bootstrap response format is a JSON array of `peer.AddrInfo` objects (the `ID` field may be omitted/empty).

Related to #829