### PR TITLE
Refactor range header handling

### DIFF
--- a/internal/ptr/ptr.go
+++ b/internal/ptr/ptr.go
@@ -1,0 +1,6 @@
+package ptr
+
+// To converts the given value to a pointer to the value.
+func To[T any](v T) *T {
+	return &v
+}

--- a/internal/ptr/ptr_test.go
+++ b/internal/ptr/ptr_test.go
@@ -1,0 +1,16 @@
+package ptr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTo(t *testing.T) {
+	t.Parallel()
+
+	v := "hello world"
+	p := To(v)
+	require.Equal(t, v, *p)
+	require.Equal(t, &v, p)
+}

--- a/pkg/httpx/range.go
+++ b/pkg/httpx/range.go
@@ -8,28 +8,21 @@ import (
 	"strings"
 )
 
+// Expected unit of range and content range headers.
 const RangeUnit = "bytes"
 
+// Range represents a range header.
+// Both start and end are optional to support parsing without known content size.
 type Range struct {
-	Start int64 `json:"start"`
-	End   int64 `json:"end"`
+	Start *int64 `json:"start"`
+	End   *int64 `json:"end"`
 }
 
-func (rng Range) String() string {
-	return fmt.Sprintf("%s=%d-%d", RangeUnit, rng.Start, rng.End)
-}
-
-func (rng Range) Size() int64 {
-	return rng.End - rng.Start + 1
-}
-
-func ParseRangeHeader(header http.Header, size int64) (*Range, error) {
+// ParseRangeHeader parses header according to RFC 9110.
+func ParseRangeHeader(header http.Header) (*Range, error) {
 	h := header.Get(HeaderRange)
 	if h == "" {
 		return nil, nil
-	}
-	if size <= 0 {
-		return nil, fmt.Errorf("size %d cannot be equal or less than zero", size)
 	}
 	rangeUnitPrefix := RangeUnit + "="
 	if !strings.HasPrefix(h, rangeUnitPrefix) {
@@ -44,66 +37,115 @@ func ParseRangeHeader(header http.Header, size int64) (*Range, error) {
 		return nil, errors.New("invalid range format")
 	}
 
-	// Suffix byte range
-	if parts[0] == "" {
-		suffixLen, err := strconv.ParseInt(parts[1], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		if suffixLen <= 0 {
-			return nil, fmt.Errorf("invalid suffix range %d", suffixLen)
-		}
-		if suffixLen > size {
-			suffixLen = size
-		}
-		rng := Range{
-			Start: size - suffixLen,
-			End:   size - 1,
-		}
-		return &rng, nil
-	}
-
 	rng := Range{}
-	start, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		return nil, err
-	}
-	if start < 0 {
-		return nil, fmt.Errorf("invalid start %d", start)
-	}
-	rng.Start = start
-	if parts[1] == "" {
-		rng.End = size - 1
-	} else {
-		end, err := strconv.ParseInt(parts[1], 10, 64)
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		v, err := strconv.ParseInt(part, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		if end >= size {
-			end = size - 1
+
+		switch i {
+		case 0:
+			rng.Start = &v
+		case 1:
+			rng.End = &v
 		}
-		rng.End = end
 	}
-	if rng.Start > rng.End {
-		return nil, fmt.Errorf("start %d cannot be larger than end %d", rng.Start, rng.End)
+	if err := rng.Validate(); err != nil {
+		return nil, err
 	}
 	return &rng, nil
 }
 
+// Validate checks the content of range.
+func (rng Range) Validate() error {
+	if rng.Start == nil && rng.End != nil && *rng.End <= 0 {
+		return fmt.Errorf("suffix range %d cannot be less than one", *rng.End)
+	}
+	if rng.Start != nil && *rng.Start < 0 {
+		return fmt.Errorf("start range %d cannot be less than zero", *rng.Start)
+	}
+	if rng.End != nil && *rng.End < 0 {
+		return fmt.Errorf("end range %d cannot be less than zero", *rng.End)
+	}
+	if rng.Start != nil && rng.End != nil && *rng.Start > *rng.End {
+		return fmt.Errorf("start %d cannot be larger than end %d", *rng.Start, *rng.End)
+	}
+	if rng.Start == nil && rng.End == nil {
+		return errors.New("start and end range cannot both be empty")
+	}
+	return nil
+}
+
+// String returns range content as formatted header value.
+func (rng Range) String() string {
+	switch {
+	case rng.Start == nil:
+		return fmt.Sprintf("%s=-%d", RangeUnit, *rng.End)
+	case rng.End == nil:
+		return fmt.Sprintf("%s=%d-", RangeUnit, *rng.Start)
+	default:
+		return fmt.Sprintf("%s=%d-%d", RangeUnit, *rng.Start, *rng.End)
+	}
+}
+
+// ContentRange represents a content range header.
 type ContentRange struct {
 	Start int64
 	End   int64
 	Size  int64
 }
 
-func ContentRangeFromRange(rng Range, size int64) ContentRange {
-	return ContentRange{
-		Start: rng.Start,
-		End:   rng.End,
+// ContentRangeFromRange returns a content range from a given range and content size.
+// Start and end are normalized based on the given size and verified to be within bounds.
+func ContentRangeFromRange(rng Range, size int64) (ContentRange, error) {
+	if size <= 0 {
+		return ContentRange{}, fmt.Errorf("size %d cannot be equal or less than zero", size)
+	}
+	if err := rng.Validate(); err != nil {
+		return ContentRange{}, err
+	}
+
+	// Suffix length range.
+	if rng.Start == nil {
+		suffixLen := min(*rng.End, size)
+		crng := ContentRange{
+			Start: size - suffixLen,
+			End:   size - 1,
+			Size:  size,
+		}
+		return crng, nil
+	}
+
+	// Offset with unknown size.
+	if rng.End == nil {
+		crng := ContentRange{
+			Start: *rng.Start,
+			End:   size - 1,
+			Size:  size,
+		}
+		return crng, nil
+	}
+
+	// Known start and end range.
+	crng := ContentRange{
+		Start: *rng.Start,
+		End:   min(*rng.End, size-1),
 		Size:  size,
 	}
+	return crng, nil
 }
 
+// String returns content range content as formatted header value.
 func (crng ContentRange) String() string {
 	return fmt.Sprintf("%s %d-%d/%d", RangeUnit, crng.Start, crng.End, crng.Size)
+}
+
+// Length returns the byte size of the content within the range.
+// This should not be confused with size which is the total size of the content.
+func (crng ContentRange) Length() int64 {
+	return crng.End - crng.Start + 1
 }

--- a/pkg/httpx/range_test.go
+++ b/pkg/httpx/range_test.go
@@ -5,92 +5,61 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/spegel-org/spegel/internal/ptr"
 )
 
 func TestRange(t *testing.T) {
 	t.Parallel()
 
-	rng, err := ParseRangeHeader(http.Header{}, 0)
+	rng, err := ParseRangeHeader(http.Header{})
 	require.NoError(t, err)
 	require.Nil(t, rng)
 
-	//nolint: govet // Ignore fieldalignment for readability.
 	validTests := []struct {
 		value          string
-		size           int64
 		expectedRange  Range
 		expectedString string
-		expectedSize   int64
 	}{
 		{
 			value: "bytes=0-0",
-			size:  1,
 			expectedRange: Range{
-				Start: 0,
-				End:   0,
+				Start: ptr.To(int64(0)),
+				End:   ptr.To(int64(0)),
 			},
 			expectedString: "bytes=0-0",
-			expectedSize:   1,
 		},
 		{
 			value: "bytes=0-499",
-			size:  1000,
 			expectedRange: Range{
-				Start: 0,
-				End:   499,
+				Start: ptr.To(int64(0)),
+				End:   ptr.To(int64(499)),
 			},
 			expectedString: "bytes=0-499",
-			expectedSize:   500,
 		},
 		{
 			value: "bytes=500-999",
-			size:  1500,
 			expectedRange: Range{
-				Start: 500,
-				End:   999,
+				Start: ptr.To(int64(500)),
+				End:   ptr.To(int64(999)),
 			},
 			expectedString: "bytes=500-999",
-			expectedSize:   500,
 		},
 		{
 			value: "bytes=500-",
-			size:  1200,
 			expectedRange: Range{
-				Start: 500,
-				End:   1199,
+				Start: ptr.To(int64(500)),
+				End:   nil,
 			},
-			expectedString: "bytes=500-1199",
-			expectedSize:   700,
+			expectedString: "bytes=500-",
 		},
 		{
 			value: "bytes=-200",
-			size:  1000,
 			expectedRange: Range{
-				Start: 800,
-				End:   999,
+				Start: nil,
+				End:   ptr.To(int64(200)),
 			},
-			expectedString: "bytes=800-999",
-			expectedSize:   200,
-		},
-		{
-			value: "bytes=0-1000",
-			size:  1000,
-			expectedRange: Range{
-				Start: 0,
-				End:   999,
-			},
-			expectedString: "bytes=0-999",
-			expectedSize:   1000,
-		},
-		{
-			value: "bytes=999-1000",
-			size:  1000,
-			expectedRange: Range{
-				Start: 999,
-				End:   999,
-			},
-			expectedString: "bytes=999-999",
-			expectedSize:   1,
+			expectedString: "bytes=-200",
 		},
 	}
 	for _, tt := range validTests {
@@ -100,53 +69,39 @@ func TestRange(t *testing.T) {
 			header := http.Header{
 				HeaderRange: {tt.value},
 			}
-			r, err := ParseRangeHeader(header, tt.size)
+			r, err := ParseRangeHeader(header)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedRange, *r)
 			require.Equal(t, tt.expectedString, r.String())
-			require.Equal(t, tt.expectedSize, r.Size())
 		})
 	}
 
-	//nolint: govet // Ignore fieldalignment for readability.
 	errorTests := []struct {
 		value    string
-		size     int64
 		expected string
 	}{
 		{
 			value:    "bytes=",
-			size:     10,
 			expected: "invalid range format",
 		},
 		{
 			value:    "bytes=abc-def",
-			size:     10,
 			expected: "strconv.ParseInt: parsing \"abc\": invalid syntax",
 		},
 		{
 			value:    "bytes=-0",
-			size:     10,
-			expected: "invalid suffix range 0",
+			expected: "suffix range 0 cannot be less than one",
 		},
 		{
 			value:    "bytes=100-50",
-			size:     400,
 			expected: "start 100 cannot be larger than end 50",
 		},
 		{
 			value:    "bytes=0-499,500-999",
-			size:     1500,
 			expected: "multiple ranges not supported",
 		},
 		{
-			value:    "bytes=0-999",
-			size:     -1,
-			expected: "size -1 cannot be equal or less than zero",
-		},
-		{
 			value:    "foobar=0-1000",
-			size:     1000,
 			expected: "invalid range unit",
 		},
 	}
@@ -157,20 +112,107 @@ func TestRange(t *testing.T) {
 			header := http.Header{
 				HeaderRange: {tt.value},
 			}
-			_, err := ParseRangeHeader(header, tt.size)
+			_, err := ParseRangeHeader(header)
 			require.EqualError(t, err, tt.expected)
 		})
 	}
+
+	err = Range{Start: ptr.To(int64(-1)), End: ptr.To(int64(0))}.Validate()
+	require.EqualError(t, err, "start range -1 cannot be less than zero")
+	err = Range{Start: ptr.To(int64(0)), End: ptr.To(int64(-1))}.Validate()
+	require.EqualError(t, err, "end range -1 cannot be less than zero")
 }
 
 func TestContentRange(t *testing.T) {
 	t.Parallel()
 
-	rng := Range{
-		Start: 0,
-		End:   50,
+	//nolint: govet // Ignore fieldalignment for readability.
+	tests := []struct {
+		value          string
+		size           int64
+		expectedString string
+		expectedLength int64
+	}{
+		{
+			value:          "bytes=0-0",
+			size:           1000,
+			expectedString: "bytes 0-0/1000",
+			expectedLength: 1,
+		},
+		{
+			value:          "bytes=0-9",
+			size:           1000,
+			expectedString: "bytes 0-9/1000",
+			expectedLength: 10,
+		},
+		{
+			value:          "bytes=500-",
+			size:           1000,
+			expectedString: "bytes 500-999/1000",
+			expectedLength: 500,
+		},
+		{
+			value:          "bytes=-500",
+			size:           1000,
+			expectedString: "bytes 500-999/1000",
+			expectedLength: 500,
+		},
+		{
+			value:          "bytes=-1000",
+			size:           1000,
+			expectedString: "bytes 0-999/1000",
+			expectedLength: 1000,
+		},
+		{
+			value:          "bytes=0-999",
+			size:           1000,
+			expectedString: "bytes 0-999/1000",
+			expectedLength: 1000,
+		},
+		{
+			value:          "bytes=900-1500",
+			size:           1000,
+			expectedString: "bytes 900-999/1000",
+			expectedLength: 100,
+		},
+		{
+			value:          "bytes=-1",
+			size:           1000,
+			expectedString: "bytes 999-999/1000",
+			expectedLength: 1,
+		},
+		{
+			value:          "bytes=100-199",
+			size:           1000,
+			expectedString: "bytes 100-199/1000",
+			expectedLength: 100,
+		},
+		{
+			value:          "bytes=0-",
+			size:           1000,
+			expectedString: "bytes 0-999/1000",
+			expectedLength: 1000,
+		},
 	}
-	crng := ContentRangeFromRange(rng, 100)
-	expected := "bytes 0-50/100"
-	require.Equal(t, expected, crng.String())
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+
+			header := http.Header{
+				HeaderRange: {tt.value},
+			}
+			rng, err := ParseRangeHeader(header)
+			require.NoError(t, err)
+			crng, err := ContentRangeFromRange(*rng, tt.size)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedString, crng.String())
+			require.Equal(t, tt.expectedLength, crng.Length())
+		})
+	}
+
+	_, err := ContentRangeFromRange(Range{}, -1)
+	require.EqualError(t, err, "size -1 cannot be equal or less than zero")
+
+	_, err = ContentRangeFromRange(Range{Start: nil, End: nil}, 100)
+	require.EqualError(t, err, "start and end range cannot both be empty")
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -18,6 +18,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/spegel-org/spegel/internal/option"
+	"github.com/spegel-org/spegel/internal/ptr"
 	"github.com/spegel-org/spegel/internal/resilient"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/metrics"
