### PR TITLE
Refactor debug measure to use specific function

### DIFF
--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -346,6 +346,43 @@ func (r *P2PRouter) Lookup(ctx context.Context, key string, count int) (Balancer
 	return bal.(Balancer), nil
 }
 
+type LookupResult struct {
+	Peer     Peer
+	Duration time.Duration
+}
+
+// Measure returns a list of time results containing the time it took to find each peer.
+func (r *P2PRouter) Measure(ctx context.Context, key string) ([]LookupResult, error) {
+	c, err := createCid(key)
+	if err != nil {
+		return nil, err
+	}
+
+	addrInfoCh := r.kdht.FindProvidersAsync(ctx, c, 0)
+
+	lookupStart := time.Now()
+	results := []LookupResult{}
+	for addrInfo := range addrInfoCh {
+		d := time.Since(lookupStart)
+		ipAddrs, err := toIPAddrs(addrInfo.Addrs)
+		if err != nil {
+			return nil, err
+		}
+		res := LookupResult{
+			Peer: Peer{
+				Host:      addrInfo.ID.String(),
+				Addresses: ipAddrs,
+				Metadata: PeerMetadata{
+					RegistryPort: r.registryPort,
+				},
+			},
+			Duration: d,
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
 func (r *P2PRouter) Advertise(ctx context.Context, keys []string) error {
 	if len(keys) == 0 {
 		return nil

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -167,24 +167,19 @@ func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 	httpx.RenderTemplate(rw, w.tmpls.Lookup("stats.html"), data)
 }
 
-type measureResult struct {
-	LookupResults []lookupResult
-	PullResults   []pullResult
-	PeerDuration  time.Duration
-	PullDuration  time.Duration
-	PullSize      int64
-}
-
-type lookupResult struct {
-	Peer     routing.Peer
-	Duration time.Duration
-}
-
 type pullResult struct {
 	Identifier string
 	Type       string
 	Size       int64
 	Duration   time.Duration
+}
+
+type measureResult struct {
+	LookupResults []routing.LookupResult
+	PullResults   []pullResult
+	PeerDuration  time.Duration
+	PullDuration  time.Duration
+	PullSize      int64
 }
 
 func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
@@ -201,32 +196,13 @@ func (w *Web) measureHandler(rw httpx.ResponseWriter, req *http.Request) {
 	}
 
 	res := measureResult{}
-
-	// Lookup peers for the given image.
-	lookupStart := time.Now()
-	lookupCtx, lookupCancel := context.WithTimeout(req.Context(), 1*time.Second)
+	lookupCtx, lookupCancel := context.WithTimeout(req.Context(), 3*time.Second)
 	defer lookupCancel()
-	rr, err := w.router.Lookup(lookupCtx, img.Identifier(), 0)
+	lookupRes, err := w.router.Measure(lookupCtx, img.Identifier())
 	if err != nil {
 		rw.WriteError(http.StatusInternalServerError, NewHTMLResponseError(err))
-		return
 	}
-	for {
-		peer, err := rr.Next()
-		if err != nil {
-			break
-		}
-
-		// TODO(phillebaba): This isnt a great solution as removing the peers will affect caching.
-		rr.Remove(peer)
-
-		d := time.Since(lookupStart)
-		res.PeerDuration += d
-		res.LookupResults = append(res.LookupResults, lookupResult{
-			Peer:     peer,
-			Duration: d,
-		})
-	}
+	res.LookupResults = lookupRes
 
 	if len(res.LookupResults) > 0 {
 		// Pull the image and measure performance.

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -68,7 +68,7 @@ func TestWeb(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	measure := measureResult{
-		LookupResults: []lookupResult{{}},
+		LookupResults: []routing.LookupResult{{}},
 		PullResults:   []pullResult{{}},
 	}
 	rw, rec = httpx.NewRecorder()


### PR DESCRIPTION
This moves the lookup measuring to the p2p router instead of the half baked solution I implemented previously. This makes any future changes to the lookup implemented for the registry a lot easier as we don't need to consider the debug use case.