### PR TITLE
Fix debug web template errors and implement tests for rendring templates

### DIFF
--- a/pkg/httpx/response.go
+++ b/pkg/httpx/response.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 )
 
@@ -142,4 +143,13 @@ func (r *response) SetAttrs(key string, value any) {
 
 func (r *response) HeadersWritten() bool {
 	return r.wroteHeader
+}
+
+// NewRecorder returns a response writer using a recorder along with the recorder.
+func NewRecorder() (ResponseWriter, *httptest.ResponseRecorder) {
+	rec := httptest.NewRecorder()
+	rw := &response{
+		ResponseWriter: rec,
+	}
+	return rw, rec
 }

--- a/pkg/httpx/response_test.go
+++ b/pkg/httpx/response_test.go
@@ -19,20 +19,17 @@ func TestResponseWriter(t *testing.T) {
 	_, ok := httpRw.(io.ReaderFrom)
 	require.True(t, ok)
 
-	httpRw = httptest.NewRecorder()
-	rw := &response{
-		ResponseWriter: httpRw,
-	}
-	require.Equal(t, httpRw, rw.Unwrap())
+	rw, rec := NewRecorder()
+	//nolint: errcheck // No need to check unwrap.
+	require.Equal(t, rec, rw.(*response).Unwrap())
 	require.NoError(t, rw.Error())
 	require.Equal(t, int64(0), rw.Size())
 	require.Equal(t, http.StatusOK, rw.Status())
 
-	rw = &response{
-		ResponseWriter: httptest.NewRecorder(),
-	}
+	rw, _ = NewRecorder()
 	rw.WriteHeader(http.StatusNotFound)
-	require.True(t, rw.wroteHeader)
+	//nolint: errcheck // No need to check unwrap.
+	require.True(t, rw.(*response).wroteHeader)
 	require.Equal(t, http.StatusNotFound, rw.Status())
 	rw.WriteHeader(http.StatusBadGateway)
 	require.Equal(t, http.StatusNotFound, rw.Status())
@@ -40,9 +37,7 @@ func TestResponseWriter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, rw.Status())
 
-	rw = &response{
-		ResponseWriter: httptest.NewRecorder(),
-	}
+	rw, _ = NewRecorder()
 	first := "hello world"
 	n, err := rw.Write([]byte(first))
 	require.Equal(t, http.StatusOK, rw.Status())
@@ -55,20 +50,18 @@ func TestResponseWriter(t *testing.T) {
 	require.Equal(t, len(second), n)
 	require.Equal(t, int64(len(first)+len(second)), rw.Size())
 
-	rw = &response{
-		ResponseWriter: httptest.NewRecorder(),
-	}
+	rw, _ = NewRecorder()
 	r := strings.NewReader("reader")
-	readFromN, err := rw.ReadFrom(r)
+	//nolint: errcheck // No need to check unwrap.
+	readFromN, err := rw.(*response).ReadFrom(r)
 	require.NoError(t, err)
 	require.Equal(t, r.Size(), readFromN)
 	require.Equal(t, r.Size(), rw.Size())
 
-	rw = &response{
-		ResponseWriter: httptest.NewRecorder(),
-	}
+	rw, _ = NewRecorder()
 	rw.SetAttrs("foo", "bar")
-	require.Equal(t, map[string]any{"foo": "bar"}, rw.attrs)
+	//nolint: errcheck // No need to check unwrap.
+	require.Equal(t, map[string]any{"foo": "bar"}, rw.(*response).attrs)
 }
 
 func TestResponseWriterError(t *testing.T) {

--- a/pkg/httpx/template.go
+++ b/pkg/httpx/template.go
@@ -1,0 +1,25 @@
+package httpx
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+	"strconv"
+)
+
+func RenderTemplate(rw ResponseWriter, tmpl *template.Template, data any) {
+	var buf bytes.Buffer
+	err := tmpl.Option("missingkey=error").Execute(&buf, data)
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	rw.Header().Set(HeaderContentLength, strconv.FormatInt(int64(buf.Len()), 10))
+	rw.Header().Set(HeaderContentType, ContentTypeHTML)
+	rw.WriteHeader(http.StatusOK)
+	_, err = rw.Write(buf.Bytes())
+	if err != nil {
+		rw.WriteError(http.StatusInternalServerError, err)
+	}
+}

--- a/pkg/httpx/template_test.go
+++ b/pkg/httpx/template_test.go
@@ -1,0 +1,38 @@
+package httpx
+
+import (
+	"html/template"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpl, err := template.New("").Parse("{{ .Test }}")
+	require.NoError(t, err)
+
+	rw, rec := NewRecorder()
+	RenderTemplate(rw, tmpl, nil)
+	resp := rec.Result()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	data := struct {
+		Test string
+	}{
+		Test: "Hello World",
+	}
+	rw, rec = NewRecorder()
+	RenderTemplate(rw, tmpl, data)
+	resp = rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, ContentTypeHTML, rw.Header().Get(HeaderContentType))
+	require.Equal(t, strconv.FormatInt(int64(len(data.Test)), 10), rw.Header().Get(HeaderContentLength))
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, data.Test, string(b))
+}

