### PR TITLE
Add unit tests for Helm chart

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -5,8 +5,22 @@ permissions:
   contents: read
 defaults:
   run:
-    shell: bash   
+    shell: bash
 jobs:
+  verfiy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./charts/spegel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - name: Setup Helm unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
+      - name: Run lint
+        run: helm lint .
+      - name: Run tests
+        run: helm unittest .
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -16,7 +30,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: go.mod
-      - name: Run helm-docs
+      - name: Generate docs
         run: make helm-docs
       - name: Check if working tree is dirty
         run: |

--- a/charts/spegel/.helmignore
+++ b/charts/spegel/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+tests/

--- a/charts/spegel/Chart.yaml
+++ b/charts/spegel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spegel
 description: Stateless cluster local OCI registry mirror.
 type: application
-version: v0.0.1
+version: 0.0.1
 appVersion: v0.0.1
 annotations:
   artifacthub.io/category: "integration-delivery"

--- a/charts/spegel/tests/daemonset_test.yaml
+++ b/charts/spegel/tests/daemonset_test.yaml
@@ -1,0 +1,71 @@
+suite: test daemonset
+templates:
+  - daemonset.yaml
+tests:
+  - it: should work with default values
+    asserts:
+      - isAPIVersion:
+          of: apps/v1
+      - isKind:
+          of: DaemonSet
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spegel
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ghcr.io/spegel-org/spegel
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: registry
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: registry
+            containerPort: 5000
+            hostPort: 30020
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: containerd-sock
+            mountPath: /run/containerd/containerd.sock
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: containerd-sock
+            hostPath:
+              path: /run/containerd/containerd.sock
+              type: Socket
+      - isNotEmpty:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true


### PR DESCRIPTION
This change adds unit tests to the Helm chart to ensure that template output is what is expected.

Part of #1304 