### PR TITLE
Upgrade testify assertions to generic variants

### DIFF
--- a/internal/channel/channel_test.go
+++ b/internal/channel/channel_test.go
@@ -41,5 +41,5 @@ func TestMerge(t *testing.T) {
 	<-waitCtx.Done()
 
 	expected := []int{1, 2, 3, 4, 5, 6}
-	require.ElementsMatch(t, expected, results)
+	require.ElementsMatchT(t, expected, results)
 }

--- a/internal/channel/gate_test.go
+++ b/internal/channel/gate_test.go
@@ -17,7 +17,7 @@ func TestGate(t *testing.T) {
 		gate := NewGate()
 
 		// Gate should start off closed.
-		require.False(t, gate.State())
+		require.FalseT(t, gate.State())
 		testutil.RequireChannelReceive(t, gate.WaitFor(false))
 
 		// Gate should block until it is opened.
@@ -27,7 +27,7 @@ func TestGate(t *testing.T) {
 			gate.Open()
 		}()
 		<-gate.WaitFor(true)
-		require.Equal(t, 1*time.Second, time.Since(start))
-		require.True(t, gate.State())
+		require.EqualT(t, 1*time.Second, time.Since(start))
+		require.TrueT(t, gate.State())
 	})
 }

--- a/internal/option/option_test.go
+++ b/internal/option/option_test.go
@@ -42,5 +42,5 @@ func TestApply(t *testing.T) {
 
 	err = Apply(&cfg, withData("foo bar"))
 	require.NoError(t, err)
-	require.Equal(t, "foo bar", cfg.Data)
+	require.EqualT(t, "foo bar", cfg.Data)
 }

--- a/internal/ptr/ptr_test.go
+++ b/internal/ptr/ptr_test.go
@@ -11,6 +11,6 @@ func TestTo(t *testing.T) {
 
 	v := "hello world"
 	p := To(v)
-	require.Equal(t, v, *p)
+	require.EqualT(t, v, *p)
 	require.Equal(t, &v, p)
 }

--- a/internal/resilient/hedge_test.go
+++ b/internal/resilient/hedge_test.go
@@ -44,7 +44,7 @@ func TestHedger(t *testing.T) {
 			t.Parallel()
 
 			hedger := NewHedger([]float64{80, 90, 95}, 100*time.Millisecond)
-			require.Equal(t, 3, hedger.Size())
+			require.EqualT(t, 3, hedger.Size())
 			for _, d := range tt.observations {
 				err := hedger.Observe(d)
 				require.NoError(t, err)
@@ -56,10 +56,10 @@ func TestHedger(t *testing.T) {
 				durations := []time.Duration{}
 				for range 3 {
 					_, ok := <-ch
-					require.True(t, ok)
+					require.TrueT(t, ok)
 					durations = append(durations, time.Since(start))
 				}
-				require.Equal(t, tt.expected, durations)
+				require.SliceEqualT(t, tt.expected, durations)
 			})
 		})
 	}

--- a/internal/resilient/retry_test.go
+++ b/internal/resilient/retry_test.go
@@ -16,7 +16,7 @@ func TestDelayFunc(t *testing.T) {
 
 	expected := 13 * time.Millisecond
 	d := FixedDelay(expected)(10, nil)
-	require.Equal(t, expected, d)
+	require.EqualT(t, expected, d)
 
 	delay := BackoffDelay(10*time.Millisecond, 140*time.Millisecond)
 	expectedDurations := []time.Duration{
@@ -28,7 +28,7 @@ func TestDelayFunc(t *testing.T) {
 	}
 	for i := range 5 {
 		d := delay(i+1, fmt.Errorf("%d", i))
-		require.Equal(t, expectedDurations[i], d)
+		require.EqualT(t, expectedDurations[i], d)
 	}
 }
 
@@ -96,7 +96,7 @@ func TestRetry(t *testing.T) {
 		return errors.New("retry error")
 	}, retryOpts...)
 	require.NoError(t, err)
-	require.Equal(t, retries-1, count)
+	require.EqualT(t, retries-1, count)
 
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel = context.WithTimeout(t.Context(), 1*time.Second)

--- a/pkg/httpx/header_test.go
+++ b/pkg/httpx/header_test.go
@@ -16,5 +16,5 @@ func TestCopyHeader(t *testing.T) {
 	dst := http.Header{}
 	CopyHeader(dst, src)
 
-	require.Equal(t, []string{"2", "1"}, dst.Values("foo"))
+	require.SliceEqualT(t, []string{"2", "1"}, dst.Values("foo"))
 }

