### PR TITLE
Fix range modification so it doesnt create side effects

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -266,6 +266,18 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 		return
 	}
 
+	// Make copy to not modify distribution range.
+	if dist.Range != nil {
+		rng := &httpx.Range{}
+		if dist.Range.Start != nil {
+			rng.Start = ptr.To(*dist.Range.Start)
+		}
+		if dist.Range.End != nil {
+			rng.End = ptr.To(*dist.Range.End)
+		}
+		dist.Range = rng
+	}
+
 	// Retry requests until success or timeout.
 	for {
 		done := func() bool {
@@ -314,7 +326,6 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 					log.Error(err, "copying of manifest data failed")
 					return true
 				case oci.DistributionKindBlob:
-					// TODO: Avoid modifying a pointer.
 					if dist.Range == nil {
 						dist.Range = &httpx.Range{
 							Start: ptr.To(int64(0)),


### PR DESCRIPTION
Modifying the range in place could cause unintended side effects. This makes a copy of the range used for the duration of the function.