### PR TITLE
Add percentile based timeout when racing fetches

### DIFF
--- a/internal/resilient/hedge.go
+++ b/internal/resilient/hedge.go
@@ -26,6 +26,25 @@ func NewHedger(percentiles []float64, initial time.Duration) *Hedger {
 	}
 }
 
+// durationAtPercentile returns the duration at the given percentile, or the the initial duration if no data is available.
+func (h *Hedger) durationAtPercentile(percentile float64) time.Duration {
+	h.mx.RLock()
+	value := h.hist.ValueAtPercentile(percentile)
+	h.mx.RUnlock()
+	if value == 0 {
+		return h.initial
+	}
+	return time.Duration(value) * time.Millisecond
+}
+
+// HighestPercentileDuration returns the duration for the highest percentile.
+func (h *Hedger) HighestPercentileDuration() time.Duration {
+	if len(h.percentiles) == 0 {
+		return h.initial
+	}
+	return h.durationAtPercentile(h.percentiles[len(h.percentiles)-1])
+}
+
 // Size returns the amount of times a hedge channel will be triggered.
 func (h *Hedger) Size() int {
 	return len(h.percentiles)
@@ -44,12 +63,7 @@ func (h *Hedger) Channel(ctx context.Context) <-chan any {
 	go func() {
 		start := time.Now()
 		for _, percentile := range h.percentiles {
-			h.mx.RLock()
-			hedgeDuration := time.Duration(h.hist.ValueAtPercentile(percentile)) * time.Millisecond
-			h.mx.RUnlock()
-			if hedgeDuration == 0 {
-				hedgeDuration = h.initial
-			}
+			hedgeDuration := h.durationAtPercentile(percentile)
 
 			d := max(hedgeDuration-time.Since(start), 0)
 			select {

--- a/internal/resilient/hedge_test.go
+++ b/internal/resilient/hedge_test.go
@@ -64,3 +64,43 @@ func TestHedger(t *testing.T) {
 		})
 	}
 }
+
+func TestHedgerHighestPercentileDuration(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		percentiles  []float64
+		observations []time.Duration
+		want         time.Duration
+	}{
+		{
+			name:         "no observed values",
+			percentiles:  []float64{80, 90, 95},
+			observations: []time.Duration{},
+			want:         100 * time.Millisecond,
+		},
+		{
+			name:         "no percentiles",
+			percentiles:  []float64{},
+			observations: []time.Duration{50 * time.Millisecond, 100 * time.Millisecond, 150 * time.Millisecond},
+			want:         100 * time.Millisecond,
+		},
+		{
+			name:         "with percentiles and observed values",
+			percentiles:  []float64{80, 90, 95},
+			observations: []time.Duration{50 * time.Millisecond, 100 * time.Millisecond, 150 * time.Millisecond},
+			want:         150 * time.Millisecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			hedger := NewHedger(tt.percentiles, 100*time.Millisecond)
+			for _, d := range tt.observations {
+				err := hedger.Observe(d)
+				require.NoError(t, err)
+			}
+			require.InEpsilon(t, tt.want, hedger.HighestPercentileDuration(), 0.01)
+		})
+	}
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -374,6 +374,9 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 			idleTimeoutCh = time.After(r.resolveTimeout)
 			exhaustedCh = iterator.Exhausted()
 		}
+		if len(fetchCtxs) > 0 && raceTimeoutCh == nil {
+			raceTimeoutCh = time.After(max(r.hedger.HighestPercentileDuration()*2, 100*time.Millisecond))
+		}
 
 		select {
 		case <-ctx.Done():
@@ -386,15 +389,13 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 		case <-idleTimeoutCh:
 			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("waited too long for new peer with no inflight fetches for %s", dist.Identifier()), errDetails)
 		case <-raceTimeoutCh:
-			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("waited too long for a response from a peer for %s", dist.Identifier()), errDetails)
+			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("waited too long for inflight dials to complete for %s", dist.Identifier()), errDetails)
 		case <-fetchCh:
 			peer, ok := iterator.Acquire()
 			if !ok {
 				immediateCh <- false
 				continue
 			}
-
-			raceTimeoutCh = time.After(max(r.hedger.HighestPercentileDuration()*2, 100*time.Millisecond))
 
 			errDetails.Attempts += 1
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -364,6 +364,8 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 		}
 	}()
 
+	var raceTimeoutCh <-chan time.Time
+
 	for {
 		// We only want to return early when there are no inflight requests.
 		var idleTimeoutCh <-chan time.Time
@@ -383,12 +385,16 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("all request retries exhausted for %s", dist.Identifier()), errDetails)
 		case <-idleTimeoutCh:
 			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("waited too long for new peer with no inflight fetches for %s", dist.Identifier()), errDetails)
+		case <-raceTimeoutCh:
+			return fetchResponse{}, oci.NewDistributionError(errCode, fmt.Sprintf("waited too long for a response from a peer for %s", dist.Identifier()), errDetails)
 		case <-fetchCh:
 			peer, ok := iterator.Acquire()
 			if !ok {
 				immediateCh <- false
 				continue
 			}