@@ -252,6 +253,13 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 		}
 	}()
 
+	// Range for initial request and to resume failed peer requests.
+	rng, err := httpx.ParseRangeHeader(req.Header)
+	if err != nil {
+		rw.WriteError(http.StatusBadRequest, err)
+		return
+	}
+
 	mirrorDetails := MirrorErrorDetails{
 		Attempts: 0,
 	}
@@ -268,9 +276,6 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 		rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
 		return
 	}
-
-	// Resume range for when blobs fail midway through copying.
-	var resumeRng *httpx.Range
 
 	// Set timeout for non blob data requests.
 	fetchCtx := req.Context()
@@ -311,10 +316,8 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 				oci.WithFetchBasicAuth(r.username, r.password),
 			}
 			// Override range header with resume range if set.
-			if resumeRng != nil {
-				fetchOpts = append(fetchOpts, oci.WithFetchRange(*resumeRng))
-			} else if h := req.Header.Get(httpx.HeaderRange); h != "" {
-				fetchOpts = append(fetchOpts, oci.WithFetchHeader(httpx.HeaderRange, h))
+			if rng != nil {
+				fetchOpts = append(fetchOpts, oci.WithFetchRange(*rng))
 			}
 			rc, desc, err := r.ociClient.Fetch(fetchCtx, req.Method, dist, fetchOpts...)
 			if err != nil {
@@ -341,19 +344,18 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 			case oci.DistributionKindManifest:
 				rw.WriteHeader(http.StatusOK)
 			case oci.DistributionKindBlob:
-				rng, err := httpx.ParseRangeHeader(req.Header, desc.Size)
-				if err != nil {
-					return resilient.Unrecoverable(err)
-				}
-				resumeRng = rng
-
 				rw.Header().Set(httpx.HeaderAcceptRanges, httpx.RangeUnit)
 				if rng == nil {
 					rw.WriteHeader(http.StatusOK)
 				} else {
+					crng, err := httpx.ContentRangeFromRange(*rng, desc.Size)
+					if err != nil {
+						rw.WriteError(http.StatusBadRequest, err)
+						return resilient.Unrecoverable(err)
+					}
 					rw.Header().Set(httpx.HeaderContentType, httpx.ContentTypeBinary)
-					rw.Header().Set(httpx.HeaderContentRange, httpx.ContentRangeFromRange(*rng, desc.Size).String())
-					rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(rng.Size(), 10))
+					rw.Header().Set(httpx.HeaderContentRange, crng.String())
+					rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(crng.Length(), 10))
 					rw.WriteHeader(http.StatusPartialContent)
 				}
 			}
