### PR TITLE
Refactor distribution to include more request parameters

### DIFF
--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -119,22 +119,17 @@ func WithPullPlatform(platform ocispec.Platform) PullOption {
 	}
 }
 
-type FetchConfig struct {
-	Range *httpx.Range
-	CommonConfig
-}
-
-type FetchOption = option.Option[FetchConfig]
+type FetchOption = option.Option[CommonConfig]
 
 func WithFetchMirror(mirror *url.URL) FetchOption {
-	return func(cfg *FetchConfig) error {
+	return func(cfg *CommonConfig) error {
 		cfg.Mirror = mirror
 		return nil
 	}
 }
 
 func WithFetchHeader(k, v string) FetchOption {
-	return func(cfg *FetchConfig) error {
+	return func(cfg *CommonConfig) error {
 		if cfg.Header == nil {
 			cfg.Header = http.Header{}
 		}
@@ -144,16 +139,9 @@ func WithFetchHeader(k, v string) FetchOption {
 }
 
 func WithFetchBasicAuth(username, password string) FetchOption {
-	return func(cfg *FetchConfig) error {
+	return func(cfg *CommonConfig) error {
 		cfg.Username = username
 		cfg.Password = password
-		return nil
-	}
-}
-
-func WithFetchRange(rng httpx.Range) FetchOption {
-	return func(cfg *FetchConfig) error {
-		cfg.Range = &rng
 		return nil
 	}
 }
@@ -173,22 +161,29 @@ func (c *Client) Pull(ctx context.Context, img Image, opts ...PullOption) ([]Pul
 	if err != nil {
 		return nil, err
 	}
-	fetchOpt := func(fetchCfg *FetchConfig) error {
-		fetchCfg.CommonConfig = cfg.CommonConfig
+	fetchOpt := func(commonCfg *CommonConfig) error {
+		commonCfg.Mirror = cfg.Mirror
+		commonCfg.Header = cfg.Header
+		commonCfg.Username = cfg.Username
+		commonCfg.Password = cfg.Password
 		return nil
 	}
 
-	pullMetrics := []PullMetric{}
-	queue := []DistributionPath{
-		img.DistributionPath(),
+	imgDist, err := img.DistributionPath("http", http.MethodGet)
+	if err != nil {
+		return nil, err
 	}
+	queue := []DistributionPath{
+		imgDist,
+	}
+	pullMetrics := []PullMetric{}
 	for len(queue) > 0 {
 		dist := queue[0]
 		queue = queue[1:]
 
 		start := time.Now()
 		desc, err := func() (ocispec.Descriptor, error) {
-			rc, desc, err := c.Get(ctx, dist, fetchOpt)
+			rc, desc, err := c.Fetch(ctx, dist, fetchOpt)
 			if err != nil {
 				return ocispec.Descriptor{}, err
 			}
@@ -220,14 +215,16 @@ func (c *Client) Pull(ctx context.Context, img Image, opts ...PullOption) ([]Pul
 						if !platforms.Only(cfg.Platform).Match(*m.Platform) {
 							continue
 						}
-						queue = append(queue, DistributionPath{
-							Kind: DistributionKindManifest,
-							Reference: Reference{
-								Registry:   dist.Registry,
-								Repository: dist.Repository,
-								Digest:     m.Digest,
-							},
-						})
+						nextRef := Reference{
+							Registry:   dist.Registry,
+							Repository: dist.Repository,
+							Digest:     m.Digest,
+						}
+						nextDist, err := NewDistributionPath(nextRef, DistributionKindManifest, dist.Scheme, http.MethodGet, nil)
+						if err != nil {
+							return ocispec.Descriptor{}, err
+						}
+						queue = append(queue, nextDist)
 					}
 				case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
 					var manifest ocispec.Manifest
@@ -235,23 +232,27 @@ func (c *Client) Pull(ctx context.Context, img Image, opts ...PullOption) ([]Pul
 					if err != nil {
 						return ocispec.Descriptor{}, err
 					}
-					queue = append(queue, DistributionPath{
-						Kind: DistributionKindBlob,
-						Reference: Reference{
+					nextRef := Reference{
+						Registry:   dist.Registry,
+						Repository: dist.Repository,
+						Digest:     manifest.Config.Digest,
+					}
+					nextDist, err := NewDistributionPath(nextRef, DistributionKindBlob, dist.Scheme, http.MethodGet, nil)
+					if err != nil {
+						return ocispec.Descriptor{}, err
+					}
+					queue = append(queue, nextDist)
+					for _, layer := range manifest.Layers {
+						nextRef := Reference{
 							Registry:   dist.Registry,
 							Repository: dist.Repository,
-							Digest:     manifest.Config.Digest,
-						},
-					})
-					for _, layer := range manifest.Layers {
-						queue = append(queue, DistributionPath{
-							Kind: DistributionKindBlob,
-							Reference: Reference{
-								Registry:   dist.Registry,
-								Repository: dist.Repository,
-								Digest:     layer.Digest,
-							},
-						})
+							Digest:     layer.Digest,
+						}
+						nextDist, err := NewDistributionPath(nextRef, DistributionKindBlob, dist.Scheme, http.MethodGet, nil)
+						if err != nil {
+							return ocispec.Descriptor{}, err
+						}
+						queue = append(queue, nextDist)
 					}
 				}
 			}
@@ -273,35 +274,15 @@ func (c *Client) Pull(ctx context.Context, img Image, opts ...PullOption) ([]Pul
 	return pullMetrics, nil
 }
 
-func (c *Client) Head(ctx context.Context, dist DistributionPath, opts ...FetchOption) (ocispec.Descriptor, error) {
-	rc, desc, err := c.Fetch(ctx, http.MethodHead, dist, opts...)
-	if err != nil {
-		return ocispec.Descriptor{}, err
-	}
-	defer httpx.DrainAndClose(rc)
-	return desc, nil
-}
-
-func (c *Client) Get(ctx context.Context, dist DistributionPath, opts ...FetchOption) (io.ReadCloser, ocispec.Descriptor, error) {
-	rc, desc, err := c.Fetch(ctx, http.MethodGet, dist, opts...)
-	if err != nil {
+func (c *Client) Fetch(ctx context.Context, dist DistributionPath, opts ...FetchOption) (io.ReadCloser, ocispec.Descriptor, error) {
+	if err := dist.Validate(); err != nil {
 		return nil, ocispec.Descriptor{}, err
 	}
-	return rc, desc, nil
-}
 
-func (c *Client) Fetch(ctx context.Context, method string, dist DistributionPath, opts ...FetchOption) (io.ReadCloser, ocispec.Descriptor, error) {
-	if method != http.MethodHead && method != http.MethodGet {
-		return nil, ocispec.Descriptor{}, errors.New("fetch only supports HEAD and GET requests")
-	}
-
-	cfg := FetchConfig{}
+	cfg := CommonConfig{}
 	err := option.Apply(&cfg, opts...)
 	if err != nil {
 		return nil, ocispec.Descriptor{}, err
-	}
-	if dist.Kind == DistributionKindManifest && cfg.Range != nil {
-		return nil, ocispec.Descriptor{}, errors.New("cannot make range requests for manifests")
 	}
 
 	tcKey := dist.Registry + dist.Repository
@@ -319,7 +300,7 @@ func (c *Client) Fetch(ctx context.Context, method string, dist DistributionPath
 	var body io.ReadCloser
 	var desc ocispec.Descriptor
 	err = resilient.Retry(ctx, 2, resilient.NoDelay(), func(ctx context.Context) error {
-		req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, dist.Method, u.String(), nil)
 		if err != nil {
 			return resilient.Unrecoverable(err)
 		}
@@ -330,8 +311,8 @@ func (c *Client) Fetch(ctx context.Context, method string, dist DistributionPath
 		req.Header.Add(httpx.HeaderAccept, images.MediaTypeDockerSchema2Manifest)
 		req.Header.Add(httpx.HeaderAccept, ocispec.MediaTypeImageIndex)
 		req.Header.Add(httpx.HeaderAccept, images.MediaTypeDockerSchema2ManifestList)
-		if cfg.Range != nil {
-			req.Header.Add(httpx.HeaderRange, cfg.Range.String())
+		if dist.Range != nil {
+			req.Header.Add(httpx.HeaderRange, dist.Range.String())
 		}
 		token, ok := c.tokenCache.Load(tcKey)
 		if ok {

--- a/pkg/oci/client_test.go
+++ b/pkg/oci/client_test.go
@@ -94,9 +94,9 @@ func TestClient(t *testing.T) {
 		Repository: img.Repository,
 		Digest:     blobs[0].Digest,
 	}
-	dist, err := NewDistributionPath(ref, DistributionKindBlob)
+	dist, err := NewDistributionPath(ref, DistributionKindBlob, "http", http.MethodHead, nil)
 	require.NoError(t, err)
-	desc, err := ociClient.Head(t.Context(), dist, WithFetchMirror(mirror))
+	_, desc, err := ociClient.Fetch(t.Context(), dist, WithFetchMirror(mirror))
 	require.NoError(t, err)
 	require.Equal(t, dist.Digest, desc.Digest)
 	require.Equal(t, httpx.ContentTypeBinary, desc.MediaType)

--- a/pkg/oci/distribution.go
+++ b/pkg/oci/distribution.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 
@@ -33,10 +34,13 @@ const (
 // DistributionPath contains the individual parameters from a OCI distribution spec request.
 type DistributionPath struct {
 	Reference
-	Kind DistributionKind
+	Range  *httpx.Range
+	Scheme string
+	Method string
+	Kind   DistributionKind
 }
 
-func NewDistributionPath(ref Reference, kind DistributionKind) (DistributionPath, error) {
+func NewDistributionPath(ref Reference, kind DistributionKind, scheme, method string, rng *httpx.Range) (DistributionPath, error) {
 	if err := ref.Validate(); err != nil {
 		return DistributionPath{}, err
 	}
@@ -49,12 +53,25 @@ func NewDistributionPath(ref Reference, kind DistributionKind) (DistributionPath
 	dist := DistributionPath{
 		Kind:      kind,
 		Reference: ref,
+		Scheme:    scheme,
+		Method:    method,
+		Range:     rng,
+	}
+	if err := dist.Validate(); err != nil {
+		return DistributionPath{}, err
 	}
 	return dist, nil
 }
 
-func (d DistributionPath) String() string {
-	return d.URL().String()
+// Validate returns an error if parameter combinations are incorrect.
+func (d DistributionPath) Validate() error {
+	if d.Method != http.MethodHead && d.Method != http.MethodGet {
+		return errors.New("fetch only supports HEAD and GET requests")
+	}
+	if d.Kind == DistributionKindManifest && d.Range != nil {
+		return errors.New("cannot make range requests for manifests")
+	}
+	return nil
 }
 
 // URL returns the reconstructed URL containing the path and query parameters.
@@ -64,7 +81,7 @@ func (d DistributionPath) URL() *url.URL {
 		ref = d.Tag
 	}
 	return &url.URL{
-		Scheme:   "https",
+		Scheme:   d.Scheme,
 		Host:     d.Registry,
 		Path:     fmt.Sprintf("/v2/%s/%s/%s", d.Repository, d.Kind, ref),
 		RawQuery: fmt.Sprintf("ns=%s", d.Registry),
@@ -74,9 +91,14 @@ func (d DistributionPath) URL() *url.URL {
 // ParseDistributionPath gets the parameters from a URL which conforms with the OCI distribution spec.
 // It returns a distribution path which contains all the individual parameters.
 // https://github.com/opencontainers/distribution-spec/blob/main/spec.md
-func ParseDistributionPath(u *url.URL) (DistributionPath, error) {
-	registry := u.Query().Get("ns")
-	comps := manifestRegexTag.FindStringSubmatch(u.Path)
+func ParseDistributionPath(req *http.Request) (DistributionPath, error) {
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+
+	registry := req.URL.Query().Get("ns")
+	comps := manifestRegexTag.FindStringSubmatch(req.URL.Path)
 	if len(comps) == 3 {
 		if registry == "" {
 			return DistributionPath{}, errors.New("registry parameter needs to be set for tag references")
@@ -86,13 +108,13 @@ func ParseDistributionPath(u *url.URL) (DistributionPath, error) {
 			Repository: comps[1],
 			Tag:        comps[2],
 		}
-		dist, err := NewDistributionPath(ref, DistributionKindManifest)
+		dist, err := NewDistributionPath(ref, DistributionKindManifest, scheme, req.Method, nil)
 		if err != nil {
 			return DistributionPath{}, err
 		}
 		return dist, nil
 	}
-	comps = manifestRegexDigest.FindStringSubmatch(u.Path)
+	comps = manifestRegexDigest.FindStringSubmatch(req.URL.Path)
 	if len(comps) == 3 {
 		dgst, err := digest.Parse(comps[2])
 		if err != nil {
@@ -103,13 +125,13 @@ func ParseDistributionPath(u *url.URL) (DistributionPath, error) {
 			Repository: comps[1],
 			Digest:     dgst,
 		}
-		dist, err := NewDistributionPath(ref, DistributionKindManifest)
+		dist, err := NewDistributionPath(ref, DistributionKindManifest, scheme, req.Method, nil)
 		if err != nil {
 			return DistributionPath{}, err
 		}
 		return dist, nil
 	}
-	comps = blobsRegexDigest.FindStringSubmatch(u.Path)
+	comps = blobsRegexDigest.FindStringSubmatch(req.URL.Path)
 	if len(comps) == 3 {
 		dgst, err := digest.Parse(comps[2])
 		if err != nil {
@@ -120,7 +142,11 @@ func ParseDistributionPath(u *url.URL) (DistributionPath, error) {
 			Repository: comps[1],
 			Digest:     dgst,
 		}
-		dist, err := NewDistributionPath(ref, DistributionKindBlob)
+		rng, err := httpx.ParseRangeHeader(req.Header)
+		if err != nil {
+			return DistributionPath{}, err
+		}
+		dist, err := NewDistributionPath(ref, DistributionKindBlob, scheme, req.Method, rng)
 		if err != nil {
 			return DistributionPath{}, err
 		}

--- a/pkg/oci/distribution_test.go
+++ b/pkg/oci/distribution_test.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -81,7 +82,9 @@ func TestParseDistributionPath(t *testing.T) {
 				Path:     tt.path,
 				RawQuery: fmt.Sprintf("ns=%s", tt.registry),
 			}
-			dist, err := ParseDistributionPath(u)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, u.String(), nil)
+			require.NoError(t, err)
+			dist, err := ParseDistributionPath(req)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedName, dist.Repository)
 			require.Equal(t, tt.expectedDgst, dist.Digest)
@@ -153,7 +156,9 @@ func TestParseDistributionPathErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := ParseDistributionPath(tt.url)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, tt.url.String(), nil)
+			require.NoError(t, err)
+			_, err = ParseDistributionPath(req)
 			require.EqualError(t, err, tt.expectedError)
 		})
 	}

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -46,15 +46,12 @@ func (i Image) TagName() (string, bool) {
 }
 
 // DistributionPath returns the distribution path for the images top layer.
-func (i Image) DistributionPath() DistributionPath {
+func (i Image) DistributionPath(scheme, method string) (DistributionPath, error) {
 	ref := i.Reference
 	if ref.Digest != "" {
 		ref.Tag = ""
 	}
-	return DistributionPath{
-		Reference: ref,
-		Kind:      DistributionKindManifest,
-	}
+	return NewDistributionPath(ref, DistributionKindManifest, scheme, method, nil)
 }
 
 type ParseImageConfig struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -190,7 +190,7 @@ func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {
 	}
 
 	// Parse out path components from request.
-	dist, err := oci.ParseDistributionPath(req.URL)
+	dist, err := oci.ParseDistributionPath(req)
 	if err != nil {
 		rw.WriteError(http.StatusNotFound, fmt.Errorf("could not parse path according to OCI distribution spec: %w", err))
 		return
@@ -214,7 +214,7 @@ func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {
 			_, ociErr = r.ociStore.Descriptor(req.Context(), dist.Digest)
 		}
 		if ociErr != nil {
-			r.mirrorHandler(rw, req, dist)
+			r.mirrorHandler(req.Context(), dist, rw)
 			return
 		}
 	}
@@ -222,10 +222,10 @@ func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {
 	// Serve registry endpoints.
 	switch dist.Kind {
 	case oci.DistributionKindManifest:
-		r.manifestHandler(rw, req, dist)
+		r.manifestHandler(req.Context(), dist, rw)
 		return
 	case oci.DistributionKindBlob:
-		r.blobHandler(rw, req, dist)
+		r.blobHandler(req.Context(), dist, rw)
 		return
 	default:
 		// This should never happen as it would be caught when parsing the path.
@@ -238,10 +238,10 @@ type MirrorErrorDetails struct {
 	Attempts int `json:"attempts"`
 }
 
-func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath) {
+func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath, rw httpx.ResponseWriter) {
 	rw.SetAttrs(HandlerAttrKey, "mirror")
 
-	log := logr.FromContextOrDiscard(req.Context()).WithValues("ref", dist.Identifier(), "path", req.URL.Path)
+	log := logr.FromContextOrDiscard(ctx).WithValues("ref", dist.Identifier(), "path", dist.URL().Path)
 
 	defer func() {
 		if rw.Error() == nil {
@@ -253,13 +253,6 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 		}
 	}()
 
-	// Range for initial request and to resume failed peer requests.
-	rng, err := httpx.ParseRangeHeader(req.Header)
-	if err != nil {
-		rw.WriteError(http.StatusBadRequest, err)
-		return
-	}
-
 	mirrorDetails := MirrorErrorDetails{
 		Attempts: 0,
 	}
@@ -268,7 +261,7 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 		oci.DistributionKindManifest: oci.ErrCodeManifestUnknown,
 	}[dist.Kind]
 
-	lookupCtx, lookupCancel := context.WithTimeout(req.Context(), r.resolveTimeout)
+	lookupCtx, lookupCancel := context.WithTimeout(ctx, r.resolveTimeout)
 	defer lookupCancel()
 	balancer, err := r.router.Lookup(lookupCtx, dist.Identifier(), r.resolveRetries)
 	if err != nil {
@@ -278,10 +271,10 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 	}
 
 	// Set timeout for non blob data requests.
-	fetchCtx := req.Context()
-	if req.Method == http.MethodHead || dist.Kind == oci.DistributionKindManifest {
+	fetchCtx := ctx
+	if dist.Method == http.MethodHead || dist.Kind == oci.DistributionKindManifest {
 		var reqCancel context.CancelFunc
-		fetchCtx, reqCancel = context.WithTimeout(req.Context(), 3*time.Second)
+		fetchCtx, reqCancel = context.WithTimeout(ctx, 3*time.Second)
 		defer reqCancel()
 	}
 
@@ -304,22 +297,15 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 		}
 		res, err := httpx.HappyEyeballs(fetchCtx, peer.Addresses, func(ctx context.Context, ipAddr netip.Addr) (fetchResult, error) {
 			mirror := &url.URL{
-				Scheme: "http",
+				Scheme: dist.Scheme,
 				Host:   netip.AddrPortFrom(peer.Addresses[0], peer.Metadata.RegistryPort).String(),
-			}
-			if req.TLS != nil {
-				mirror.Scheme = "https"
 			}
 			fetchOpts := []oci.FetchOption{
 				oci.WithFetchHeader(HeaderSpegelMirrored, "true"),
 				oci.WithFetchMirror(mirror),
 				oci.WithFetchBasicAuth(r.username, r.password),
 			}
-			// Override range header with resume range if set.
-			if rng != nil {
-				fetchOpts = append(fetchOpts, oci.WithFetchRange(*rng))
-			}
-			rc, desc, err := r.ociClient.Fetch(fetchCtx, req.Method, dist, fetchOpts...)
+			rc, desc, err := r.ociClient.Fetch(fetchCtx, dist, fetchOpts...)
 			if err != nil {
 				return fetchResult{}, err
 			}
@@ -345,10 +331,10 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 				rw.WriteHeader(http.StatusOK)
 			case oci.DistributionKindBlob:
 				rw.Header().Set(httpx.HeaderAcceptRanges, httpx.RangeUnit)
-				if rng == nil {
+				if dist.Range == nil {
 					rw.WriteHeader(http.StatusOK)
 				} else {
-					crng, err := httpx.ContentRangeFromRange(*rng, desc.Size)
+					crng, err := httpx.ContentRangeFromRange(*dist.Range, desc.Size)
 					if err != nil {
 						rw.WriteError(http.StatusBadRequest, err)
 						return resilient.Unrecoverable(err)
@@ -360,7 +346,7 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 				}
 			}
 		}
-		if req.Method == http.MethodHead {
+		if dist.Method == http.MethodHead {
 			return nil
 		}
 
@@ -373,13 +359,14 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 			case oci.DistributionKindManifest:
 				return resilient.Unrecoverable(fmt.Errorf("copying of manifest data failed: %w", err))
 			case oci.DistributionKindBlob:
-				if rng == nil {
-					rng = &httpx.Range{
+				// TODO: Avoid modifying a pointer.
+				if dist.Range == nil {
+					dist.Range = &httpx.Range{
 						Start: ptr.To(int64(0)),
 						End:   ptr.To(desc.Size - 1),
 					}
 				}
-				rng.Start = ptr.To(*rng.Start + n)
+				dist.Range.Start = ptr.To(*dist.Range.Start + n)
 				balancer.Remove(peer)
 				return fmt.Errorf("copying of blob data failed: %w", err)
 			}
@@ -400,11 +387,11 @@ func (r *Registry) mirrorHandler(rw httpx.ResponseWriter, req *http.Request, dis
 	}
 }
 
-func (r *Registry) manifestHandler(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath) {
+func (r *Registry) manifestHandler(ctx context.Context, dist oci.DistributionPath, rw httpx.ResponseWriter) {
 	rw.SetAttrs(HandlerAttrKey, "manifest")
 
 	if dist.Digest == "" {
-		dgst, err := r.ociStore.Resolve(req.Context(), dist.Identifier())
+		dgst, err := r.ociStore.Resolve(ctx, dist.Identifier())
 		if err != nil {
 			respErr := oci.NewDistributionError(oci.ErrCodeManifestUnknown, fmt.Sprintf("could not get digest for image tag %s", dist.Identifier()), nil)
 			rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
@@ -412,7 +399,7 @@ func (r *Registry) manifestHandler(rw httpx.ResponseWriter, req *http.Request, d
 		}
 		dist.Digest = dgst
 	}
-	desc, err := r.ociStore.Descriptor(req.Context(), dist.Digest)
+	desc, err := r.ociStore.Descriptor(ctx, dist.Digest)
 	if err != nil {
 		respErr := oci.NewDistributionError(oci.ErrCodeManifestUnknown, fmt.Sprintf("could not get manifest %s", dist.Digest), nil)
 		rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
@@ -428,12 +415,12 @@ func (r *Registry) manifestHandler(rw httpx.ResponseWriter, req *http.Request, d
 	rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(desc.Size, 10))
 	rw.Header().Set(oci.HeaderDockerDigest, desc.Digest.String())
 	rw.Header().Set(oci.HeaderNamespace, dist.Registry)
-	if req.Method == http.MethodHead {
+	if dist.Method == http.MethodHead {
 		rw.WriteHeader(http.StatusOK)
 		return
 	}
 
-	rc, err := r.ociStore.Open(req.Context(), dist.Digest)
+	rc, err := r.ociStore.Open(ctx, dist.Digest)
 	if err != nil {
 		respErr := oci.NewDistributionError(oci.ErrCodeManifestUnknown, fmt.Sprintf("could not get manifest %s", dist.Digest), nil)
 		rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
@@ -443,21 +430,15 @@ func (r *Registry) manifestHandler(rw httpx.ResponseWriter, req *http.Request, d
 	rw.WriteHeader(http.StatusOK)
 	_, err = io.Copy(rw, rc)
 	if err != nil {
-		logr.FromContextOrDiscard(req.Context()).Error(err, "error occurred when writing manifest")
+		logr.FromContextOrDiscard(ctx).Error(err, "error occurred when writing manifest")
 		return
 	}
 }
 
-func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist oci.DistributionPath) {
+func (r *Registry) blobHandler(ctx context.Context, dist oci.DistributionPath, rw httpx.ResponseWriter) {
 	rw.SetAttrs(HandlerAttrKey, "blob")
 
-	rng, err := httpx.ParseRangeHeader(req.Header)
-	if err != nil {
-		rw.WriteError(http.StatusBadRequest, err)
-		return
-	}
-
-	desc, err := r.ociStore.Descriptor(req.Context(), dist.Digest)
+	desc, err := r.ociStore.Descriptor(ctx, dist.Digest)
 	if err != nil {
 		respErr := oci.NewDistributionError(oci.ErrCodeBlobUnknown, fmt.Sprintf("could not get blob %s", dist.Digest), nil)
 		rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
@@ -469,14 +450,19 @@ func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist 
 		return
 	}
 
-	var crng *httpx.ContentRange
-	if rng != nil {
-		v, err := httpx.ContentRangeFromRange(*rng, desc.Size)
-		if err != nil {
-			rw.WriteError(http.StatusBadRequest, err)
-			return
+	crng, err := func() (*httpx.ContentRange, error) {
+		if dist.Range == nil {
+			return nil, nil
 		}
-		crng = &v
+		crng, err := httpx.ContentRangeFromRange(*dist.Range, desc.Size)
+		if err != nil {
+			return nil, err
+		}
+		return &crng, nil
+	}()
+	if err != nil {
+		rw.WriteError(http.StatusBadRequest, err)
+		return
 	}
 
 	rw.Header().Set(oci.HeaderDockerDigest, dist.Digest.String())
@@ -493,12 +479,12 @@ func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist 
 		rw.Header().Set(httpx.HeaderContentLength, strconv.FormatInt(crng.Length(), 10))
 		rw.Header().Set(httpx.HeaderContentRange, crng.String())
 	}
-	if req.Method == http.MethodHead {
+	if dist.Method == http.MethodHead {
 		rw.WriteHeader(status)
 		return
 	}
 
-	rc, err := r.ociStore.Open(req.Context(), dist.Digest)
+	rc, err := r.ociStore.Open(ctx, dist.Digest)
 	if err != nil {
 		respErr := oci.NewDistributionError(oci.ErrCodeBlobUnknown, fmt.Sprintf("could not get reader for blob %s", dist.Digest), nil)
 		rw.WriteError(http.StatusNotFound, errors.Join(respErr, err))
@@ -517,7 +503,7 @@ func (r *Registry) blobHandler(rw httpx.ResponseWriter, req *http.Request, dist 
 	rw.WriteHeader(status)
 	_, err = io.Copy(rw, src)
 	if err != nil {
-		logr.FromContextOrDiscard(req.Context()).Error(err, "failed to write blob")
+		logr.FromContextOrDiscard(ctx).Error(err, "failed to write blob")
 		return
 	}
 }


### PR DESCRIPTION
This simplifies some of the registry logic by putting more request parameters into the distribution path. Hoping this will simplify #1258 logic.