### PR TITLE
Change range to retry for token fetching

### DIFF
--- a/internal/resilient/retry.go
+++ b/internal/resilient/retry.go
@@ -19,6 +19,12 @@ func Unrecoverable(err error) error {
 
 type DelayFunc func(attempt int, err error) time.Duration
 
+func NoDelay() DelayFunc {
+	return func(int, error) time.Duration {
+		return 0
+	}
+}
+
 func FixedDelay(delay time.Duration) DelayFunc {
 	return func(int, error) time.Duration {
 		return delay
@@ -38,7 +44,8 @@ func BackoffDelay(start, limit time.Duration) DelayFunc {
 type OnRetryFunc func(attempt int, err error)
 
 type RetryConfig struct {
-	OnRetry OnRetryFunc
+	OnRetry       OnRetryFunc
+	LastErrorOnly bool
 }
 
 type RetryOption = option.Option[RetryConfig]
@@ -46,6 +53,13 @@ type RetryOption = option.Option[RetryConfig]
 func WithOnRetry(onRetry OnRetryFunc) RetryOption {
 	return func(cfg *RetryConfig) error {
 		cfg.OnRetry = onRetry
+		return nil
+	}
+}
+
+func WithLastErrorOnly() RetryOption {
+	return func(cfg *RetryConfig) error {
+		cfg.LastErrorOnly = true
 		return nil
 	}
 }
@@ -120,5 +134,9 @@ func RetryValue[T any](ctx context.Context, attempts int, delay DelayFunc, fn fu
 			cfg.OnRetry(len(errs), err)
 		}
 	}
-	return zeroT, errs[len(errs)-1]
+
+	if cfg.LastErrorOnly {
+		return zeroT, errs[len(errs)-1]
+	}
+	return zeroT, errors.Join(errs...)
 }

--- a/internal/resilient/retry_test.go
+++ b/internal/resilient/retry_test.go
@@ -62,7 +62,7 @@ func TestRetry(t *testing.T) {
 	err = Retry(t.Context(), 3, delay, func(ctx context.Context) error {
 		return expected
 	})
-	require.ErrorIs(t, expected, err)
+	require.EqualError(t, err, "fail\nfail\nfail")
 
 	expected = errors.New("unrecoverable")
 	i := 0
@@ -73,7 +73,7 @@ func TestRetry(t *testing.T) {
 		i += 1
 		return errors.New("retry error")
 	})
-	require.ErrorIs(t, expected, err)
+	require.EqualError(t, err, "retry error\nretry error\nretry error\nunrecoverable")
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -22,6 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/spegel-org/spegel/internal/option"
+	"github.com/spegel-org/spegel/internal/resilient"
 	"github.com/spegel-org/spegel/pkg/httpx"
 )
 
@@ -315,10 +316,12 @@ func (c *Client) Fetch(ctx context.Context, method string, dist DistributionPath
 		u.Host = "registry-1.docker.io"
 	}
 
-	for range 2 {
+	var body io.ReadCloser
+	var desc ocispec.Descriptor
+	err = resilient.Retry(ctx, 2, resilient.NoDelay(), func(ctx context.Context) error {
 		req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
 		if err != nil {
-			return nil, ocispec.Descriptor{}, err
+			return resilient.Unrecoverable(err)
 		}
 		httpx.CopyHeader(req.Header, cfg.Header)
 		req.SetBasicAuth(cfg.Username, cfg.Password)
@@ -337,22 +340,22 @@ func (c *Client) Fetch(ctx context.Context, method string, dist DistributionPath
 		}
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			return nil, ocispec.Descriptor{}, err
+			return resilient.Unrecoverable(err)
 		}
 		if resp.StatusCode == http.StatusUnauthorized {
 			c.tokenCache.Delete(tcKey)
 			wwwAuth := resp.Header.Get(httpx.HeaderWWWAuthenticate)
 			token, err = getBearerToken(ctx, c.httpClient, dist.Repository, wwwAuth)
 			if err != nil {
-				return nil, ocispec.Descriptor{}, err
+				return resilient.Unrecoverable(err)
 			}
 			c.tokenCache.Store(tcKey, token)
-			continue
+			return errors.New("token refresh")
 		}
 		err = httpx.CheckResponseStatus(resp, http.StatusOK, http.StatusPartialContent)
 		if err != nil {
 			httpx.DrainAndClose(resp.Body)
-			return nil, ocispec.Descriptor{}, err
+			return resilient.Unrecoverable(err)
 		}
 
 		// Handle optional headers for blobs.
@@ -366,14 +369,18 @@ func (c *Client) Fetch(ctx context.Context, method string, dist DistributionPath
 			}
 		}
 
-		desc, err := DescriptorFromHeader(header)
+		desc, err = DescriptorFromHeader(header)
 		if err != nil {
 			httpx.DrainAndClose(resp.Body)
-			return nil, ocispec.Descriptor{}, err
+			return resilient.Unrecoverable(err)
 		}
-		return resp.Body, desc, nil
+		body = resp.Body
+		return nil
+	})
+	if err != nil {
+		return nil, ocispec.Descriptor{}, err
 	}
-	return nil, ocispec.Descriptor{}, errors.New("could not perform request")
+	return body, desc, nil
 }
 
 func getBearerToken(ctx context.Context, client *http.Client, repository, wwwAuth string) (string, error) {

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -391,7 +391,7 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 				return resilient.Unrecoverable(err)
 			}
 			return fmt.Errorf("manifest with digest %s still exists", img.Digest.String())
-		})
+		}, resilient.WithLastErrorOnly())
 		if err != nil {
 			return nil, fmt.Errorf("image manifest has not been deleted: %w", err)
 		}

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -227,6 +227,7 @@ func (r *P2PRouter) Run(ctx context.Context) error {
 					resilient.WithOnRetry(func(attempt int, err error) {
 						log.Error(err, "failed to run bootstrap", "attempts", attempt+1)
 					}),
+					resilient.WithLastErrorOnly(),
 				}
 				err := resilient.Retry(gCtx, 0, resilient.BackoffDelay(50*time.Millisecond, 10*time.Second), func(ctx context.Context) error {
 					if !r.connectivityGate.IsOpen() {


### PR DESCRIPTION
This changes the retry logic for the token fetching to use the resilient package.