### PR TITLE
Allow disabling internalTrafficPolicy for backwards compatibility

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -45,6 +45,7 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | service.metrics.annotations | object | `{}` | Annotations to add to the metrics service |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |
 | service.registry.annotations | object | `{}` | Annotations to add to the registry service |
+| service.registry.internalTrafficLocal | bool | `false` | Enable internalTrafficPolicy: Local. This is only for 1.33 clusters compatibility instead of PreferSameNode. |
 | service.registry.nodeIp | string | `""` | Override the NODE_ID environment variable. It defaults to the field status.hostIP |
 | service.registry.nodePort | int | `30020` | Node port to expose the registry via the service. |
 | service.registry.port | int | `5000` | Port to expose the registry via the service. |

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -33,9 +33,10 @@ metadata:
   {{- end }}
 spec:
   type: NodePort
-  trafficDistribution: PreferSameNode
   {{- if .Values.service.registry.internalTrafficLocal }}
   internalTrafficPolicy: Local
+  {{- else }}
+  trafficDistribution: PreferSameNode
   {{- end }}
   selector:
     app.kubernetes.io/component: spegel

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -34,6 +34,9 @@ metadata:
 spec:
   type: NodePort
   trafficDistribution: PreferSameNode
+  {{- if .Values.service.registry.internalTrafficLocal }}
+  internalTrafficPolicy: Local
+  {{- end }}
   selector:
     app.kubernetes.io/component: spegel
     {{- include "spegel.selectorLabels" . | nindent 4 }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -51,6 +51,8 @@ service:
     nodePort: 30020
     # -- Annotations to add to the registry service
     annotations: {}
+    # -- Enable internalTrafficPolicy: Local. This is only for 1.33 clusters compatibility instead of PreferSameNode.
+    internalTrafficLocal: false
 
   router:
     # -- Port to expose the router via the service.


### PR DESCRIPTION
## Details

As discussed [here](https://github.com/spegel-org/spegel/discussions/1371), creating a PR to add backwards compatibility, avoiding a double call for the [mirrorGo function](https://github.com/spegel-org/spegel/pull/18), when the layer isn't found because we didn't have time to decompress it from ctr.

This will add compatibility with `1.33.x` since preferSameNode was moved to `1.34` when `1.37` releases this will be removed from the chart as discussed previously