### PR TITLE
Remove host port and only depend on prefer same node service

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -45,12 +45,9 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | service.metrics.annotations | object | `{}` | Annotations to add to the metrics service |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |
 | service.registry.annotations | object | `{}` | Annotations to add to the registry service |
-| service.registry.hostPort | int | `30020` | Local host port to expose the registry. |
 | service.registry.nodeIp | string | `""` | Override the NODE_ID environment variable. It defaults to the field status.hostIP |
-| service.registry.nodePort | int | `30021` | Node port to expose the registry via the service. |
+| service.registry.nodePort | int | `30020` | Node port to expose the registry via the service. |
 | service.registry.port | int | `5000` | Port to expose the registry via the service. |
-| service.registry.topologyAwareHintsEnabled | bool | `true` | If true adds topology aware hints annotation to node port service. |
-| service.registry.usePreferSameNodeTrafficDistribution | bool | `false` | Use PreferSameNode traffic distribution on the node port service instead of using an additional mirror registry on a container host port. |
 | service.router.port | int | `5001` | Port to expose the router via the service. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -60,9 +60,6 @@ spec:
           {{- end }}
           {{- end }}
           - --mirror-targets
-          {{- if not .Values.service.registry.usePreferSameNodeTrafficDistribution }}
-          - http://$(NODE_IP):{{ .Values.service.registry.hostPort }}
-          {{- end }}
           - http://$(NODE_IP):{{ .Values.service.registry.nodePort }}
           {{- with .Values.spegel.additionalMirrorTargets }}
           {{- range . }}
@@ -137,9 +134,6 @@ spec:
         ports:
           - name: registry
             containerPort: {{ .Values.service.registry.port }}
-            {{- if not .Values.service.registry.usePreferSameNodeTrafficDistribution }}
-            hostPort: {{ .Values.service.registry.hostPort }}
-            {{- end }}
             protocol: TCP
           - name: router-tcp
             containerPort: {{ .Values.service.router.port }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -27,17 +27,13 @@ metadata:
   namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
-  {{- if or (and (not .Values.service.registry.usePreferSameNodeTrafficDistribution) .Values.service.registry.topologyAwareHintsEnabled) .Values.service.registry.annotations }}
+  {{- with .Values.service.registry.annotations }}
   annotations:
-    {{- if and (not .Values.service.registry.usePreferSameNodeTrafficDistribution) .Values.service.registry.topologyAwareHintsEnabled }}
-    service.kubernetes.io/topology-mode: "auto"
-    {{- end }}
-    {{- with .Values.service.registry.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   type: NodePort
+  trafficDistribution: PreferSameNode
   selector:
     app.kubernetes.io/component: spegel
     {{- include "spegel.selectorLabels" . | nindent 4 }}
@@ -47,9 +43,6 @@ spec:
       targetPort: registry
       nodePort: {{ .Values.service.registry.nodePort }}
       protocol: TCP
-  {{- if .Values.service.registry.usePreferSameNodeTrafficDistribution }}
-  trafficDistribution: PreferSameNode
-  {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/spegel/tests/daemonset_test.yaml
+++ b/charts/spegel/tests/daemonset_test.yaml
@@ -33,7 +33,6 @@ tests:
           content:
             name: registry
             containerPort: 5000
-            hostPort: 30020
             protocol: TCP
       - contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -48,16 +48,9 @@ service:
     # -- Port to expose the registry via the service.
     port: 5000
     # -- Node port to expose the registry via the service.
-    nodePort: 30021
-    # -- Local host port to expose the registry.
-    hostPort: 30020
-    # -- If true adds topology aware hints annotation to node port service.
-    topologyAwareHintsEnabled: true
+    nodePort: 30020
     # -- Annotations to add to the registry service
     annotations: {}
-    # -- Use PreferSameNode traffic distribution on the node port service
-    # instead of using an additional mirror registry on a container host port.
-    usePreferSameNodeTrafficDistribution: false
 
   router:
     # -- Port to expose the router via the service.

--- a/test/integration/kubernetes/kubernetes_test.go
+++ b/test/integration/kubernetes/kubernetes_test.go
@@ -353,45 +353,6 @@ func TestKubernetes(t *testing.T) {
 			}
 			watcher.Stop()
 
-			// Give time for system to balance. Without this tests tend to be flaky.
-			time.Sleep(10 * time.Second)
-
-			t.Log("Checking node port accessibility")
-			tests := []struct {
-				node     kindnodes.Node
-				port     string
-				expected string
-			}{
-				{
-					node:     kindNodes[0],
-					port:     "30020",
-					expected: "200",
-				},
-				{
-					node:     kindNodes[0],
-					port:     "30021",
-					expected: "200",
-				},
-				{
-					node:     kindNodes[2],
-					port:     "30020",
-					expected: "000",
-				},
-				{
-					node:     kindNodes[2],
-					port:     "30021",
-					expected: "200",
-				},
-			}
-			for _, tt := range tests {
-				node, err := k8sClient.CoreV1().Nodes().Get(t.Context(), tt.node.String(), metav1.GetOptions{})
-				require.NoError(t, err)
-				nodeIP := getNodeIP(t, node)
-				buf := &bytes.Buffer{}
-				tt.node.CommandContext(t.Context(), "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", fmt.Sprintf("http://%s:%s/readyz", nodeIP, tt.port)).SetStdout(buf).Run()
-				require.Equal(t, tt.expected, buf.String(), fmt.Sprintf("%s %s", tt.node, tt.port))
-			}
-
 			t.Log("Deploy pull test pods")
 			runPullTests(t, k8sClient, k8sDynClient, k8sCfg, testImages[1:], kindNodes)
 			noSpegelRestart(t, k8sClient)


### PR DESCRIPTION
With Kubernetes 1.36 released there are three latest releases which support perfer local node on the service. This removes the need to have a backup service if the local Spegel instance is not running. Now instead if the local pod does not respond kube-proxy will forward the request to a nearby node.