--- a/pkg/httpx/httpx_test.go
+++ b/pkg/httpx/httpx_test.go
@@ -19,9 +19,9 @@ func TestBaseClient(t *testing.T) {
 	t.Parallel()
 
 	c := BaseClient()
-	require.Equal(t, 10*time.Second, c.Timeout)
+	require.EqualT(t, 10*time.Second, c.Timeout)
 	_, ok := c.Transport.(*http.Transport)
-	require.True(t, ok)
+	require.TrueT(t, ok)
 }
 
 func TestBaseTransport(t *testing.T) {

--- a/pkg/httpx/mux_test.go
+++ b/pkg/httpx/mux_test.go
@@ -34,7 +34,7 @@ func TestServeMux(t *testing.T) {
 	}
 
 	expectedHandlersCalled := []string{"prefix", "exact", "prefix"}
-	require.Equal(t, expectedHandlersCalled, handlersCalled)
+	require.SliceEqualT(t, expectedHandlersCalled, handlersCalled)
 
 	expectedMetrics := `
 # HELP http_requests_inflight The number of inflight requests being handled at the same time.
@@ -118,7 +118,7 @@ func TestGetClientIP(t *testing.T) {
 			t.Parallel()
 
 			ip := GetClientIP(tt.request)
-			require.Equal(t, tt.expected, ip)
+			require.EqualT(t, tt.expected, ip)
 		})
 	}
 }
@@ -153,7 +153,7 @@ func TestMetricsFriendlyPath(t *testing.T) {
 				t.Parallel()
 
 				metricsPath := metricsFriendlyPath(method + tt.pattern)
-				require.Equal(t, tt.expected, metricsPath)
+				require.EqualT(t, tt.expected, metricsPath)
 			})
 		}
 	}

--- a/pkg/httpx/race_test.go
+++ b/pkg/httpx/race_test.go
@@ -73,5 +73,5 @@ func TestHappyEyeballs(t *testing.T) {
 		return string(b), nil
 	})
 	require.NoError(t, err)
-	require.Equal(t, "Hello World", res)
+	require.EqualT(t, "Hello World", res)
 }

--- a/pkg/httpx/range_test.go
+++ b/pkg/httpx/range_test.go
@@ -72,7 +72,7 @@ func TestRange(t *testing.T) {
 			r, err := ParseRangeHeader(header)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedRange, *r)
-			require.Equal(t, tt.expectedString, r.String())
+			require.EqualT(t, tt.expectedString, r.String())
 		})
 	}
 
@@ -205,8 +205,8 @@ func TestContentRange(t *testing.T) {
 			require.NoError(t, err)
 			crng, err := ContentRangeFromRange(*rng, tt.size)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedString, crng.String())
-			require.Equal(t, tt.expectedLength, crng.Length())
+			require.EqualT(t, tt.expectedString, crng.String())
+			require.EqualT(t, tt.expectedLength, crng.Length())
 		})
 	}
 
@@ -273,7 +273,7 @@ func TestRangeClone(t *testing.T) {
 			t.Parallel()
 			rng := tt.rng.Clone()
 			if tt.rng != nil {
-				require.NotSame(t, tt.rng, rng)
+				require.NotSameT(t, tt.rng, rng)
 			}
 			require.Equal(t, tt.want, rng)
 		})

--- a/pkg/httpx/response_test.go
+++ b/pkg/httpx/response_test.go
@@ -17,51 +17,51 @@ func TestResponseWriter(t *testing.T) {
 
 	var httpRw http.ResponseWriter = &response{}
 	_, ok := httpRw.(io.ReaderFrom)
-	require.True(t, ok)
+	require.TrueT(t, ok)
 
 	rw, rec := NewRecorder()
 	//nolint: errcheck // No need to check unwrap.
 	require.Equal(t, rec, rw.(*response).Unwrap())
 	require.NoError(t, rw.Error())
-	require.Equal(t, int64(0), rw.Size())
-	require.Equal(t, http.StatusOK, rw.Status())
+	require.EqualT(t, int64(0), rw.Size())
+	require.EqualT(t, http.StatusOK, rw.Status())
 
 	rw, _ = NewRecorder()
 	rw.WriteHeader(http.StatusNotFound)
 	//nolint: errcheck // No need to check unwrap.
-	require.True(t, rw.(*response).wroteHeader)
-	require.Equal(t, http.StatusNotFound, rw.Status())
+	require.TrueT(t, rw.(*response).wroteHeader)
+	require.EqualT(t, http.StatusNotFound, rw.Status())
 	rw.WriteHeader(http.StatusBadGateway)
-	require.Equal(t, http.StatusNotFound, rw.Status())
+	require.EqualT(t, http.StatusNotFound, rw.Status())
 	_, err := rw.Write([]byte("foo"))
 	require.NoError(t, err)
-	require.Equal(t, http.StatusNotFound, rw.Status())
+	require.EqualT(t, http.StatusNotFound, rw.Status())
 
 	rw, _ = NewRecorder()
 	first := "hello world"
 	n, err := rw.Write([]byte(first))
-	require.Equal(t, http.StatusOK, rw.Status())
+	require.EqualT(t, http.StatusOK, rw.Status())
 	require.NoError(t, err)
-	require.Equal(t, len(first), n)
-	require.Equal(t, int64(len(first)), rw.Size())
+	require.EqualT(t, len(first), n)
+	require.EqualT(t, int64(len(first)), rw.Size())
 	second := "foo bar"
 	n, err = rw.Write([]byte(second))
 	require.NoError(t, err)
-	require.Equal(t, len(second), n)
-	require.Equal(t, int64(len(first)+len(second)), rw.Size())
+	require.EqualT(t, len(second), n)
+	require.EqualT(t, int64(len(first)+len(second)), rw.Size())
 
 	rw, _ = NewRecorder()
 	r := strings.NewReader("reader")
 	//nolint: errcheck // No need to check unwrap.
 	readFromN, err := rw.(*response).ReadFrom(r)
 	require.NoError(t, err)
-	require.Equal(t, r.Size(), readFromN)
-	require.Equal(t, r.Size(), rw.Size())
+	require.EqualT(t, r.Size(), readFromN)
+	require.EqualT(t, r.Size(), rw.Size())
 
 	rw, _ = NewRecorder()
 	rw.SetAttrs("foo", "bar")
 	//nolint: errcheck // No need to check unwrap.
-	require.Equal(t, map[string]any{"foo": "bar"}, rw.(*response).attrs)
+	require.MapEqualT(t, map[string]any{"foo": "bar"}, rw.(*response).attrs)
 }
 
 func TestResponseWriterError(t *testing.T) {
@@ -100,10 +100,10 @@ func TestResponseWriterError(t *testing.T) {
 				}
 				rw.WriteError(http.StatusInternalServerError, tt.err)
 				require.Equal(t, tt.err, rw.Error())
-				require.Equal(t, http.StatusInternalServerError, rw.Status())
+				require.EqualT(t, http.StatusInternalServerError, rw.Status())
 				require.Equal(t, tt.expectedHeaders, rec.Header())
 				if method != http.MethodHead {
-					require.Equal(t, tt.expectedBody, rec.Body.String())
+					require.EqualT(t, tt.expectedBody, rec.Body.String())
 				}
 			})
 		}

--- a/pkg/httpx/template_test.go
+++ b/pkg/httpx/template_test.go
@@ -19,7 +19,7 @@ func TestRenderTemplate(t *testing.T) {
 	rw, rec := NewRecorder()
 	RenderTemplate(rw, tmpl, nil)
 	resp := rec.Result()
-	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	require.EqualT(t, http.StatusInternalServerError, resp.StatusCode)
 
 	data := struct {
 		Test string
@@ -29,10 +29,10 @@ func TestRenderTemplate(t *testing.T) {
 	rw, rec = NewRecorder()
 	RenderTemplate(rw, tmpl, data)
 	resp = rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.Equal(t, ContentTypeHTML, rw.Header().Get(HeaderContentType))
-	require.Equal(t, strconv.FormatInt(int64(len(data.Test)), 10), rw.Header().Get(HeaderContentLength))
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, ContentTypeHTML, rw.Header().Get(HeaderContentType))
+	require.EqualT(t, strconv.FormatInt(int64(len(data.Test)), 10), rw.Header().Get(HeaderContentLength))
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, data.Test, string(b))
+	require.EqualT(t, data.Test, string(b))
 }

--- a/pkg/oci/client_test.go
+++ b/pkg/oci/client_test.go
@@ -98,8 +98,8 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	_, desc, err := ociClient.Fetch(t.Context(), dist, WithFetchMirror(mirror))
 	require.NoError(t, err)
-	require.Equal(t, dist.Digest, desc.Digest)
-	require.Equal(t, httpx.ContentTypeBinary, desc.MediaType)
+	require.EqualT(t, dist.Digest, desc.Digest)
+	require.EqualT(t, httpx.ContentTypeBinary, desc.MediaType)
 }
 
 func TestDescriptorHeader(t *testing.T) {
@@ -112,9 +112,9 @@ func TestDescriptorHeader(t *testing.T) {
 		Digest:    digest.Digest("sha256:b6d6089ca6c395fd563c2084f5dd7bc56a2f5e6a81413558c5be0083287a77e9"),
 	}
 	WriteDescriptorToHeader(desc, header)
-	require.Equal(t, "foo", header.Get(httpx.HeaderContentType))
-	require.Equal(t, "909", header.Get(httpx.HeaderContentLength))
-	require.Equal(t, "sha256:b6d6089ca6c395fd563c2084f5dd7bc56a2f5e6a81413558c5be0083287a77e9", header.Get(HeaderDockerDigest))
+	require.EqualT(t, "foo", header.Get(httpx.HeaderContentType))
+	require.EqualT(t, "909", header.Get(httpx.HeaderContentLength))
+	require.EqualT(t, "sha256:b6d6089ca6c395fd563c2084f5dd7bc56a2f5e6a81413558c5be0083287a77e9", header.Get(HeaderDockerDigest))
 	headerDesc, err := DescriptorFromHeader(header)
 	require.NoError(t, err)
 	require.Equal(t, desc, headerDesc)

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -23,7 +23,7 @@ func TestBackupConfig(t *testing.T) {
 	require.NoError(t, err)
 	ok, err := dirExists(filepath.Join(configPath, "_backup"))
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.TrueT(t, ok)
 	files, err := os.ReadDir(filepath.Join(configPath, "_backup"))
 	require.NoError(t, err)
 	require.Empty(t, files)
@@ -35,7 +35,7 @@ func TestBackupConfig(t *testing.T) {
 	require.NoError(t, err)
 	ok, err = dirExists(filepath.Join(configPath, "_backup"))
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.TrueT(t, ok)
 	files, err = os.ReadDir(filepath.Join(configPath, "_backup"))
 	require.NoError(t, err)
 	require.Len(t, files, 1)
@@ -89,7 +89,7 @@ func TestContentLabelsToReferences(t *testing.T) {
 
 			refs, err := contentLabelsToReferences(tt.labels, dgst)
 			require.NoError(t, err)
-			require.ElementsMatch(t, tt.expected, refs)
+			require.ElementsMatchT(t, tt.expected, refs)
 		})
 	}
 
@@ -430,7 +430,7 @@ Authorization = 'Basic aGVsbG86d29ybGQ='`,
 			require.NoError(t, err)
 			ok, err := dirExists(filepath.Join(registryConfigPath, "_backup"))
 			require.NoError(t, err)
-			require.True(t, ok)
+			require.TrueT(t, ok)
 			seenExpectedFiles := maps.Clone(tt.expectedFiles)
 			err = filepath.Walk(registryConfigPath, func(path string, fi iofs.FileInfo, _ error) error {
 				if fi.IsDir() {
@@ -439,11 +439,11 @@ Authorization = 'Basic aGVsbG86d29ybGQ='`,
 				relPath, err := filepath.Rel(registryConfigPath, path)
 				require.NoError(t, err)
 				expectedContent, ok := tt.expectedFiles[relPath]
-				require.True(t, ok, relPath)
+				require.TrueT(t, ok, relPath)
 				delete(seenExpectedFiles, relPath)
 				b, err := os.ReadFile(path)
 				require.NoError(t, err)
-				require.Equal(t, expectedContent, string(b))
+				require.EqualT(t, expectedContent, string(b))
 				return nil
 			})
 			require.NoError(t, err)
@@ -535,7 +535,7 @@ x-custom-2 = ['foo']
 [host.'https://non-compliant-mirror.registry/v2/upstream']
 capabilities = ['pull']
 override_path = true`
-	require.Equal(t, expected, eh)
+	require.EqualT(t, expected, eh)
 }
 
 func TestCleanupMirrorConfiguration(t *testing.T) {
@@ -557,6 +557,6 @@ func TestCleanupMirrorConfiguration(t *testing.T) {
 		files, err := os.ReadDir(configPath)
 		require.NoError(t, err)
 		require.Len(t, files, 1)
-		require.Equal(t, "data.txt", files[0].Name())
+		require.EqualT(t, "data.txt", files[0].Name())
 	}
 }

--- a/pkg/oci/distribution_test.go
+++ b/pkg/oci/distribution_test.go
@@ -89,14 +89,14 @@ func TestParseDistributionPath(t *testing.T) {
 			require.NoError(t, err)
 			dist, err := ParseDistributionPath(req)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedName, dist.Repository)
-			require.Equal(t, tt.expectedDgst, dist.Digest)
-			require.Equal(t, tt.expectedTag, dist.Tag)
-			require.Equal(t, tt.expectedRef, dist.Identifier())
-			require.Equal(t, tt.expectedKind, dist.Kind)
-			require.Equal(t, tt.registry, dist.Registry)
-			require.Equal(t, tt.path, dist.URL().Path)
-			require.Equal(t, tt.registry, dist.URL().Query().Get("ns"))
+			require.EqualT(t, tt.expectedName, dist.Repository)
+			require.EqualT(t, tt.expectedDgst, dist.Digest)
+			require.EqualT(t, tt.expectedTag, dist.Tag)
+			require.EqualT(t, tt.expectedRef, dist.Identifier())
+			require.EqualT(t, tt.expectedKind, dist.Kind)
+			require.EqualT(t, tt.registry, dist.Registry)
+			require.EqualT(t, tt.path, dist.URL().Path)
+			require.EqualT(t, tt.registry, dist.URL().Query().Get("ns"))
 		})
 	}
 }
