### PR TITLE
feat(mirror): support override_path on additionalMirrorTargets

### DIFF
--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -63,7 +63,11 @@ spec:
           - http://$(NODE_IP):{{ .Values.service.registry.nodePort }}
           {{- with .Values.spegel.additionalMirrorTargets }}
           {{- range . }}
+          {{- if kindIs "string" . }}
           - {{ . | quote }}
+          {{- else }}
+          - {{ toJson . | quote }}
+          {{- end }}
           {{- end }}
           {{- end }}
           - --resolve-tags={{ .Values.spegel.resolveTags }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -162,8 +162,15 @@ spegel:
   mirroredRegistries: []
     # - https://docker.io
     # - https://ghcr.io
-  # -- Additional target mirror registries other than Spegel.
+  # -- Additional target mirror registries other than Spegel. Each entry is
+  # either a plain URL string, or an object with a url field and optional
+  # overridePath flag. overridePath maps to containerd's hosts.toml
+  # `override_path = true` and is required when the mirror URL contains a
+  # path prefix, for example AWS ECR pull-through cache.
   additionalMirrorTargets: []
+  #   - https://my-mirror.example.com
+  #   - url: https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub
+  #     overridePath: true
   # -- Max amount of mirrors to attempt.
   mirrorResolveRetries: 3
   # -- Max duration spent finding a mirror.

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -443,7 +443,7 @@ func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegi
 	if err != nil {
 		return err
 	}
-	parsedMirrorTargets, err := parseRegistries(mirrorTargets, false)
+	parsedMirrorTargets, err := parseMirrorTargets(mirrorTargets)
 	if err != nil {
 		return err
 	}
@@ -629,7 +629,7 @@ func clearConfig(configPath string) error {
 	return nil
 }
 
-func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, capabilities []string, username, password string) (string, error) {
+func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []parsedMirrorTarget, capabilities []string, username, password string) (string, error) {
 	server := parsedMirrorRegistry.String()
 	if parsedMirrorRegistry.String() == "https://docker.io" {
 		server = "https://registry-1.docker.io"
@@ -645,25 +645,37 @@ func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, 
 		authorization = "Basic " + authorization
 	}
 
+	type templateMirrorTarget struct {
+		URL          string
+		OverridePath bool
+	}
+	tmts := make([]templateMirrorTarget, 0, len(parsedMirrorTargets))
+	for _, mt := range parsedMirrorTargets {
+		tmts = append(tmts, templateMirrorTarget{URL: mt.URL.String(), OverridePath: mt.OverridePath})
+	}
+
 	hc := struct {
 		Authorization string
 		Server        string
 		Capabilities  string
-		MirrorTargets []url.URL
+		MirrorTargets []templateMirrorTarget
 	}{
 		Server:        server,
 		Capabilities:  fmt.Sprintf("['%s']", strings.Join(capabilities, "', '")),
-		MirrorTargets: parsedMirrorTargets,
+		MirrorTargets: tmts,
 		Authorization: authorization,
 	}
 	tmpl, err := template.New("").Parse(`{{- with .Server }}server = '{{ . }}'{{ end }}
 {{- $authorization := .Authorization }}
 {{ range .MirrorTargets }}
-[host.'{{ .String }}']
+[host.'{{ .URL }}']
 capabilities = {{ $.Capabilities }}
 dial_timeout = '200ms'
+{{- if .OverridePath }}
+override_path = true
+{{- end }}
 {{- if $authorization }}
-[host.'{{ .String }}'.header]
+[host.'{{ .URL }}'.header]
 Authorization = '{{ $authorization }}'
 {{- end }}
 {{ end }}`)

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -386,6 +386,28 @@ dial_timeout = '200ms'`,
 			},
 		},
 		{
+			name:               "mirror target with override path",
+			resolveTags:        true,
+			mirroredRegistries: []string{"https://docker.io"},
+			mirrorTargets: []string{
+				"http://127.0.0.1:5000",
+				`{"url":"https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub","overridePath":true}`,
+			},
+			prependExisting: false,
+			expectedFiles: map[string]string{
+				"docker.io/hosts.toml": `server = 'https://registry-1.docker.io'
+
+[host.'http://127.0.0.1:5000']
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
+
+[host.'https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub']
+capabilities = ['pull', 'resolve']
+dial_timeout = '200ms'
+override_path = true`,
+			},
+		},
+		{
 			name:               "with basic authentication",
 			resolveTags:        true,
 			mirroredRegistries: []string{"http://foo.bar:5000"},

--- a/pkg/oci/filter.go
+++ b/pkg/oci/filter.go
@@ -1,11 +1,13 @@
 package oci
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
 	"slices"
+	"strings"
 )
 
 var (
@@ -72,6 +74,104 @@ func FilterForMirroredRegistries(mirroredRegistries []string) (*RegistryWhitelis
 		registryHosts = append(registryHosts, ru.Host)
 	}
 	return &RegistryWhitelistFilter{Whitelist: registryHosts}, nil
+}
+
+// MirrorTarget represents a single mirror endpoint that Spegel should write
+// into containerd's hosts.toml. It can be expressed either as a plain URL
+// string or as a struct with additional options such as OverridePath, which
+// is required when the mirror URL contains a path prefix (for example AWS
+// ECR pull-through cache, where the upstream URL is shaped as
+// <account>.dkr.ecr.<region>.amazonaws.com/v2/<cache-prefix>).
+type MirrorTarget struct {
+	URL          string `json:"url" yaml:"url"`
+	OverridePath bool   `json:"overridePath" yaml:"overridePath"`
+}
+
+// UnmarshalJSON allows MirrorTarget to be decoded either from a plain JSON
+// string (backwards compatible) or from a JSON object with a url field.
+func (m *MirrorTarget) UnmarshalJSON(b []byte) error {
+	trimmed := strings.TrimSpace(string(b))
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		m.URL = s
+		m.OverridePath = false
+		return nil
+	}
+	type raw MirrorTarget
+	var r raw
+	if err := json.Unmarshal(b, &r); err != nil {
+		return err
+	}
+	*m = MirrorTarget(r)
+	return nil
+}
+
+// parseMirrorTarget parses a single mirror target entry. The entry can be a
+// plain URL or a JSON object of the form {"url":"...","overridePath":true}.
+// This allows Helm charts to configure the new struct form without changing
+// the underlying CLI flag type.
+func parseMirrorTarget(s string) (MirrorTarget, error) {
+	trimmed := strings.TrimSpace(s)
+	if strings.HasPrefix(trimmed, "{") {
+		var mt MirrorTarget
+		if err := json.Unmarshal([]byte(trimmed), &mt); err != nil {
+			return MirrorTarget{}, fmt.Errorf("invalid mirror target JSON: %w", err)
+		}
+		if mt.URL == "" {
+			return MirrorTarget{}, errors.New("invalid mirror target: url is required")
+		}
+		return mt, nil
+	}
+	return MirrorTarget{URL: trimmed}, nil
+}
+
+// parseMirrorTargets parses the raw mirror target entries supplied through
+// the --mirror-targets flag, validating each URL. Mirror targets are not
+// allowed to contain a path unless OverridePath is set, in which case the
+// path is forwarded as-is to containerd through hosts.toml.
+func parseMirrorTargets(entries []string) ([]parsedMirrorTarget, error) {
+	out := []parsedMirrorTarget{}
+	for _, e := range entries {
+		mt, err := parseMirrorTarget(e)
+		if err != nil {
+			return nil, err
+		}
+		u, err := url.Parse(mt.URL)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateMirrorTargetURL(u, mt.OverridePath); err != nil {
+			return nil, err
+		}
+		out = append(out, parsedMirrorTarget{URL: *u, OverridePath: mt.OverridePath})
+	}
+	return out, nil
+}
+
+// parsedMirrorTarget is the internal representation handed to templateHosts.
+type parsedMirrorTarget struct {
+	URL          url.URL
+	OverridePath bool
+}
+
+func validateMirrorTargetURL(u *url.URL, overridePath bool) error {
+	errs := []error{}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		errs = append(errs, fmt.Errorf("invalid registry url scheme must be http or https: %s", u.String()))
+	}
+	if u.Path != "" && !overridePath {
+		errs = append(errs, fmt.Errorf("invalid registry url path has to be empty: %s", u.String()))
+	}
+	if len(u.Query()) != 0 {
+		errs = append(errs, fmt.Errorf("invalid registry url query has to be empty: %s", u.String()))
+	}
+	if u.User != nil {
+		errs = append(errs, fmt.Errorf("invalid registry url user has to be empty: %s", u.String()))
+	}
+	return errors.Join(errs...)
 }
 
 func parseRegistries(registries []string, allowWildcard bool) ([]url.URL, error) {

--- a/pkg/oci/filter_test.go
+++ b/pkg/oci/filter_test.go
@@ -155,6 +155,83 @@ func TestParseRegistries(t *testing.T) {
 	}
 }
 
+func TestParseMirrorTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain URL", func(t *testing.T) {
+		t.Parallel()
+		mts, err := parseMirrorTargets([]string{"http://127.0.0.1:5000"})
+		require.NoError(t, err)
+		require.Len(t, mts, 1)
+		require.Equal(t, "http://127.0.0.1:5000", mts[0].URL.String())
+		require.False(t, mts[0].OverridePath)
+	})
+
+	t.Run("JSON object enables override path", func(t *testing.T) {
+		t.Parallel()
+		entry := `{"url":"https://123.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub","overridePath":true}`
+		mts, err := parseMirrorTargets([]string{entry})
+		require.NoError(t, err)
+		require.Len(t, mts, 1)
+		require.Equal(t, "https://123.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub", mts[0].URL.String())
+		require.True(t, mts[0].OverridePath)
+	})
+
+	t.Run("path requires override path", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseMirrorTargets([]string{"https://example.com/v2/cache"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid registry url path has to be empty")
+	})
+
+	t.Run("mixed plain and struct", func(t *testing.T) {
+		t.Parallel()
+		mts, err := parseMirrorTargets([]string{
+			"http://127.0.0.1:5000",
+			`{"url":"https://example.com/v2/foo","overridePath":true}`,
+		})
+		require.NoError(t, err)
+		require.Len(t, mts, 2)
+		require.False(t, mts[0].OverridePath)
+		require.True(t, mts[1].OverridePath)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseMirrorTargets([]string{`{"url":}`})
+		require.Error(t, err)
+	})
+
+	t.Run("missing url in struct", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseMirrorTargets([]string{`{"overridePath":true}`})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "url is required")
+	})
+}
+
+func TestMirrorTargetUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string form", func(t *testing.T) {
+		t.Parallel()
+		var mt MirrorTarget
+		err := mt.UnmarshalJSON([]byte(`"https://example.com"`))
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com", mt.URL)
+		require.False(t, mt.OverridePath)
+	})
+
+	t.Run("object form", func(t *testing.T) {
+		t.Parallel()
+		var mt MirrorTarget
+		err := mt.UnmarshalJSON([]byte(`{"url":"https://example.com/v2/cache","overridePath":true}`))
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/v2/cache", mt.URL)
+		require.True(t, mt.OverridePath)
+	})
+}
+
 func TestValidateRegistryURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds support for `override_path = true` on individual entries in `additionalMirrorTargets`. This makes Spegel usable as a transparent client in front of registries that expect a path prefix — most notably AWS ECR pull-through cache, where the upstream URL is shaped as `<account>.dkr.ecr.<region>.amazonaws.com/v2/<cache-prefix>`.

containerd's [hosts.toml](https://github.com/containerd/containerd/blob/main/docs/hosts.md#override_path-field) already supports `override_path = true` so that the configured URL is used literally, instead of containerd appending `/v2/<image>` to it. Spegel currently emits no such field, which means a target like `https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub` is silently turned into `https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub/v2/library/alpine/manifests/...` and the request fails.

This unblocks deployments that want to combine Spegel's peer-to-peer cache with ECR pull-through cache as a fallback target.

Closes #277.
Closes #708.

## Use case (ECR pull-through cache)

```yaml
spegel:
  mirroredRegistries:
    - https://docker.io
  additionalMirrorTargets:
    - url: https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub
      overridePath: true
```

## Before / after

`hosts.toml` rendered for the example above.

**Before** (existing behaviour — entry is rejected by `validateRegistryURL` because the path is non-empty):

```
invalid registry url path has to be empty: https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub
```

**After**:

```toml
server = 'https://docker.io'

[host.'http://127.0.0.1:5000']
capabilities = ['pull', 'resolve']
dial_timeout = '200ms'

[host.'https://123456789012.dkr.ecr.eu-west-1.amazonaws.com/v2/docker-hub']
capabilities = ['pull', 'resolve']
dial_timeout = '200ms'
override_path = true
```

## Backwards compatibility

Plain string entries continue to work unchanged. The Helm chart accepts either:

```yaml
additionalMirrorTargets:
  - https://my-mirror.example.com         # plain string (existing)
  - url: https://my-ecr/v2/docker-hub     # new struct form
    overridePath: true
```

Internally:

- A new `MirrorTarget` type is introduced with a custom `UnmarshalJSON` that accepts both a string and an object form.
- `parseMirrorTargets` parses each `--mirror-targets` flag value as either a plain URL or a JSON object.
- `validateMirrorTargetURL` permits a non-empty path only when `overridePath` is set; the wildcard / mirrored-registry validator (`validateRegistryURL`) is unchanged.
- The Helm chart renders plain strings as-is, and renders struct-form entries as a JSON object string. The CLI flag remains a `[]string`, so existing users see no change.

## Test plan

- [x] `go test ./...` passes locally
- [x] `helm lint charts/spegel` passes
- [x] `helm template charts/spegel` correctly renders both forms
- [x] New unit tests cover both plain and override-path entries (`TestParseMirrorTargets`, `TestMirrorTargetUnmarshalJSON`, and a new `TestMirrorConfiguration` case asserting that `override_path = true` ends up in `hosts.toml`)
- [ ] Maintainers to confirm CI passes