### PR TITLE
 Hedge requests to peers to protect against tail latency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.0
 
 require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20250530080122-d0efc28a5723
+	github.com/HdrHistogram/hdrhistogram-go v1.2.0
 	github.com/alexflint/go-arg v1.6.1
 	github.com/containerd/containerd/api v1.10.0
 	github.com/containerd/containerd/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41G2q8KWhVGkNiY=
+github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=

--- a/internal/resilient/hedge.go
+++ b/internal/resilient/hedge.go
@@ -1,0 +1,65 @@
+package resilient
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/HdrHistogram/hdrhistogram-go"
+)
+
+// Hedger keeps track of durations and triggers hedges after the given quantile duration.
+type Hedger struct {
+	hist        *hdrhistogram.Histogram
+	percentiles []float64
+	initial     time.Duration
+	mx          sync.RWMutex
+}
+
+// NewHedger returns a hedger with the given quantile.
+func NewHedger(percentiles []float64, initial time.Duration) *Hedger {
+	hist := hdrhistogram.New(0, int64(500*time.Millisecond), 1)
+	return &Hedger{
+		percentiles: percentiles,
+		hist:        hist,
+		initial:     initial,
+	}
+}
+
+// Size returns the amount of times a hedge channel will be triggered.
+func (h *Hedger) Size() int {
+	return len(h.percentiles)
+}
+
+// Observe adds the duration to be used in hedge duration calculation.
+func (h *Hedger) Observe(d time.Duration) error {
+	h.mx.Lock()
+	defer h.mx.Unlock()
+	return h.hist.RecordValue(d.Milliseconds())
+}
+
+// Channel returns a channel which tirggers after the percentile hedge durations.
+func (h *Hedger) Channel(ctx context.Context) <-chan any {
+	ch := make(chan any, len(h.percentiles))
+	go func() {
+		start := time.Now()
+		for _, percentile := range h.percentiles {
+			h.mx.RLock()
+			hedgeDuration := time.Duration(h.hist.ValueAtPercentile(percentile)) * time.Millisecond
+			h.mx.RUnlock()
+			if hedgeDuration == 0 {
+				hedgeDuration = h.initial
+			}
+
+			d := max(hedgeDuration-time.Since(start), 0)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(d):
+			}
+
+			ch <- nil
+		}
+	}()
+	return ch
+}

--- a/internal/resilient/hedge_test.go
+++ b/internal/resilient/hedge_test.go
@@ -1,0 +1,66 @@
+package resilient
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHedger(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		observations []time.Duration
+		expected     []time.Duration
+	}{
+		{
+			name: "no observed values",
+			expected: []time.Duration{
+				100 * time.Millisecond,
+				100 * time.Millisecond,
+				100 * time.Millisecond,
+			},
+		},
+		{
+			name: "with observed values",
+			observations: []time.Duration{
+				50 * time.Millisecond,
+				100 * time.Millisecond,
+				150 * time.Millisecond,
+				200 * time.Millisecond,
+			},
+			expected: []time.Duration{
+				151 * time.Millisecond,
+				207 * time.Millisecond,
+				207 * time.Millisecond,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hedger := NewHedger([]float64{80, 90, 95}, 100*time.Millisecond)
+			require.Equal(t, 3, hedger.Size())
+			for _, d := range tt.observations {
+				err := hedger.Observe(d)
+				require.NoError(t, err)
+			}
+
+			synctest.Test(t, func(t *testing.T) {
+				ch := hedger.Channel(t.Context())
+				start := time.Now()
+				durations := []time.Duration{}
+				for range 3 {
+					_, ok := <-ch
+					require.True(t, ok)
+					durations = append(durations, time.Since(start))
+				}
+				require.Equal(t, tt.expected, durations)
+			})
+		})
+	}
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -85,6 +85,7 @@ type Statistics struct {
 
 type Registry struct {
 	bufferPool     *sync.Pool
+	hedger         *resilient.Hedger
 	ociStore       oci.Store
 	ociClient      *oci.Client
 	router         routing.Router
@@ -131,6 +132,7 @@ func NewRegistry(ociStore oci.Store, router routing.Router, opts ...RegistryOpti
 		password:       cfg.Password,
 		bufferPool:     bufferPool,
 		stats:          Statistics{},
+		hedger:         resilient.NewHedger([]float64{80, 85, 90}, 50*time.Millisecond),
 	}
 	return r, nil
 }
@@ -234,14 +236,11 @@ func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {
 	}
 }
 
