### PR TITLE
fix: update Grafana dashboard datasource configuration for Prometheus

### DIFF
--- a/charts/spegel/monitoring/grafana-dashboard.json
+++ b/charts/spegel/monitoring/grafana-dashboard.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -1336,6 +1326,17 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "current": {}
+      }
       {
         "current": {},
         "includeAll": false,


### PR DESCRIPTION
Fixes #1303

The `__inputs` format is only resolved by Grafana's UI import wizard, not by file/ConfigMap provisioning, causing all panels to fail with `Datasource ${DS_PROMETHEUS} was not found`.

Replaces `__inputs` with a proper `datasource` type variable in `templating.list`.