@@ -215,7 +215,7 @@ func TestDistributionPathClone(t *testing.T) {
 			dist := tt.dist.Clone()
 			require.Equal(t, tt.want, dist)
 			if tt.dist.Range != nil {
-				require.NotSame(t, tt.want.Range, dist.Range)
+				require.NotSameT(t, tt.want.Range, dist.Range)
 			}
 		})
 	}

--- a/pkg/oci/filter_test.go
+++ b/pkg/oci/filter_test.go
@@ -50,7 +50,7 @@ func TestMatchesFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, tt.expected, MatchesFilter(tt.ref, tt.filters))
+			require.EqualT(t, tt.expected, MatchesFilter(tt.ref, tt.filters))
 		})
 	}
 }
@@ -85,7 +85,7 @@ func TestFilterForMirroredRegistries(t *testing.T) {
 	filter, err := FilterForMirroredRegistries(registries)
 	require.NoError(t, err)
 	expected := []string{"docker.io", "quay.io", "localhost:5000"}
-	require.Equal(t, expected, filter.Whitelist)
+	require.SliceEqualT(t, expected, filter.Whitelist)
 
 	ref := Reference{
 		Registry:   "localhost:6000",
@@ -93,7 +93,7 @@ func TestFilterForMirroredRegistries(t *testing.T) {
 		Tag:        "bar",
 	}
 	matches := MatchesFilter(ref, []Filter{filter})
-	require.True(t, matches)
+	require.TrueT(t, matches)
 
 	ref = Reference{
 		Registry:   "localhost:5000",
@@ -101,7 +101,7 @@ func TestFilterForMirroredRegistries(t *testing.T) {
 		Tag:        "bar",
 	}
 	matches = MatchesFilter(ref, []Filter{filter})
-	require.False(t, matches)
+	require.FalseT(t, matches)
 
 	ref = Reference{
 		Registry:   "docker.io",
@@ -109,7 +109,7 @@ func TestFilterForMirroredRegistries(t *testing.T) {
 		Tag:        "bar",
 	}
 	matches = MatchesFilter(ref, []Filter{filter})
-	require.False(t, matches)
+	require.FalseT(t, matches)
 }
 
 func TestParseRegistries(t *testing.T) {
@@ -123,7 +123,7 @@ func TestParseRegistries(t *testing.T) {
 		strs = append(strs, ru.String())
 	}
 	expected := []string{"https://docker.io", "//_default", "http://localhost:9090"}
-	require.Equal(t, expected, strs)
+	require.SliceEqualT(t, expected, strs)
 
 	//nolint: govet // Prioritize readability in tests.
 	fail := []struct {

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -82,19 +82,19 @@ func TestParseImageStrict(t *testing.T) {
 						continue
 					}
 					require.NoError(t, err)
-					require.Equal(t, registry, img.Registry)
-					require.Equal(t, tt.expectedRepository, img.Repository)
-					require.Equal(t, tt.expectedTag, img.Tag)
-					require.Equal(t, tt.expectedDigest, img.Digest)
+					require.EqualT(t, registry, img.Registry)
+					require.EqualT(t, tt.expectedRepository, img.Repository)
+					require.EqualT(t, tt.expectedTag, img.Tag)
+					require.EqualT(t, tt.expectedDigest, img.Digest)
 					tagName, ok := img.TagName()
 					if tt.expectedTag == "" {
-						require.False(t, ok)
+						require.FalseT(t, ok)
 						require.Empty(t, tagName)
 					} else {
-						require.True(t, ok)
-						require.Equal(t, registry+"/"+tt.expectedRepository+":"+tt.expectedTag, tagName)
+						require.TrueT(t, ok)
+						require.EqualT(t, registry+"/"+tt.expectedRepository+":"+tt.expectedTag, tagName)
 					}
-					require.Equal(t, fmt.Sprintf("%s/%s", registry, tt.expectedString), img.String())
+					require.EqualT(t, fmt.Sprintf("%s/%s", registry, tt.expectedString), img.String())
 				}
 			})
 		}
@@ -249,7 +249,7 @@ func TestParseImageDefaults(t *testing.T) {
 
 			img, err := ParseImage(tt.input, AllowDefaults(), AllowTagOnly())
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, img.String())
+			require.EqualT(t, tt.expected, img.String())
 		})
 	}
 }

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -56,13 +56,13 @@ func TestFingerprintMediaType(t *testing.T) {
 			defer f.Close()
 			mt, err := FingerprintMediaType(f)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedMediaType, mt)