@@ -371,12 +373,13 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 			case oci.DistributionKindManifest:
 				return resilient.Unrecoverable(fmt.Errorf("copying of manifest data failed: %w", err))
 			case oci.DistributionKindBlob:
-				if resumeRng == nil {
-					resumeRng = &httpx.Range{
-						End: desc.Size - 1,
+				if rng == nil {
+					rng = &httpx.Range{
+						Start: ptr.To(int64(0)),
+						End:   ptr.To(desc.Size - 1),
 					}
 				}
-				resumeRng.Start += n
+				rng.Start = ptr.To(*rng.Start + n)
 				balancer.Remove(peer)
 				return fmt.Errorf("copying of blob data failed: %w", err)
 			}
@@ -448,6 +451,12 @@ func (r *Registry) manifestHandler(rw httpx.ResponseWriter, req *http.Request, d
 func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath) {
 	rw.SetAttrs(HandlerAttrKey, "blob")
 
+	rng, err := httpx.ParseRangeHeader(req.Header)
+	if err != nil {
+		rw.WriteError(http.StatusBadRequest, err)
+		return
+	}
+
 	desc, err := r.ociStore.Descriptor(req.Context(), dist.Digest)
 	if err != nil {
 		respErr := oci.NewDistributionError(oci.ErrCodeBlobUnknown, fmt.Sprintf("could not get blob %s", dist.Digest), nil)
@@ -460,25 +469,29 @@ func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist 
 		return
 	}
 
-	rng, err := httpx.ParseRangeHeader(req.Header, desc.Size)
-	if err != nil {
-		rw.WriteError(http.StatusBadRequest, err)
-		return
+	var crng *httpx.ContentRange
+	if rng != nil {
+		v, err := httpx.ContentRangeFromRange(*rng, desc.Size)
+		if err != nil {
+			rw.WriteError(http.StatusBadRequest, err)
+			return
+		}
+		crng = &v
 	}
 
 	rw.Header().Set(oci.HeaderDockerDigest, dist.Digest.String())
 	rw.Header().Set(oci.HeaderNamespace, dist.Registry)
 	rw.Header().Set(httpx.HeaderAcceptRanges, httpx.RangeUnit)
 	var status int
-	if rng == nil {
+	if crng == nil {
 		status = http.StatusOK
 		rw.Header().Set(httpx.HeaderContentType, desc.MediaType)
 		rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(desc.Size, 10))
 	} else {
 		status = http.StatusPartialContent
 		rw.Header().Set(httpx.HeaderContentType, httpx.ContentTypeBinary)
-		rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(rng.Size(), 10))
-		rw.Header().Set(httpx.HeaderContentRange, httpx.ContentRangeFromRange(*rng, desc.Size).String())
+		rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(crng.Length(), 10))
+		rw.Header().Set(httpx.HeaderContentRange, crng.String())
 	}
 	if req.Method == http.MethodHead {
 		rw.WriteHeader(status)
@@ -493,13 +506,13 @@ func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist 
 	}
 	defer rc.Close()
 	var src io.Reader = rc
-	if rng != nil {
-		_, err := rc.Seek(rng.Start, io.SeekStart)
+	if crng != nil {
+		_, err := rc.Seek(crng.Start, io.SeekStart)
 		if err != nil {
 			rw.WriteError(http.StatusInternalServerError, err)
 			return
 		}
-		src = io.LimitReader(rc, rng.Size())
+		src = io.LimitReader(rc, crng.Length())
 	}
 	rw.WriteHeader(status)
 	_, err = io.Copy(rw, src)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spegel-org/spegel/internal/option"
+	"github.com/spegel-org/spegel/internal/ptr"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
@@ -392,7 +393,7 @@ func TestRegistryHandler(t *testing.T) {
 			name:             "blob request with range",
 			key:              "sha256:ac73670af3abed54ac6fb4695131f4099be9fbe39d6076c5d0264a6bbdae9d83",
 			distributionKind: oci.DistributionKindBlob,
-			rng:              &httpx.Range{Start: 1, End: 3},
+			rng:              &httpx.Range{Start: ptr.To(int64(1)), End: ptr.To(int64(3))},
 			expectedStatus:   http.StatusPartialContent,
 			expectedBody:     []byte{0x8b, 0x8, 0x0},
 			expectedHeaders: http.Header{
@@ -433,7 +434,7 @@ func TestRegistryHandler(t *testing.T) {
 			name:             "flaky reader with range should return partial",
 			key:              "sha256:c8dc81dabe7ad5e801191aade7c87fb806d0ef9ce9b699d2e9598337f57f14d0",
 			distributionKind: oci.DistributionKindBlob,
-			rng:              &httpx.Range{Start: 2, End: 15},
+			rng:              &httpx.Range{Start: ptr.To(int64(2)), End: ptr.To(int64(15))},
 			expectedStatus:   http.StatusPartialContent,
 			expectedBody:     []byte("rem Ipsum Dolo"),
 			expectedHeaders: http.Header{


### PR DESCRIPTION
This change will help with the work in #1258 by removing the need to know the size of content when parsing range requests. This requirement made some logic a bit complicated to deal with. Instead this logic has been shifted to the content range header which is created from a range header. There we do validation that the requested content ranges are within bounds.