-type MirrorErrorDetails struct {
-	Attempts int `json:"attempts"`
-}
-
 func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath, rw httpx.ResponseWriter) {
 	rw.SetAttrs(HandlerAttrKey, "mirror")
 
 	log := logr.FromContextOrDiscard(ctx).WithValues("ref", dist.Identifier(), "path", dist.URL().Path)
+	ctx = logr.NewContext(ctx, log)
 
 	defer func() {
 		if rw.Error() == nil {
@@ -253,15 +252,107 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 		}
 	}()
 
-	// Set timeout for non blob data requests.
-	fetchCtx := ctx
+	// Set max duration for non blob requests.
 	if dist.Method == http.MethodHead || dist.Kind == oci.DistributionKindManifest {
-		var fetchCancel context.CancelFunc
-		fetchCtx, fetchCancel = context.WithTimeout(ctx, 3*time.Second)
-		defer fetchCancel()
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
 	}
 
-	mirrorDetails := MirrorErrorDetails{
+	// Lookup peers for the given key.
+	iter, err := r.router.Lookup(ctx, dist.Identifier(), r.resolveRetries)
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	// Retry requests until success or timeout.
+	for {
+		done := func() bool {
+			res, err := r.raceFetch(ctx, iter, dist)
+			if err != nil {
+				rw.WriteError(http.StatusNotFound, err)
+				return true
+			}
+			defer httpx.DrainAndClose(res.rc)
+
+			if !rw.HeadersWritten() {
+				oci.WriteDescriptorToHeader(res.desc, rw.Header())
+
+				switch dist.Kind {
+				case oci.DistributionKindManifest:
+					rw.WriteHeader(http.StatusOK)
+				case oci.DistributionKindBlob:
+					rw.Header().Set(httpx.HeaderAcceptRanges, httpx.RangeUnit)
+					if dist.Range == nil {
+						rw.WriteHeader(http.StatusOK)
+					} else {
+						crng, err := httpx.ContentRangeFromRange(*dist.Range, res.desc.Size)
+						if err != nil {
+							rw.WriteError(http.StatusRequestedRangeNotSatisfiable, err)
+							return true
+						}
+						rw.Header().Set(httpx.HeaderContentType, httpx.ContentTypeBinary)
+						rw.Header().Set(httpx.HeaderContentRange, crng.String())
+						rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(crng.Length(), 10))
+						rw.WriteHeader(http.StatusPartialContent)
+					}
+				}
+			}
+			if dist.Method == http.MethodHead {
+				return true
+			}
+
+			// Copy the data to the response writer.
+			//nolint: errcheck // Ignore
+			buf := r.bufferPool.Get().(*[]byte)
+			defer r.bufferPool.Put(buf)
+			n, err := io.CopyBuffer(rw, res.rc, *buf)
+			if err != nil {
+				switch dist.Kind {
+				case oci.DistributionKindManifest:
+					log.Error(err, "copying of manifest data failed")
+					return true
+				case oci.DistributionKindBlob:
+					// TODO: Avoid modifying a pointer.
+					if dist.Range == nil {
+						dist.Range = &httpx.Range{
+							Start: ptr.To(int64(0)),
+							End:   ptr.To(res.desc.Size - 1),
+						}
+					}
+					dist.Range.Start = ptr.To(*dist.Range.Start + n)
+					log.Error(err, "copying of blob data failed")
+					return false
+				}
+			}
+			return true
+		}()
+		if done {
+			return
+		}
+	}
+}
+
+type mirrorErrorDetails struct {
+	Attempts int `json:"attempts"`
+}
+
+type fetchResponse struct {
+	rc   io.ReadCloser
+	desc ocispec.Descriptor
+	peer routing.Peer
+}
+
+type fetchFailure struct {
+	err  error
+	peer routing.Peer
+}
+
+func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, dist oci.DistributionPath) (fetchResponse, error) {
+	log := logr.FromContextOrDiscard(ctx)
+
+	errDetails := mirrorErrorDetails{
 		Attempts: 0,
 	}
 	errCode := map[oci.DistributionKind]oci.DistributionErrorCode{
@@ -269,128 +360,118 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 		oci.DistributionKindManifest: oci.ErrCodeManifestUnknown,
 	}[dist.Kind]
 
-	iter, err := r.router.Lookup(fetchCtx, dist.Identifier(), r.resolveRetries)
-	if err != nil {
-		respErr := oci.NewDistributionError(errCode, fmt.Sprintf("lookup failed for %s", dist.Identifier()), mirrorDetails)
-		rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
-		return
-	}
+	fetchCh, immediateCh := fetchChannel(ctx, r.hedger, iterator)
+	resCh := make(chan fetchResponse)
+	failureCh := make(chan fetchFailure)
 
-	retryOpts := []resilient.RetryOption{
-		resilient.WithOnRetry(func(attempt int, err error) {
-			log.Error(err, "retrying mirror request", "attempt", attempt)
-		}),
-	}
-	err = resilient.Retry(fetchCtx, 0, resilient.NoDelay(), func(ctx context.Context) error {
+	fetchCtxs := map[string]context.Context{}
+	fetchCancels := map[string]context.CancelFunc{}
+	defer func() {
+		for _, cancel := range fetchCancels {
+			cancel()
+		}
+	}()
+
+	for {
+		// We only want to return early when there are no inflight requests.
+		var idleTimeoutCh <-chan time.Time
+		var exhaustedCh <-chan any
+		if len(fetchCtxs) == 0 {
+			idleTimeoutCh = time.After(r.resolveTimeout)
+			exhaustedCh = iterator.Exhausted()
+		}
+
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
-		case <-iter.Exhausted():
-			return resilient.Unrecoverable(errors.New("iterator has become exhausted"))
-		case <-time.After(r.resolveTimeout):
-			return resilient.Unrecoverable(errors.New("waited too long for new peer"))
-		case <-iter.Ready():
-		}
-
-		peer, ok := iter.Acquire()
-		if !ok {
-			return errors.New("could not acquire peer")
-		}
-
-		mirrorDetails.Attempts += 1
-
-		type fetchResult struct {
-			rc   io.ReadCloser
-			desc ocispec.Descriptor
-		}
-		res, err := httpx.HappyEyeballs(ctx, peer.Addresses, func(ctx context.Context, ipAddr netip.Addr) (fetchResult, error) {
-			mirror := &url.URL{
-				Scheme: dist.Scheme,
-				Host:   netip.AddrPortFrom(ipAddr, peer.Metadata.RegistryPort).String(),
+			return fetchResponse{}, ctx.Err()
+		case <-exhaustedCh:
+			if errDetails.Attempts == 0 {
+				return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("could not find peer for %s", dist.Identifier()), errDetails)
 			}
-			fetchOpts := []oci.FetchOption{
-				oci.WithFetchHeader(HeaderSpegelMirrored, "true"),
-				oci.WithFetchMirror(mirror),
-				oci.WithFetchBasicAuth(r.username, r.password),
+			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("all request retries exhausted for %s", dist.Identifier()), errDetails)
+		case <-idleTimeoutCh:
+			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("waited too long for new peer with no inflight fetches for %s", dist.Identifier()), errDetails)
+		case <-fetchCh:
+			peer, ok := iterator.Acquire()
+			if !ok {
+				immediateCh <- false
+				continue
 			}
-			rc, desc, err := r.ociClient.Fetch(ctx, dist, fetchOpts...)
-			if err != nil {
-				return fetchResult{}, err
-			}
-			res := fetchResult{
-				desc: desc,
-				rc:   rc,
-			}
-			return res, nil
-		})
-		if err != nil {
-			iter.Remove(peer)
-			return fmt.Errorf("request to mirror failed: %w", err)
-		}
 
-		iter.Release(peer)
+			errDetails.Attempts += 1
 
-		defer httpx.DrainAndClose(res.rc)
-		if !rw.HeadersWritten() {
-			oci.WriteDescriptorToHeader(res.desc, rw.Header())
+			fetchCtx, fetchCancel := context.WithCancel(ctx)
+			fetchCtxs[peer.Host] = fetchCtx
+			fetchCancels[peer.Host] = fetchCancel
 
-			switch dist.Kind {
-			case oci.DistributionKindManifest:
-				rw.WriteHeader(http.StatusOK)
-			case oci.DistributionKindBlob:
-				rw.Header().Set(httpx.HeaderAcceptRanges, httpx.RangeUnit)
-				if dist.Range == nil {
-					rw.WriteHeader(http.StatusOK)
-				} else {
-					crng, err := httpx.ContentRangeFromRange(*dist.Range, res.desc.Size)
+			go func() {
+				start := time.Now()
+				res, err := httpx.HappyEyeballs(fetchCtx, peer.Addresses, func(ctx context.Context, ipAddr netip.Addr) (fetchResponse, error) {
+					mirror := &url.URL{
+						Scheme: dist.Scheme,
+						Host:   netip.AddrPortFrom(ipAddr, peer.Metadata.RegistryPort).String(),
+					}
+					fetchOpts := []oci.FetchOption{
+						oci.WithFetchHeader(HeaderSpegelMirrored, "true"),
+						oci.WithFetchMirror(mirror),
+						oci.WithFetchBasicAuth(r.username, r.password),
+					}
+					rc, desc, err := r.ociClient.Fetch(ctx, dist, fetchOpts...)
 					if err != nil {
-						rw.WriteError(http.StatusBadRequest, err)
-						return resilient.Unrecoverable(err)
+						return fetchResponse{}, err
 					}
-					rw.Header().Set(httpx.HeaderContentType, httpx.ContentTypeBinary)
-					rw.Header().Set(httpx.HeaderContentRange, crng.String())
-					rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(crng.Length(), 10))
-					rw.WriteHeader(http.StatusPartialContent)
-				}
-			}
-		}
-		if dist.Method == http.MethodHead {
-			return nil
-		}
+					res := fetchResponse{
+						peer: peer,
+						desc: desc,
+						rc:   rc,
+					}
+					return res, nil
+				})
+				if err != nil {
+					if fetchCtx.Err() != nil {
+						return
+					}
 
-		//nolint: errcheck // Ignore
-		buf := r.bufferPool.Get().(*[]byte)
-		defer r.bufferPool.Put(buf)
-		n, err := io.CopyBuffer(rw, res.rc, *buf)
-		if err != nil {
-			switch dist.Kind {
-			case oci.DistributionKindManifest:
-				return resilient.Unrecoverable(fmt.Errorf("copying of manifest data failed: %w", err))
-			case oci.DistributionKindBlob:
-				// TODO: Avoid modifying a pointer.
-				if dist.Range == nil {
-					dist.Range = &httpx.Range{
-						Start: ptr.To(int64(0)),
-						End:   ptr.To(res.desc.Size - 1),
+					iterator.Remove(peer)
+
+					failure := fetchFailure{
+						peer: peer,
+						err:  err,
 					}
+					select {
+					case <-fetchCtx.Done():
+					case failureCh <- failure:
+					}
+					return
 				}
-				dist.Range.Start = ptr.To(*dist.Range.Start + n)
-				return fmt.Errorf("copying of blob data failed: %w", err)
-			}
+
+				iterator.Release(peer)
+				err = r.hedger.Observe(time.Since(start))
+				if err != nil {
+					log.Error(err, "could not observe fetch duration for hedger")
+				}
+
+				select {
+				case <-fetchCtx.Done():
+					err = httpx.DrainAndClose(res.rc)
+					if err != nil {
+						log.Error(err, "could not drain and close")
+					}
+				case resCh <- res:
+				}
+			}()
+		case failure := <-failureCh:
+			// Remove context to indicate fetch is not inflight.
+			delete(fetchCtxs, failure.peer.Host)
+			delete(fetchCancels, failure.peer.Host)
+			log.Error(failure.err, "request to peer failed")
+			immediateCh <- true
+		case res := <-resCh:
+			// Remove context so successful request is not cancelled.
+			delete(fetchCtxs, res.peer.Host)
+			delete(fetchCancels, res.peer.Host)
+			return res, nil
 		}
-		return nil
-	}, retryOpts...)
-	if err != nil {
-		if !rw.HeadersWritten() {
-			respErr := oci.NewDistributionError(errCode, fmt.Sprintf("all request retries exhausted for %s", dist.Identifier()), mirrorDetails)
-			if mirrorDetails.Attempts == 0 {
-				respErr = oci.NewDistributionError(errCode, fmt.Sprintf("could not find peer for %s", dist.Identifier()), mirrorDetails)
-			}
-			rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
-		} else {
-			log.Error(err, "failure after headers written")
-		}
-		return
 	}
 }
 
