### PR TITLE
Disable cache when building release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone repo
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Setup Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
       - name: Setup Docker Buildx


### PR DESCRIPTION
This change disables use of actions cache for Go to make sure that the binary is build completely from source. The cost of extra compile time is worth it to protect against a potential cache poisoning. Releases are not run that often so the additional time is negligable. 