+
+			raceTimeoutCh = time.After(max(r.hedger.HighestPercentileDuration()*2, 100*time.Millisecond))
 
 			errDetails.Attempts += 1
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -312,10 +312,10 @@ func TestRegistryHandler(t *testing.T) {
 			key:              "sha256:3cd9b6cd0c4cdf1b9ab934a5a8b61f419b74261829c2d2a69c227594333e38e8",
 			distributionKind: oci.DistributionKindBlob,
 			expectedStatus:   http.StatusNotFound,
-			expectedBody:     []byte(`{"errors":[{"code":"BLOB_UNKNOWN","detail":{"attempts":2},"message":"waited too long for a response from a peer for sha256:3cd9b6cd0c4cdf1b9ab934a5a8b61f419b74261829c2d2a69c227594333e38e8"}]}`),
+			expectedBody:     []byte(`{"errors":[{"code":"BLOB_UNKNOWN","detail":{"attempts":2},"message":"waited too long for inflight dials to complete for sha256:3cd9b6cd0c4cdf1b9ab934a5a8b61f419b74261829c2d2a69c227594333e38e8"}]}`),
 			expectedHeaders: http.Header{
 				httpx.HeaderContentType:   {httpx.ContentTypeJSON},
-				httpx.HeaderContentLength: {"191"},
+				httpx.HeaderContentLength: {"195"},
 			},
 		},
 		{

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -173,6 +174,24 @@ func TestRegistryHandler(t *testing.T) {
 		},
 	}
 
+	silentPeers := []routing.Peer{}
+	for i := range 2 {
+		silentListener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			silentListener.Close()
+		})
+		addrPort := netip.MustParseAddrPort(silentListener.Addr().String())
+		silentPeer := routing.Peer{
+			Host:      fmt.Sprintf("slient-%d", i),
+			Addresses: []netip.Addr{addrPort.Addr()},
+			Metadata: routing.PeerMetadata{
+				RegistryPort: addrPort.Port(),
+			},
+		}
+		silentPeers = append(silentPeers, silentPeer)
+	}
+
 	badPeers := []routing.Peer{}
 	for i := range 2 {
 		badReg, err := NewRegistry(oci.NewMemory(), routing.NewMemoryRouter(map[string][]routing.Peer{}, routing.Peer{}))
@@ -247,6 +266,8 @@ func TestRegistryHandler(t *testing.T) {
 	resolver := map[string][]routing.Peer{
 		// No working peers.
 		"sha256:18ca1296b9cc90d29b51b4a8724d97aa055102c3d74e53a8eafb3904c079c0c6": {badPeers[0], unreachablePeer, badPeers[1]},
+		// No responding peers.
+		"sha256:3cd9b6cd0c4cdf1b9ab934a5a8b61f419b74261829c2d2a69c227594333e38e8": {silentPeers[0], silentPeers[1]},
 		// First peer.
 		"sha256:0b7e0ac6364af64af017531f137a95f3a5b12ea38be0e74a860004d3e5760a67": {goodPeer, badPeers[0], badPeers[1]},
 		// Second peer.
@@ -284,6 +305,17 @@ func TestRegistryHandler(t *testing.T) {
 			expectedHeaders: http.Header{
 				httpx.HeaderContentType:   {httpx.ContentTypeJSON},
 				httpx.HeaderContentLength: {"168"},
+			},
+		},
+		{
+			name:             "request should timeout when no peers responds",
+			key:              "sha256:3cd9b6cd0c4cdf1b9ab934a5a8b61f419b74261829c2d2a69c227594333e38e8",
+			distributionKind: oci.DistributionKindBlob,
+			expectedStatus:   http.StatusNotFound,
+			expectedBody:     []byte(`{"errors":[{"code":"BLOB_UNKNOWN","detail":{"attempts":2},"message":"waited too long for a response from a peer for sha256:3cd9b6cd0c4cdf1b9ab934a5a8b61f419b74261829c2d2a69c227594333e38e8"}]}`),
+			expectedHeaders: http.Header{
+				httpx.HeaderContentType:   {httpx.ContentTypeJSON},
+				httpx.HeaderContentLength: {"191"},
 			},
 		},
 		{
@@ -452,9 +484,12 @@ func TestRegistryHandler(t *testing.T) {
 			t.Run(fmt.Sprintf("%s-%s", method, tt.name), func(t *testing.T) {
 				t.Parallel()
 
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+
 				target := fmt.Sprintf("http://example.com/v2/foo/bar/%s/%s?ns=docker.io", tt.distributionKind, tt.key)
 				rw := httptest.NewRecorder()
-				req := httptest.NewRequestWithContext(t.Context(), method, target, nil)
+				req := httptest.NewRequestWithContext(ctx, method, target, nil)
 				if tt.rng != nil {
 					req.Header.Set(httpx.HeaderRange, tt.rng.String())
 				}


### PR DESCRIPTION
Add a race fetch timeout in `registry.go`.
Use twice the highest percentile duration from the hedger (with minimum of 100ms) and reset the timer each time a new fetch is started.
This does not affect content proxying, which still has no timeout.

The 100 ms minimum comes from test failures caused by very low hedger values during the tests, and setting a lower bound seems reasonable. This is still a fairly low value, and increasing it may be safer.
The timeout formula could be adjusted, or we could simply use a fixed value.

Fix #1311.