@@ -513,4 +594,47 @@ func (r *Registry) blobHandler(ctx context.Context, dist oci.DistributionPath, r
 		logr.FromContextOrDiscard(ctx).Error(err, "failed to write blob")
 		return
 	}
+}
+
+func fetchChannel(ctx context.Context, hedger *resilient.Hedger, iterator *routing.Iterator) (<-chan any, chan<- bool) {
+	fetchCh := make(chan any)
+	immediateCh := make(chan bool, hedger.Size()+1)
+	immediateCh <- false
+	go func() {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		hedgeCount := 0
+		hedgeCh := hedger.Channel(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-hedgeCh:
+				hedgeCount += 1
+			case count := <-immediateCh:
+				if count {
+					hedgeCount += 1
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-iterator.Ready():
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case fetchCh <- nil:
+			}
+
+			// We dont want to trigger fetch more than want hedger would.
+			if hedgeCount == hedger.Size() {
+				return
+			}
+		}
+	}()
+	return fetchCh, immediateCh
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -9,19 +9,27 @@ import (
 	"net/netip"
 	"regexp"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/internal/ptr"
+	"github.com/spegel-org/spegel/internal/resilient"
+	"github.com/spegel-org/spegel/internal/testutil"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestRegistryOptions(t *testing.T) {
 	t.Parallel()
@@ -526,4 +534,60 @@ func (f *flakyReadSeekCloser) Read(p []byte) (int, error) {
 	}
 
 	return n, err
+}
+
+func TestFetchChannel(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		hedger := resilient.NewHedger([]float64{50, 90, 99}, time.Second)
+
+		iterator := routing.NewIterator()
+		iterator.Add(routing.Peer{Host: "foo"})
+
+		// Fetch triggers immediately and after a fixed time.
+		fetchCh, _ := fetchChannel(ctx, hedger, iterator)
+
+		start := time.Now()
+		synctest.Wait()
+		testutil.RequireChannelReceive(t, fetchCh)
+		require.Zero(t, time.Since(start))
+
+		for range 3 {
+			start = time.Now()
+			synctest.Wait()
+			time.Sleep(1 * time.Second)
+			synctest.Wait()
+			testutil.RequireChannelReceive(t, fetchCh)
+			require.Equal(t, time.Second, time.Since(start))
+		}
+
+		// Fetch skips hedges when immediate are called.
+		fetchCh, immediateCh := fetchChannel(ctx, hedger, iterator)
+		immediateCh <- true
+		immediateCh <- true
+		immediateCh <- false
+
+		for range 4 {
+			start = time.Now()
+			synctest.Wait()
+			testutil.RequireChannelReceive(t, fetchCh)
+			require.Zero(t, time.Since(start))
+		}
+
+		start = time.Now()
+		synctest.Wait()
+		time.Sleep(1 * time.Second)
+		synctest.Wait()
+		testutil.RequireChannelReceive(t, fetchCh)
+		require.Equal(t, time.Second, time.Since(start))
+
+		synctest.Wait()
+		time.Sleep(1 * time.Second)
+		synctest.Wait()
+		testutil.RequireChannelOpen(t, fetchCh)
+	})
 }