+			require.EqualT(t, tt.expectedMediaType, mt)
 		})
 	}
 
 	mt, err := FingerprintMediaType(strings.NewReader("{}"))
 	require.NoError(t, err)
-	require.Equal(t, ocispec.MediaTypeEmptyJSON, mt)
+	require.EqualT(t, ocispec.MediaTypeEmptyJSON, mt)
 
 	_, err = FingerprintMediaType(strings.NewReader(" "))
 	require.ErrorIs(t, err, io.EOF)
@@ -110,7 +110,7 @@ func TestIsManifestMediatype(t *testing.T) {
 			t.Parallel()
 
 			ok := IsManifestsMediatype(tt.mt)
-			require.Equal(t, tt.expected, ok)
+			require.EqualT(t, tt.expected, ok)
 		})
 	}
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -51,12 +51,12 @@ func TestRegistryOptions(t *testing.T) {
 	cfg := RegistryConfig{}
 	err = option.Apply(&cfg, opts...)
 	require.NoError(t, err)
-	require.Equal(t, 5, cfg.ResolveRetries)
-	require.Equal(t, filters, cfg.Filters)
-	require.Equal(t, 10*time.Minute, cfg.ResolveTimeout)
+	require.EqualT(t, 5, cfg.ResolveRetries)
+	require.SliceEqualT(t, filters, cfg.Filters)
+	require.EqualT(t, 10*time.Minute, cfg.ResolveTimeout)
 	require.Equal(t, ociClient, cfg.OCIClient)
-	require.Equal(t, "foo", cfg.Username)
-	require.Equal(t, "bar", cfg.Password)
+	require.EqualT(t, "foo", cfg.Username)
+	require.EqualT(t, "bar", cfg.Password)
 }
 
 func TestProbeHandlers(t *testing.T) {
@@ -77,21 +77,21 @@ func TestProbeHandlers(t *testing.T) {
 	rw := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost/readyz", nil)
 	handler.ServeHTTP(rw, req)
-	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+	require.EqualT(t, http.StatusOK, rw.Result().StatusCode)
 	rw = httptest.NewRecorder()
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost/livez", nil)
 	handler.ServeHTTP(rw, req)
-	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+	require.EqualT(t, http.StatusOK, rw.Result().StatusCode)
 
 	router.SetReadiness(false)
 	rw = httptest.NewRecorder()
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost/readyz", nil)
 	handler.ServeHTTP(rw, req)
-	require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+	require.EqualT(t, http.StatusInternalServerError, rw.Result().StatusCode)
 	rw = httptest.NewRecorder()
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost/livez", nil)
 	handler.ServeHTTP(rw, req)
-	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+	require.EqualT(t, http.StatusOK, rw.Result().StatusCode)
 }
 
 func TestBasicAuth(t *testing.T) {
@@ -164,7 +164,7 @@ func TestBasicAuth(t *testing.T) {
 			handler := reg.Handler(logr.Discard())
 			handler.ServeHTTP(rw, req)
 
-			require.Equal(t, tt.expected, rw.Result().StatusCode)
+			require.EqualT(t, tt.expected, rw.Result().StatusCode)
 		})
 	}
 }
