### PR TITLE
Reduce BaseTransport dial timeout

### DIFF
--- a/pkg/httpx/httpx.go
+++ b/pkg/httpx/httpx.go
@@ -20,7 +20,7 @@ func BaseClient() *http.Client {
 func BaseTransport() *http.Transport {
 	return &http.Transport{
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   200 * time.Millisecond,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,


### PR DESCRIPTION
Drastically reduce the dial timeout for connections using `httpx.BaseTransport()`.
This is currently only used by `oic.NewClient()` to set up the HTTP client, and then by `Client.Fetch()` when fetching data from other Spegel pods.
The current timeout of 30s is far too long when a pod does not respond (for example, when it has been deleted).
As far as I understand, it’s possible to resolve the IP of a deleted pod via the P2P network, so this situation is expected to happen from time to time.
Correct me if I’m wrong, as I’m not familiar with the codebase and may have missed something.