### PR TITLE
Fix data race when modifying range for failed blob request

### DIFF
--- a/pkg/httpx/range.go
+++ b/pkg/httpx/range.go
@@ -92,6 +92,26 @@ func (rng Range) String() string {
 	}
 }
 
+// Clone returns a deep copy of the range.
+func (rng *Range) Clone() *Range {
+	if rng == nil {
+		return nil
+	}
+	var start, end *int64
+	if rng.Start != nil {
+		v := *rng.Start
+		start = &v
+	}
+	if rng.End != nil {
+		v := *rng.End
+		end = &v
+	}
+	return &Range{
+		Start: start,
+		End:   end,
+	}
+}
+
 // ContentRange represents a content range header.
 type ContentRange struct {
 	Start int64

--- a/pkg/httpx/range_test.go
+++ b/pkg/httpx/range_test.go
@@ -216,3 +216,66 @@ func TestContentRange(t *testing.T) {
 	_, err = ContentRangeFromRange(Range{Start: nil, End: nil}, 100)
 	require.EqualError(t, err, "start and end range cannot both be empty")
 }
+
+func TestRangeClone(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		rng  *Range
+		want *Range
+		name string
+	}{
+		{
+			name: "nil range",
+			rng:  nil,
+			want: nil,
+		},
+		{
+			name: "empty range",
+			rng:  &Range{},
+			want: &Range{},
+		},
+		{
+			name: "range with start and end",
+			rng: &Range{
+				Start: ptr.To(int64(0)),
+				End:   ptr.To(int64(100)),
+			},
+			want: &Range{
+				Start: ptr.To(int64(0)),
+				End:   ptr.To(int64(100)),
+			},
+		},
+		{
+			name: "range with only start",
+			rng: &Range{
+				Start: ptr.To(int64(50)),
+				End:   nil,
+			},
+			want: &Range{
+				Start: ptr.To(int64(50)),
+				End:   nil,
+			},
+		},
+		{
+			name: "range with only end",
+			rng: &Range{
+				Start: nil,
+				End:   ptr.To(int64(50)),
+			},
+			want: &Range{
+				Start: nil,
+				End:   ptr.To(int64(50)),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rng := tt.rng.Clone()
+			if tt.rng != nil {
+				require.NotSame(t, tt.rng, rng)
+			}
+			require.Equal(t, tt.want, rng)
+		})
+	}
+}

--- a/pkg/oci/distribution.go
+++ b/pkg/oci/distribution.go
@@ -88,6 +88,15 @@ func (d DistributionPath) URL() *url.URL {
 	}
 }
 
+// Clone returns a deep copy of the distribution path.
+func (d DistributionPath) Clone() DistributionPath {
+	out := d
+	if d.Range != nil {
+		out.Range = d.Range.Clone()
+	}
+	return out
+}
+
 // ParseDistributionPath gets the parameters from a URL which conforms with the OCI distribution spec.
 // It returns a distribution path which contains all the individual parameters.
 // https://github.com/opencontainers/distribution-spec/blob/main/spec.md

--- a/pkg/oci/distribution_test.go
+++ b/pkg/oci/distribution_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spegel-org/spegel/internal/ptr"
+	"github.com/spegel-org/spegel/pkg/httpx"
 )
 
 func TestParseDistributionPath(t *testing.T) {
@@ -160,6 +163,60 @@ func TestParseDistributionPathErrors(t *testing.T) {
 			require.NoError(t, err)
 			_, err = ParseDistributionPath(req)
 			require.EqualError(t, err, tt.expectedError)
+		})
+	}
+}
+
+func TestDistributionPathClone(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		dist DistributionPath
+		want DistributionPath
+	}{
+		{
+			name: "empty distribution path",
+			dist: DistributionPath{},
+			want: DistributionPath{},
+		},
+		{
+			name: "distribution path with range",
+			dist: DistributionPath{
+				Reference: Reference{
+					Registry:   "example.com",
+					Repository: "foo/bar",
+					Tag:        "latest",
+				},
+				Scheme: "https",
+				Kind:   DistributionKindManifest,
+				Range: &httpx.Range{
+					Start: ptr.To[int64](0),
+					End:   ptr.To[int64](100),
+				},
+			},
+			want: DistributionPath{
+				Reference: Reference{
+					Registry:   "example.com",
+					Repository: "foo/bar",
+					Tag:        "latest",
+				},
+				Scheme: "https",
+				Kind:   DistributionKindManifest,
+				Range: &httpx.Range{
+					Start: ptr.To[int64](0),
+					End:   ptr.To[int64](100),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dist := tt.dist.Clone()
+			require.Equal(t, tt.want, dist)
+			if tt.dist.Range != nil {
+				require.NotSame(t, tt.want.Range, dist.Range)
+			}
 		})
 	}
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -266,18 +266,6 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 		return
 	}
 
-	// Make copy to not modify distribution range.
-	if dist.Range != nil {
-		rng := &httpx.Range{}
-		if dist.Range.Start != nil {
-			rng.Start = ptr.To(*dist.Range.Start)
-		}
-		if dist.Range.End != nil {
-			rng.End = ptr.To(*dist.Range.End)
-		}
-		dist.Range = rng
-	}
-
 	// Retry requests until success or timeout.
 	for {
 		done := func() bool {
@@ -326,6 +314,7 @@ func (r *Registry) mirrorHandler(ctx context.Context, dist oci.DistributionPath,
 					log.Error(err, "copying of manifest data failed")
 					return true
 				case oci.DistributionKindBlob:
+					dist = dist.Clone()
 					if dist.Range == nil {
 						dist.Range = &httpx.Range{
 							Start: ptr.To(int64(0)),


### PR DESCRIPTION
fix #1318 

Diagnostic & fix assisted by AI (GPT-5.3-Codex):
> Root Cause:
The race is on the mutable range object shared through DistributionPath.Range.
Read side: [client.go:315](https://github.com/spegel-org/spegel/blob/06c693120e23f372d6cbbc7e1cbc312ae21a8075/pkg/oci/client.go#L315) reads dist.Range.String() inside concurrent fetch/retry goroutines.
Write side: [registry.go:335](https://github.com/spegel-org/spegel/blob/06c693120e23f372d6cbbc7e1cbc312ae21a8075/pkg/registry/registry.go#L335) updates dist.Range.Start after a partial blob copy failure to resume from the next byte.
Why it races: DistributionPath is passed by value, but Range is a pointer field. So multiple goroutines end up sharing the same underlying Range object.

Solution is to pass a copy of the DistributionPath to fetch routines so they never race with the update at [registry.go:335](https://github.com/vflaux/spegel/blob/06c693120e23f372d6cbbc7e1cbc312ae21a8075/pkg/registry/registry.go#L335).
I don't think this bug affects responses by spegel - as it should only occurs in losing fetches - but this may still send requests with inconsistent ranges to other peers before being canceled.