### PR TITLE
Release peer when happy eyeballs errors due to context being cancelled

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -429,6 +429,7 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 				})
 				if err != nil {
 					if fetchCtx.Err() != nil {
+						iterator.Release(peer)
 						return
 					}
 
@@ -446,6 +447,7 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 				}
 
 				iterator.Release(peer)
+
 				err = r.hedger.Observe(time.Since(start))
 				if err != nil {
 					log.Error(err, "could not observe fetch duration for hedger")
@@ -462,9 +464,9 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 			}()
 		case failure := <-failureCh:
 			// Remove context to indicate fetch is not inflight.
+			log.Error(failure.err, "request to peer failed")
 			delete(fetchCtxs, failure.peer.Host)
 			delete(fetchCancels, failure.peer.Host)
-			log.Error(failure.err, "request to peer failed")
 			immediateCh <- true
 		case res := <-resCh:
 			// Remove context so successful request is not cancelled.

--- a/test/integration/kubernetes/kubernetes_test.go
+++ b/test/integration/kubernetes/kubernetes_test.go
@@ -499,7 +499,7 @@ func waitForStatus(t *testing.T, k8sDynClient dynamic.Interface, gvr schema.Grou
 		res, err := status.Compute(u)
 		require.NoError(c, err)
 		require.Equal(c, s, res.Status)
-	}, 30*time.Second, 500*time.Millisecond)
+	}, 60*time.Second, 500*time.Millisecond)
 }
 
 func uninstallSpegel(t *testing.T, actionCfg *action.Configuration, kindNodes []kindnodes.Node) {


### PR DESCRIPTION
Previously peers would not be released if the request was hedged and lost. Meaning future requests will never see the peer. This change fixes that. Making sure that a peer is either removed or released and not acquired forever.