@@ -471,11 +471,11 @@ func TestRegistryHandler(t *testing.T) {
 				defer httpx.DrainAndClose(resp.Body)
 				b, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
-				require.Equal(t, tt.expectedStatus, resp.StatusCode)
+				require.EqualT(t, tt.expectedStatus, resp.StatusCode)
 
 				switch method {
 				case http.MethodGet:
-					require.Equal(t, tt.expectedBody, b)
+					require.SliceEqualT(t, tt.expectedBody, b)
 				case http.MethodHead:
 					require.Empty(t, b)
 				default:
@@ -562,7 +562,7 @@ func TestFetchChannel(t *testing.T) {
 			time.Sleep(1 * time.Second)
 			synctest.Wait()
 			testutil.RequireChannelReceive(t, fetchCh)
-			require.Equal(t, time.Second, time.Since(start))
+			require.EqualT(t, time.Second, time.Since(start))
 		}
 
 		// Fetch skips hedges when immediate are called.
@@ -583,7 +583,7 @@ func TestFetchChannel(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		synctest.Wait()
 		testutil.RequireChannelReceive(t, fetchCh)
-		require.Equal(t, time.Second, time.Since(start))
+		require.EqualT(t, time.Second, time.Since(start))
 
 		synctest.Wait()
 		time.Sleep(1 * time.Second)

--- a/pkg/routing/bootstrap_test.go
+++ b/pkg/routing/bootstrap_test.go
@@ -91,7 +91,7 @@ func TestDNSBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
 	require.Len(t, addrInfos[0].Addrs, 1)
-	require.Equal(t, "{: [/ip4/10.1.2.3]}", addrInfos[0].String())
+	require.EqualT(t, "{: [/ip4/10.1.2.3]}", addrInfos[0].String())
 
 	cancel()
 	err = g.Wait()
@@ -128,8 +128,8 @@ func TestHTTPBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
 	require.Len(t, addrInfos[0].Addrs, 1)
-	require.Equal(t, parentAddrInfo.ID, addrInfos[0].ID)
-	require.Equal(t, "{12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB: [/ip4/127.0.0.1/tcp/4001]}", addrInfos[0].String())
+	require.EqualT(t, parentAddrInfo.ID, addrInfos[0].ID)
+	require.EqualT(t, "{12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB: [/ip4/127.0.0.1/tcp/4001]}", addrInfos[0].String())
 
 	cancel()
 	err = g.Wait()

--- a/pkg/routing/iterator_test.go
+++ b/pkg/routing/iterator_test.go
@@ -17,12 +17,12 @@ func TestIterator(t *testing.T) {
 	iter := NewIterator()
 	require.Empty(t, iter.peers)
 	require.Empty(t, iter.acquired)
-	require.False(t, iter.closed)
-	require.Equal(t, 0, iter.Count())
+	require.FalseT(t, iter.closed)
+	require.EqualT(t, 0, iter.Count())
 	testutil.RequireChannelOpen(t, iter.Ready())
 	testutil.RequireChannelOpen(t, iter.Exhausted())
 	_, ok := iter.Acquire()
-	require.False(t, ok)
+	require.FalseT(t, ok)
 
 	// Open iterator should reset exhausted.
 	iter.Open()
@@ -40,14 +40,14 @@ func TestIterator(t *testing.T) {
 
 	// Acquire and release peer.
 	acquiredPeer, ok := iter.Acquire()
-	require.True(t, ok)
-	require.Equal(t, peer.Host, acquiredPeer.Host)
+	require.TrueT(t, ok)
+	require.EqualT(t, peer.Host, acquiredPeer.Host)
 	require.Len(t, iter.peers, 1)
 	require.Len(t, iter.acquired, 1)
 	testutil.RequireChannelOpen(t, iter.Ready())
 	testutil.RequireChannelOpen(t, iter.Exhausted())
 	_, ok = iter.Acquire()
-	require.False(t, ok)
+	require.FalseT(t, ok)
 
 	iter.Release(acquiredPeer)
 	require.Len(t, iter.peers, 1)
@@ -57,7 +57,7 @@ func TestIterator(t *testing.T) {
 
 	// Remove acquired peer should work.
 	acquiredPeer, ok = iter.Acquire()
-	require.True(t, ok)
+	require.TrueT(t, ok)
 	for range 3 {
 		iter.Remove(acquiredPeer)
 	}
@@ -68,7 +68,7 @@ func TestIterator(t *testing.T) {
 
 	// Closed channel.
 	iter.Close()
-	require.True(t, iter.closed)
+	require.TrueT(t, iter.closed)
 	testutil.RequireChannelOpen(t, iter.Ready())
 	testutil.RequireChannelClosed(t, iter.Exhausted())
 	iter.Add(peer)
@@ -88,11 +88,11 @@ func TestIterator(t *testing.T) {
 	require.Len(t, iter.peers, 3)
 	for range 6 {
 		peer, ok := iter.Acquire()
-		require.True(t, ok)
+		require.TrueT(t, ok)
 		iter.Release(peer)
 	}
 	for _, v := range iter.usage {
-		require.Equal(t, 2, v)
+		require.EqualT(t, 2, v)
 	}
 
 	// All peers should be removed.
@@ -107,27 +107,27 @@ func TestIterator(t *testing.T) {
 	// Open and close should be
 	for range 3 {
 		iter.Open()
-		require.False(t, iter.closed)
+		require.FalseT(t, iter.closed)
 	}
 	for range 3 {
 		iter.Close()
-		require.True(t, iter.closed)
+		require.TrueT(t, iter.closed)
 	}
 
 	synctest.Test(t, func(t *testing.T) {
 		iter := NewIterator()
 
-		require.Equal(t, 0*time.Second, iter.TimeSinceUpdate())
+		require.EqualT(t, 0*time.Second, iter.TimeSinceUpdate())
 		time.Sleep(1 * time.Second)
-		require.Equal(t, 1*time.Second, iter.TimeSinceUpdate())
+		require.EqualT(t, 1*time.Second, iter.TimeSinceUpdate())
 
 		iter.Close()
 		time.Sleep(1 * time.Second)
-		require.Equal(t, 2*time.Second, iter.TimeSinceUpdate())
+		require.EqualT(t, 2*time.Second, iter.TimeSinceUpdate())
 
 		iter.Open()
-		require.Equal(t, 0*time.Second, iter.TimeSinceUpdate())
+		require.EqualT(t, 0*time.Second, iter.TimeSinceUpdate())
 		time.Sleep(5 * time.Second)
-		require.Equal(t, 5*time.Second, iter.TimeSinceUpdate())
+		require.EqualT(t, 5*time.Second, iter.TimeSinceUpdate())
 	})
 }

--- a/pkg/routing/memory_test.go
+++ b/pkg/routing/memory_test.go
@@ -14,11 +14,11 @@ func TestMemoryRouter(t *testing.T) {
 
 	isReady, err := r.Ready(t.Context())
 	require.NoError(t, err)
-	require.True(t, isReady)
+	require.TrueT(t, isReady)
 	r.SetReadiness(false)
 	isReady, err = r.Ready(t.Context())
 	require.NoError(t, err)
-	require.False(t, isReady)
+	require.FalseT(t, isReady)
 	r.SetReadiness(true)
 
 	err = r.Advertise(t.Context(), []string{"foo"})
@@ -36,19 +36,19 @@ func TestMemoryRouter(t *testing.T) {
 	peers := []Peer{}
 	for range 2 {
 		peer, ok := iter.Acquire()
-		require.True(t, ok)
+		require.TrueT(t, ok)
 		peers = append(peers, peer)
 	}
 
 	require.Len(t, peers, 2)
 	peers, ok := r.Get("foo")
-	require.True(t, ok)
+	require.TrueT(t, ok)
 	require.Len(t, peers, 2)
 
 	iter, err = r.Lookup(t.Context(), "bar", 1)
 	require.NoError(t, err)
 	_, ok = iter.Acquire()
-	require.False(t, ok)
+	require.FalseT(t, ok)
 	_, ok = r.Get("bar")
-	require.False(t, ok)
+	require.FalseT(t, ok)
 }

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -34,7 +34,7 @@ func TestP2PRouterOptions(t *testing.T) {
 	err := option.Apply(&cfg, opts...)
 	require.NoError(t, err)
 	require.Equal(t, libp2pOpts, cfg.Libp2pOpts)
-	require.Equal(t, "foobar", cfg.DataDir)
+	require.EqualT(t, "foobar", cfg.DataDir)
 }
 
 func TestP2PRouter(t *testing.T) {
@@ -59,7 +59,7 @@ func TestP2PRouter(t *testing.T) {
 	})
 	ready, err := primaryRouter.Ready(t.Context())
 	require.NoError(t, err)
-	require.False(t, ready)
+	require.FalseT(t, ready)
 
 	// Advertise and Withdraw nil keys should not error.
 	err = primaryRouter.Advertise(t.Context(), nil)
@@ -78,14 +78,14 @@ func TestP2PRouter(t *testing.T) {
 	addrInfos, err := primaryRouter.kdht.FindProviders(t.Context(), c)
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
-	require.Equal(t, primaryRouter.host.ID(), addrInfos[0].ID)
+	require.EqualT(t, primaryRouter.host.ID(), addrInfos[0].ID)
 
 	// Lookup local key should not return self when offline.
 	iter, err := primaryRouter.Lookup(t.Context(), advertisedKey, 3)
 	require.NoError(t, err)
 	<-iter.Exhausted()
 	_, ok := iter.Acquire()
-	require.False(t, ok)
+	require.FalseT(t, ok)
 
 	// Create routers that all bootstrap with the primary router.
 	routers := []*P2PRouter{}
@@ -103,25 +103,25 @@ func TestP2PRouter(t *testing.T) {
 	<-primaryRouter.connectivityGate.WaitFor(false)
 	ready, err = primaryRouter.Ready(t.Context())
 	require.NoError(t, err)
-	require.True(t, ready)
+	require.TrueT(t, ready)
 	require.EventuallyWith(t, func(c *assert.CollectT) {
-		require.Equal(c, int64(1), primaryRouter.prov.Stats().Operations.Past.KeysProvided)
+		require.EqualT(c, int64(1), primaryRouter.prov.Stats().Operations.Past.KeysProvided)
 	}, 5*time.Second, time.Second)
 
 	for _, router := range routers {
 		<-router.connectivityGate.WaitFor(false)
 		ready, err := router.Ready(t.Context())
 		require.NoError(t, err)
-		require.True(t, ready)
+		require.TrueT(t, ready)
 	}
-	require.Equal(t, 30, primaryRouter.kdht.RoutingTable().Size())
+	require.EqualT(t, 30, primaryRouter.kdht.RoutingTable().Size())
 
 	// Lookup should not return self when online.
 	iter, err = primaryRouter.Lookup(t.Context(), advertisedKey, 3)
 	require.NoError(t, err)
 	<-iter.Exhausted()
 	_, ok = iter.Acquire()
-	require.False(t, ok)
+	require.FalseT(t, ok)
 
 	// Advertised keys should be found.
 	for _, r := range routers {
@@ -129,9 +129,9 @@ func TestP2PRouter(t *testing.T) {
 		require.NoError(t, err)
 		<-iter.Ready()
 		peer, ok := iter.Acquire()
-		require.True(t, ok)
+		require.TrueT(t, ok)
 		iter.Release(peer)
-		require.Equal(t, primaryRouter.host.ID().String(), peer.Host)
+		require.EqualT(t, primaryRouter.host.ID().String(), peer.Host)
 		primaryIPAddrs, err := toIPAddrs(primaryRouter.host.Addrs())
 		require.NoError(t, err)
 		require.ElementsMatch(t, primaryIPAddrs, peer.Addresses)
@@ -140,7 +140,7 @@ func TestP2PRouter(t *testing.T) {
 		require.NoError(t, err)
 		<-iter.Exhausted()
 		_, ok = iter.Acquire()
-		require.False(t, ok)
+		require.FalseT(t, ok)
 	}
 
 	// Advertise key from another router and lookup.
@@ -150,16 +150,16 @@ func TestP2PRouter(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EventuallyWith(t, func(c *assert.CollectT) {
-		require.Equal(c, int64(1), lastRouter.prov.Stats().Operations.Past.KeysProvided)
+		require.EqualT(c, int64(1), lastRouter.prov.Stats().Operations.Past.KeysProvided)
 	}, 5*time.Second, 1*time.Second)
 
 	iter, err = primaryRouter.Lookup(t.Context(), newKey, 3)
 	require.NoError(t, err)
 	<-iter.Ready()
 	peer, ok := iter.Acquire()
-	require.True(t, ok)
+	require.TrueT(t, ok)
 	iter.Release(peer)
-	require.Equal(t, lastRouter.host.ID().String(), peer.Host)
+	require.EqualT(t, lastRouter.host.ID().String(), peer.Host)
 	lastIPAddrs, err := toIPAddrs(lastRouter.host.Addrs())
 	require.NoError(t, err)
 	require.ElementsMatch(t, lastIPAddrs, peer.Addresses)
@@ -194,7 +194,7 @@ func TestProvideTTL(t *testing.T) {
 	err := routers[0].Advertise(t.Context(), []string{"foo"})
 	require.NoError(t, err)
 	require.EventuallyWith(t, func(c *assert.CollectT) {
-		require.Equal(c, int64(1), routers[0].prov.Stats().Operations.Past.KeysProvided)
+		require.EqualT(c, int64(1), routers[0].prov.Stats().Operations.Past.KeysProvided)
 	}, 5*time.Second, time.Second)
 	err = routers[0].Withdraw(t.Context(), []string{"foo"})
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestProvideTTL(t *testing.T) {
 		require.NoError(t, err)
 		<-iter.Ready()
 		_, ok := iter.Acquire()
-		require.True(t, ok)
+		require.TrueT(t, ok)
 	}
 
 	// Wait past TTL and expect content to not be found.
@@ -216,7 +216,7 @@ func TestProvideTTL(t *testing.T) {
 		require.NoError(t, err)
 		<-iter.Exhausted()
 		_, ok := iter.Acquire()
-		require.False(t, ok)
+		require.FalseT(t, ok)
 	}
 
 	runCancel()
@@ -266,7 +266,7 @@ func TestListenMultiaddrs(t *testing.T) {
 			listenAddrs, err := listenMultiaddrs(tt.addr)
 			require.NoError(t, err)
 			for i, e := range tt.expectedListenAddrs {
-				require.Equal(t, e.String(), listenAddrs[i].String())
+				require.EqualT(t, e.String(), listenAddrs[i].String())
 			}
 		})
 	}
@@ -277,7 +277,7 @@ func TestCreateCid(t *testing.T) {
 
 	c, err := createCid("foobar")
 	require.NoError(t, err)
-	require.Equal(t, "bafkreigdvoh7cnza5cwzar65hfdgwpejotszfqx2ha6uuolaofgk54ge6i", c.String())
+	require.EqualT(t, "bafkreigdvoh7cnza5cwzar65hfdgwpejotszfqx2ha6uuolaofgk54ge6i", c.String())
 }
 
 func TestAddrsEqual(t *testing.T) {
@@ -331,7 +331,7 @@ func TestAddrsEqual(t *testing.T) {
 			t.Parallel()
 
 			matches := addrsEqual(tt.a, tt.b)
-			require.Equal(t, tt.expected, matches)
+			require.EqualT(t, tt.expected, matches)
 		})
 	}
 }
@@ -350,8 +350,8 @@ func TestLoadOrCreatePrivateKey(t *testing.T) {
 	require.NoError(t, err)
 	ok, err := secondPrivKey.GetPublic().Verify(data, sig)
 	require.NoError(t, err)
-	require.True(t, ok)
-	require.True(t, firstPrivKey.Equals(secondPrivKey))
+	require.TrueT(t, ok)
+	require.TrueT(t, firstPrivKey.Equals(secondPrivKey))
 }
 
 func TestListPeers(t *testing.T) {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -112,7 +112,7 @@ func TestTrack(t *testing.T) {
 			// Check that all images are advertised by digest (this should always happen)
 			for _, img := range imgs {
 				peers, ok := router.Get(img.Digest.String())
-				require.True(t, ok, "Image digest %s should be advertised", img.Digest.String())
+				require.TrueT(t, ok, "Image digest %s should be advertised", img.Digest.String())
 				require.Len(t, peers, 1)
 			}
 
@@ -125,10 +125,10 @@ func TestTrack(t *testing.T) {
 				peers, ok := router.Get(tagName)
 				shouldBeAdvertised := slices.Contains(tt.expectedImages, tagName)
 				if shouldBeAdvertised {
-					require.True(t, ok, "Image %s should be advertised", tagName)
+					require.TrueT(t, ok, "Image %s should be advertised", tagName)
 					require.Len(t, peers, 1)
 				} else {
-					require.False(t, ok, "Image %s should NOT be advertised", tagName)
+					require.FalseT(t, ok, "Image %s should NOT be advertised", tagName)
 				}
 			}
 

--- a/pkg/web/format_test.go
+++ b/pkg/web/format_test.go
@@ -32,7 +32,7 @@ func TestFormatBytes(t *testing.T) {
 			t.Parallel()
 
 			result := formatBytes(tt.size)
-			require.Equal(t, tt.expected, result)
+			require.EqualT(t, tt.expected, result)
 		})
 	}
 }
@@ -66,7 +66,7 @@ func TestDuration(t *testing.T) {
 			t.Parallel()
 
 			result := formatDuration(tt.duration)
-			require.Equal(t, tt.expected, result)
+			require.EqualT(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/web/html_test.go
+++ b/pkg/web/html_test.go
@@ -50,8 +50,8 @@ func TestHTMLResponseError(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tt.wantBody, body)
-			require.Equal(t, tt.wantContentType, contentType)
+			require.SliceEqualT(t, tt.wantBody, body)
+			require.EqualT(t, tt.wantContentType, contentType)
 		})
 	}
 }

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -33,19 +33,19 @@ func TestWeb(t *testing.T) {
 	rw, rec := httpx.NewRecorder()
 	w.indexHandler(rw, nil)
 	resp := rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
 
 	rw, rec = httpx.NewRecorder()
 	w.metaDataHandler(rw, nil)
 	resp = rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.Equal(t, httpx.ContentTypeJSON, resp.Header.Get(httpx.HeaderContentType))
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, httpx.ContentTypeJSON, resp.Header.Get(httpx.HeaderContentType))
 
 	rw, rec = httpx.NewRecorder()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w.statsHandler(rw, req)
 	resp = rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
 
 	stats := statsData{
 		LocalAddresses:    []netip.Addr{{}},
@@ -56,7 +56,7 @@ func TestWeb(t *testing.T) {
 	rw, rec = httpx.NewRecorder()
 	httpx.RenderTemplate(rw, w.tmpls.Lookup("stats.html"), stats)
 	resp = rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
 
 	rw, rec = httpx.NewRecorder()
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
@@ -65,7 +65,7 @@ func TestWeb(t *testing.T) {
 	req.URL.RawQuery = query.Encode()
 	w.measureHandler(rw, req)
 	resp = rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
 
 	measure := measureResult{
 		LookupResults: []routing.LookupResult{{}},
@@ -74,5 +74,5 @@ func TestWeb(t *testing.T) {
 	rw, rec = httpx.NewRecorder()
 	httpx.RenderTemplate(rw, w.tmpls.Lookup("measure.html"), measure)
 	resp = rec.Result()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.EqualT(t, http.StatusOK, resp.StatusCode)
 }

--- a/test/integration/containerd/containerd_test.go
+++ b/test/integration/containerd/containerd_test.go
@@ -119,7 +119,7 @@ func TestContainerdPull(t *testing.T) {
 			containerdStore, err := oci.NewContainerd(t.Context(), socketPath, "k8s.io")
 			require.NoError(t, err)
 			name := containerdStore.Name()
-			require.Equal(t, "containerd", name)
+			require.EqualT(t, "containerd", name)
 			eventCh, err := containerdStore.Subscribe(t.Context())
 			require.NoError(t, err)
 
@@ -167,10 +167,10 @@ func TestContainerdPull(t *testing.T) {
 				require.Len(t, imgs, 1)
 				tagName, ok := imgs[0].TagName()
 				if ok {
-					require.Equal(t, benchmarkImg.String(), tagName)
+					require.EqualT(t, benchmarkImg.String(), tagName)
 					dgst, err := containerdStore.Resolve(t.Context(), tagName)
 					require.NoError(t, err)
-					require.Equal(t, imgs[0].Digest, dgst)
+					require.EqualT(t, imgs[0].Digest, dgst)
 				}
 
 				descs := []ocispec.Descriptor{}
@@ -215,5 +215,5 @@ func ensureEvents(t *testing.T, ch <-chan oci.OCIEvent, expected []oci.OCIEvent)
 		event := <-ch
 		received = append(received, event)
 	}
-	require.ElementsMatch(t, expected, received)
+	require.ElementsMatchT(t, expected, received)
 }

--- a/test/integration/kubernetes/kubernetes_test.go
+++ b/test/integration/kubernetes/kubernetes_test.go
@@ -308,7 +308,7 @@ func TestKubernetes(t *testing.T) {
 			backupHostBuffer := bytes.NewBuffer(nil)
 			err = kindNodes[0].CommandContext(t.Context(), "cat", "/etc/containerd/certs.d/_backup/docker.io/hosts.toml").SetStdout(backupHostBuffer).Run()
 			require.NoError(t, err)
-			require.Equal(t, hostsToml, backupHostBuffer.String())
+			require.EqualT(t, hostsToml, backupHostBuffer.String())
 			err = kindNodes[0].CommandContext(t.Context(), "rm", "-rf", "/etc/containerd/certs.d/_backup").Run()
 			require.NoError(t, err)
 			err = kindNodes[0].CommandContext(t.Context(), "mkdir", "/etc/containerd/certs.d/_backup").Run()
@@ -324,13 +324,13 @@ func TestKubernetes(t *testing.T) {
 			require.NoError(t, err)
 			require.EventuallyWith(t, func(c *assert.CollectT) {
 				_, err := k8sClient.CoreV1().Pods(spegelNamespace).Get(t.Context(), initPodName, metav1.GetOptions{})
-				require.True(c, kerrors.IsNotFound(err))
+				require.TrueT(c, kerrors.IsNotFound(err))
 			}, 15*time.Second, 1*time.Second)
 			gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}
 			waitForStatus(t, k8sDynClient, gvr, spegelNamespace, spegelNamespace, status.CurrentStatus)
 
 			_, newPeerID := getSpegelPeerID(t, k8sClient, kindNodes[2])
-			require.Equal(t, initPeerID, newPeerID)
+			require.EqualT(t, initPeerID, newPeerID)
 
 			t.Log("Remove Spegel from a node")
 			watcher, err := k8sClient.CoreV1().Pods(spegelNamespace).Watch(t.Context(), metav1.ListOptions{FieldSelector: "spec.nodeName=" + kindNodes[2].String()})
@@ -349,7 +349,7 @@ func TestKubernetes(t *testing.T) {
 					continue
 				}
 				// Ensure Spegel exist cleanly.
-				require.Equal(t, int32(0), pod.Status.ContainerStatuses[0].State.Terminated.ExitCode)
+				require.EqualT(t, int32(0), pod.Status.ContainerStatuses[0].State.Terminated.ExitCode)
 				break
 			}
 			watcher.Stop()
@@ -368,7 +368,7 @@ func TestKubernetes(t *testing.T) {
 				pod, err := k8sClient.CoreV1().Pods(spegelNamespace).Get(t.Context(), podList.Items[0].Name, metav1.GetOptions{})
 				require.NoError(c, err)
 				require.Len(c, pod.Status.ContainerStatuses, 1)
-				require.Equal(c, int32(1), pod.Status.ContainerStatuses[0].RestartCount)
+				require.EqualT(c, int32(1), pod.Status.ContainerStatuses[0].RestartCount)
 			}, 15*time.Second, 1*time.Second)
 
 			t.Log("Scale down Spegel to single instance")
@@ -384,7 +384,7 @@ func TestKubernetes(t *testing.T) {
 			require.EventuallyWith(t, func(c *assert.CollectT) {
 				for _, pod := range podList.Items {
 					_, err := k8sClient.CoreV1().Pods(spegelNamespace).Get(t.Context(), pod.Name, metav1.GetOptions{})
-					require.True(c, kerrors.IsNotFound(err))
+					require.TrueT(c, kerrors.IsNotFound(err))
 				}
 			}, 5*time.Second, 1*time.Second)
 
@@ -478,7 +478,7 @@ func installSpegel(t *testing.T, actionCfg *action.Configuration, k8sClient kube
 
 	podList, err := k8sClient.CoreV1().Pods(spegelNamespace).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, len(kindNodes), len(podList.Items))
+	require.EqualT(t, len(kindNodes), len(podList.Items))
 }
 
 func waitForStatus(t *testing.T, k8sDynClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string, s status.Status) {
@@ -490,7 +490,7 @@ func waitForStatus(t *testing.T, k8sDynClient dynamic.Interface, gvr schema.Grou
 		require.NotNil(t, status.GetLegacyConditionsFn(u))
 		res, err := status.Compute(u)
 		require.NoError(c, err)
-		require.Equal(c, s, res.Status)
+		require.EqualT(c, s, res.Status)
 	}, 60*time.Second, 500*time.Millisecond)
 }
 
@@ -620,13 +620,13 @@ func runPullTests(t *testing.T, k8sClient kubernetes.Interface, k8sDynClient dyn
 			require.Len(c, pod.Status.ContainerStatuses, 1)
 			waitingState := pod.Status.ContainerStatuses[0].State.Waiting
 			require.NotNil(c, waitingState)
-			require.Equal(c, "ErrImagePull", waitingState.Reason)
+			require.EqualT(c, "ErrImagePull", waitingState.Reason)
 		}, 10*time.Second, 500*time.Millisecond)
 
 		podList, err := k8sClient.CoreV1().Pods(pullTestNamespace).List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		for _, pod := range podList.Items {
-			require.NotEqual(t, kindNodes[0].String(), pod.Spec.NodeName)
+			require.NotEqualT(t, kindNodes[0].String(), pod.Spec.NodeName)
 		}
 
 		// Check OCI volume content.
@@ -657,9 +657,9 @@ func runPullTests(t *testing.T, k8sClient kubernetes.Interface, k8sDynClient dyn
 			"random_file_7526869637736667835.txt",
 			"random_file_8163815451001128425.txt",
 		}
-		require.ElementsMatch(t, expected, files)
+		require.ElementsMatchT(t, expected, files)
 	})
-	require.True(t, succeeded, "pull test failed")
+	require.TrueT(t, succeeded, "pull test failed")
 }
 
 func runConformanceTests(t *testing.T, k8sClient kubernetes.Interface, kindNodes []kindnodes.Node) {
@@ -741,11 +741,11 @@ func runConformanceTests(t *testing.T, k8sClient kubernetes.Interface, kindNodes
 		require.EventuallyWith(t, func(c *assert.CollectT) {
 			job, err := k8sClient.BatchV1().Jobs(conformanceNamespace).Get(t.Context(), job.Name, metav1.GetOptions{})
 			require.NoError(c, err)
-			require.Equal(c, int32(0), job.Status.Failed)
-			require.Equal(c, int32(1), job.Status.Succeeded)
+			require.EqualT(c, int32(0), job.Status.Failed)
+			require.EqualT(c, int32(1), job.Status.Succeeded)
 		}, 15*time.Second, 1*time.Second)
 	})
-	require.True(t, succeeded, "conformance test failed")
+	require.TrueT(t, succeeded, "conformance test failed")
 }
 
 func noSpegelRestart(t *testing.T, k8sClient kubernetes.Interface) {
@@ -755,7 +755,7 @@ func noSpegelRestart(t *testing.T, k8sClient kubernetes.Interface) {
 	require.NoError(t, err)
 	require.NotEmpty(t, podList.Items)
 	for _, pod := range podList.Items {
-		require.Equal(t, int32(0), pod.Status.ContainerStatuses[0].RestartCount)
+		require.EqualT(t, int32(0), pod.Status.ContainerStatuses[0].RestartCount)
 	}
 }
 
@@ -769,7 +769,7 @@ func getSpegelPeerID(t *testing.T, k8sClient kubernetes.Interface, kindNode kind
 	portIdx := slices.IndexFunc(podList.Items[0].Spec.Containers[0].Ports, func(port corev1.ContainerPort) bool {
 		return port.Name == "metrics"
 	})
-	require.Positive(t, portIdx)
+	require.PositiveT(t, portIdx)
 	debugWebPort := podList.Items[0].Spec.Containers[0].Ports[portIdx].ContainerPort
 	podName := podList.Items[0].Name
 


### PR DESCRIPTION
Hey @phillebaba!

Full disclosure: AI was used to create these changes.

I was not able to "stack" the PRs since the original branch is on my fork of spegel and not in the project proper. Should be rebased or something like that after the first PR is merged.

Runs pass 2 of the upstream `migrate-testify` tool (`--upgrade-generics`) to rewrite reflection-based assertions to their type-safe generic counterparts (suffixed `T`).

- 30 test files changed, 183 assertions upgraded:
  `Equal→EqualT` (×117), `True→TrueT` (×32), `False→FalseT` (×17),
  `Equal→SliceEqualT` (×8), `ElementsMatch→ElementsMatchT` (×4),
  `NotSame→NotSameT` (×2), plus single occurrences of
  `Equal→MapEqualT`, `NotEqual→NotEqualT`, `Positive→PositiveT`.
- 18 assertions intentionally left as reflection-based by the tool
  (pointer comparisons, non-`comparable` types, structs containing
  pointers — e.g. `net/http.Header`, libp2p `peer.AddrInfo`).
- No `go.mod` / `go.sum` changes.

`go build ./...`, `make lint`, and `make test-unit` (`-race`) pass.
`go vet ./...` clean in both integration modules.

Follow-up to #1330 