--- a/test/integration/containerd/go.mod
+++ b/test/integration/containerd/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	cyphar.com/go-pathrs v0.2.1 // indirect
+	github.com/HdrHistogram/hdrhistogram-go v1.2.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.14.0-rc.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/integration/containerd/go.sum
+++ b/test/integration/containerd/go.sum
@@ -6,6 +6,8 @@ cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcG
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41G2q8KWhVGkNiY=
+github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxzmlQKxKsQ=


### PR DESCRIPTION
This changes how we make requests to peer when mirroring a requests to protect against tail latency. The main reason large differences in latency occurs is mostly due to peers being removed but still being present in the DHT.

The logic that is implemented is meant to minimize latency while also reducing the amount of in flight requests. In the normal flow without hedges a request is immediately fired and the result is picked up in the result channel. Content is written back to the response and returned.

If the request takes too long to return a series of hedge requests will be triggered to race the original request. The first request to return is used to write to the response. When the response is being written to no hedge requests will be triggered. Response durations are measured and recorded with the hedger to determine the time to wait before hedging. There will be 3 hedge requests sent at p80, p90 and p95.

When a request dial succeeds but the actual request fails due to 404 or some other http status code the next request will be fired off immediately.

There are two failure conditions separate from the request timing out. These are only active when there are no in flight requests. The first is an idle timeout that sets the max amount of time doing nothing. The reason is that  the query can take a lot longer than expected to determine that no peer is found. To protect against this we chose to just assume no more peers will be returned after a set amount of idle. The second is a failure state when the query completes before the timeout and does not have any peers left. In this scenario the DHT has completed the walk and determined no peers can be found. As stated the failure conditions are only active when no requests are running to allow for all requests to complete.

Fixes #1193 
Closes #1195 