--- a/pkg/web/format.go
+++ b/pkg/web/format.go
@@ -2,9 +2,30 @@ package web
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 )
+
+func joinStrings(items any, sep string) (string, error) {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice {
+		return "", fmt.Errorf("expected a slice, got %T", items)
+	}
+	strs := make([]string, v.Len())
+	for i := range v.Len() {
+		elem := v.Index(i).Interface()
+		switch e := elem.(type) {
+		case fmt.Stringer:
+			strs[i] = e.String()
+		case string:
+			strs[i] = e
+		default:
+			strs[i] = fmt.Sprint(e)
+		}
+	}
+	return strings.Join(strs, sep), nil
+}
 
 func formatBytes(size int64) string {
 	const unit = 1024

--- a/pkg/web/templates/stats.html
+++ b/pkg/web/templates/stats.html
@@ -35,7 +35,7 @@
         </tr>
         {{ range .Peers }}
         <tr>
-          <td>{{ .ID }}</td>
+          <td>{{ .Host }}</td>
           <td>{{ join .Addresses ", " }}</td>
         </tr>
         {{ end }}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -70,7 +69,7 @@ func NewWeb(router *routing.P2PRouter, ociStore oci.Store, reg *registry.Registr
 	}
 
 	funcs := template.FuncMap{
-		"join":           strings.Join,
+		"join":           joinStrings,
 		"formatBytes":    formatBytes,
 		"formatDuration": formatDuration,
 	}
@@ -99,11 +98,7 @@ func (w *Web) Handler(log logr.Logger) http.Handler {
 }
 
 func (w *Web) indexHandler(rw httpx.ResponseWriter, req *http.Request) {
-	err := w.tmpls.ExecuteTemplate(rw, "index.html", nil)
-	if err != nil {
-		rw.WriteError(http.StatusInternalServerError, err)
-		return
-	}
+	httpx.RenderTemplate(rw, w.tmpls.Lookup("index.html"), nil)
 }
 
 type LibP2P struct {
@@ -128,13 +123,15 @@ func (w *Web) metaDataHandler(rw httpx.ResponseWriter, req *http.Request) {
 	}
 }
 
+type statsData struct {
+	LocalAddresses    []netip.Addr
+	Images            []oci.Image
+	Peers             []routing.Peer
+	MirrorLastSuccess time.Duration
+}
+
 func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
-	data := struct {
-		LocalAddresses    []netip.Addr
-		Images            []oci.Image
-		Peers             []routing.Peer
-		MirrorLastSuccess time.Duration
-	}{}
+	data := statsData{}
 
 	images, err := w.ociStore.ListImages(req.Context())
 	if err != nil {
@@ -167,11 +164,7 @@ func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 	}
 	data.Peers = peers
 
-	err = w.tmpls.ExecuteTemplate(rw, "stats.html", data)
-	if err != nil {
-		rw.WriteError(http.StatusInternalServerError, err)
-		return
-	}
+	httpx.RenderTemplate(rw, w.tmpls.Lookup("stats.html"), data)
 }
 
 type measureResult struct {
@@ -254,9 +247,5 @@ func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	err = w.tmpls.ExecuteTemplate(rw, "measure.html", res)
-	if err != nil {
-		rw.WriteError(http.StatusInternalServerError, NewHTMLResponseError(err))
-		return
-	}
+	httpx.RenderTemplate(rw, w.tmpls.Lookup("measure.html"), res)
 }

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -1,15 +1,78 @@
 package web
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/spegel-org/spegel/pkg/httpx"
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/registry"
+	"github.com/spegel-org/spegel/pkg/routing"
 )
 
 func TestWeb(t *testing.T) {
 	t.Parallel()
 
-	w, err := NewWeb(nil, nil, nil, nil)
+	router, err := routing.NewP2PRouter(t.Context(), ":0", nil, "5000")
+	require.NoError(t, err)
+
+	ociStore := oci.NewMemory()
+
+	reg, err := registry.NewRegistry(ociStore, router)
+	require.NoError(t, err)
+
+	w, err := NewWeb(router, ociStore, reg, nil)
 	require.NoError(t, err)
 	require.NotNil(t, w.tmpls)
+
+	rw, rec := httpx.NewRecorder()
+	w.indexHandler(rw, nil)
+	resp := rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	rw, rec = httpx.NewRecorder()
+	w.metaDataHandler(rw, nil)
+	resp = rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, httpx.ContentTypeJSON, resp.Header.Get(httpx.HeaderContentType))
+
+	rw, rec = httpx.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	w.statsHandler(rw, req)
+	resp = rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	stats := statsData{
+		LocalAddresses:    []netip.Addr{{}},
+		Images:            []oci.Image{{}},
+		Peers:             []routing.Peer{{}},
+		MirrorLastSuccess: 1 * time.Minute,
+	}
+	rw, rec = httpx.NewRecorder()
+	httpx.RenderTemplate(rw, w.tmpls.Lookup("stats.html"), stats)
+	resp = rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	rw, rec = httpx.NewRecorder()
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	query := req.URL.Query()
+	query.Add("image", "docker.io/library/ubuntu:latest")
+	req.URL.RawQuery = query.Encode()
+	w.measureHandler(rw, req)
+	resp = rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	measure := measureResult{
+		LookupResults: []lookupResult{{}},
+		PullResults:   []pullResult{{}},
+	}
+	rw, rec = httpx.NewRecorder()
+	httpx.RenderTemplate(rw, w.tmpls.Lookup("measure.html"), measure)
+	resp = rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
This change fixes some template issues with the debug web page. It also adds test to the handlers and rendering. Additionally it adds a new template rendering function which will return a failing status code on render error. Previously these errors would fail silently as the body would be streamed. The additional minimal memory cost is worth having the option to error a response.