### PR TITLE
feat: expose router-advertise-ttl and router-max-reprovide-delay as CLI flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,8 @@ type RegistryCmd struct {
 	RegistryFilters       []*regexp.Regexp `arg:"--registry-filters,env:REGISTRY_FILTERS" help:"Regular expressions to filter out tags/registries, if slice is empty all registries/tags are resolved."`
 	MirrorResolveTimeout  time.Duration    `arg:"--mirror-resolve-timeout,env:MIRROR_RESOLVE_TIMEOUT" default:"20ms" help:"Max duration spent finding a mirror."`
 	MirrorResolveRetries  int              `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
+	RouterAdvertiseTTL    time.Duration    `arg:"--router-advertise-ttl,env:ROUTER_ADVERTISE_TTL" default:"15m" help:"TTL for provider records advertised to the DHT. Controls how long peers are discoverable after a node stops re-advertising (e.g. on termination)."`
+	RouterMaxReprovideDelay time.Duration  `arg:"--router-max-reprovide-delay,env:ROUTER_MAX_REPROVIDE_DELAY" default:"2m" help:"Max random delay added to the re-provide interval to avoid thundering herd. Provider record validity is set to advertise-ttl plus twice this value."`
 	DebugWebEnabled       bool             `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"true" help:"When true enables debug web page."`
 }
 
@@ -224,6 +226,8 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	}
 	routerOpts := []routing.P2PRouterOption{
 		routing.WithDataDir(args.DataDir),
+		routing.WithAdvertiseTTL(args.RouterAdvertiseTTL),
+		routing.WithMaxReprovideDelay(args.RouterMaxReprovideDelay),
 	}
 	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper, registryPort, routerOpts...)
 	if err != nil {

--- a/pkg/routing/p2p_test.go
+++ b/pkg/routing/p2p_test.go
@@ -29,12 +29,16 @@ func TestP2PRouterOptions(t *testing.T) {
 	opts := []P2PRouterOption{
 		WithLibP2POptions(libp2pOpts...),
 		WithDataDir("foobar"),
+		WithAdvertiseTTL(10 * time.Minute),
+		WithMaxReprovideDelay(30 * time.Second),
 	}
 	cfg := P2PRouterConfig{}
 	err := option.Apply(&cfg, opts...)
 	require.NoError(t, err)
 	require.Equal(t, libp2pOpts, cfg.Libp2pOpts)
 	require.EqualT(t, "foobar", cfg.DataDir)
+	require.EqualT(t, 10*time.Minute, cfg.AdvertiseTTL)
+	require.EqualT(t, 30*time.Second, cfg.MaxReprovideDelay)
 }
 
 func TestP2PRouter(t *testing.T) {


### PR DESCRIPTION
## Problem

When a node is removed (autoscaler scale-down, pod eviction), its DHT provider records persist until `ProvideValidity = AdvertiseTTL + 2*MaxReprovideDelay` elapses. With hardcoded defaults (15m TTL, 2m reprovide delay), stale records cause surviving peers to waste time dialing dead nodes for up to **~19 minutes**, producing `context deadline exceeded` errors on every mirror request that routes to the dead peer:

```
{"err":"context deadline exceeded","path":"/v2/library/busybox/manifests/1.35.0",
 "status":404,"latency":"3.001739377s","handler":"mirror","registry":"docker.io"}
```

Operators had no way to tune these values without recompiling. Fixes #1365.

## Solution

Expose the existing `WithAdvertiseTTL` and `WithMaxReprovideDelay` routing options as CLI flags:

- `--router-advertise-ttl` / `ROUTER_ADVERTISE_TTL` (default `15m`) — controls how long provider records remain valid after a node stops re-advertising
- `--router-max-reprovide-delay` / `ROUTER_MAX_REPROVIDE_DELAY` (default `2m`) — max random jitter added to reprovide interval to avoid thundering herd

Provider record validity = `advertise-ttl + 2 * max-reprovide-delay`.

## Verification

Tested in a 4-node kind cluster with `--router-advertise-ttl=1m --router-max-reprovide-delay=5s`:

| Phase | Status | Latency |
|---|---|---|
| Peer alive, DHT working | 200 | ~20ms |
| Peer killed — stale record in DHT | **404** | **3.0s** ← bug reproduced |
| T+75s with `--router-advertise-ttl=1m` | **200** | **~25ms** ← record expired, fixed |
| T+75s without flag (default 19m validity) | **404** | **3.0s** ← still broken |

The existing `TestProvideTTL` unit test (5 routers, `WithAdvertiseTTL(5s)`) validates provider record expiry end-to-end. `TestP2PRouterOptions` is extended to cover the two new option functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)