### PR TITLE
Fix linting import order and grouping

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -86,24 +86,20 @@ linters:
         - error
         - empty
         - stdlib
-        - github.com/libp2p/go-libp2p/core/crypto.PrivKey
   exclusions:
-    generated: lax
     presets:
-      - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
-    - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - prefix(golang.org/x)
+        - default
+        - prefix(github.com/spegel-org)
+        - localmodule
+      no-inline-comments: true
+      no-prefix-comments: true
+      custom-order: true

--- a/internal/channel/gate_test.go
+++ b/internal/channel/gate_test.go
@@ -5,8 +5,9 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/spegel-org/spegel/internal/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spegel-org/spegel/internal/testutil"
 )
 
 func TestGate(t *testing.T) {

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -8,8 +8,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/go-logr/logr"
 
 	"github.com/spegel-org/spegel/internal/channel"
 	"github.com/spegel-org/spegel/pkg/httpx"

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanupFail(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -17,10 +17,11 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/alexflint/go-arg"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/spegel-org/spegel/internal/cleanup"
 	"github.com/spegel-org/spegel/internal/version"

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/spegel-org/spegel/pkg/httpx"
 )
 

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/go-logr/logr"
 	tlog "github.com/go-logr/logr/testing"
 	"github.com/libp2p/go-libp2p"
@@ -14,7 +16,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/spegel-org/spegel/internal/option"
 )

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"math/rand/v2"
 	"net/netip"
 	"regexp"
 	"slices"
@@ -11,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"math/rand/v2"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/go-logr/logr"
 	tlog "github.com/go-logr/logr/testing"
@@ -19,7 +20,6 @@ import (
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"


### PR DESCRIPTION
I have opinions about import ordering, so it should be enforced with a linter not at review time.  