### PR TITLE
Fix so copy failure does not remove peer from iterator

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -363,8 +363,6 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 		defer r.bufferPool.Put(buf)
 		n, err := io.CopyBuffer(rw, res.rc, *buf)
 		if err != nil {
-			iter.Remove(peer)
-
 			switch dist.Kind {
 			case oci.DistributionKindManifest:
 				return resilient.Unrecoverable(fmt.Errorf("copying of manifest data failed: %w", err))

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -405,11 +405,11 @@ func TestRegistryHandler(t *testing.T) {
 			},
 		},
 		{
-			name:             "flaky reader with one peers should fail",
+			name:             "flaky reader with one peer should keep retrying",
 			key:              "sha256:68a2f9c5f175c838c5e9433dfe7b9d3a73caade76b2185a8d9164405c5286edd",
 			distributionKind: oci.DistributionKindBlob,
 			expectedStatus:   http.StatusOK,
-			expectedBody:     []byte("Only a "),
+			expectedBody:     []byte("Only a single peer"),
 			expectedHeaders: http.Header{
 				httpx.HeaderAcceptRanges:  {httpx.RangeUnit},
 				httpx.HeaderContentType:   {"dummy"},


### PR DESCRIPTION
Copy failure can be caused by many reasons so removing the peer from the iterator does not make sense. It is better to retry with the same peer and just see if the connection fails.