### PR TITLE
Fix ipv6 compatibility with Go 1.26

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spegel-org/spegel/internal/cleanup"
 	"github.com/spegel-org/spegel/internal/version"
+	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/metrics"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/registry"
@@ -161,6 +162,7 @@ func versionCommand(_ context.Context, args *VersionCmd) error {
 }
 
 func configurationCommand(ctx context.Context, args *ConfigurationCmd) error {
+	args.MirrorTargets[0] = httpx.EncapsulateIPv6Host(args.MirrorTargets[0])
 	username, password, err := loadBasicAuth()
 	if err != nil {
 		return err

--- a/pkg/httpx/url.go
+++ b/pkg/httpx/url.go
@@ -1,0 +1,27 @@
+package httpx
+
+import "strings"
+
+// EncapsulateIPv6Host adds square brackets to URLs with IPv6 host to make parsing work.
+func EncapsulateIPv6Host(rawURL string) string {
+	schemeEnd := strings.Index(rawURL, "://")
+	if schemeEnd == -1 {
+		return rawURL
+	}
+	rest := rawURL[schemeEnd+3:]
+	slashIdx := strings.IndexByte(rest, '/')
+	host := rest
+	if slashIdx != -1 {
+		host = rest[:slashIdx]
+	}
+	if strings.Count(host, ":") >= 2 && !strings.Contains(host, "[") {
+		lastColon := strings.LastIndex(host, ":")
+		ip := host[:lastColon]
+		port := host[lastColon:]
+		rawURL = rawURL[:schemeEnd+3] + "[" + ip + "]" + port
+		if slashIdx != -1 {
+			rawURL += rest[slashIdx:]
+		}
+	}
+	return rawURL
+}

--- a/pkg/httpx/url_test.go
+++ b/pkg/httpx/url_test.go
@@ -1,0 +1,14 @@
+package httpx
+
+import (
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestEncapsulateIPv6Host(t *testing.T) {
+	t.Parallel()
+
+	res := EncapsulateIPv6Host("http://fc00:f853:ccd:e793::2:30020")
+	require.Equal(t, "http://[fc00:f853:ccd:e793::2]:30020", res)
+}

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -30,7 +30,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/sec"
-	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
@@ -119,11 +118,6 @@ func NewP2PRouter(ctx context.Context, addr string, bs Bootstrapper, registryPor
 		return nil, err
 	}
 	hostOpts := []libp2p.Option{
-		libp2p.ChainOptions(
-			libp2p.NoTransports,
-			libp2p.Transport(quic.NewTransport),
-			libp2p.Transport(tcp.NewTCPTransport),
-		),
 		libp2p.ListenAddrs(listenAddrs...),
 		libp2p.DisableIdentifyAddressDiscovery(),
 		libp2p.PrometheusRegisterer(metrics.DefaultRegisterer),
@@ -137,6 +131,10 @@ func NewP2PRouter(ctx context.Context, addr string, bs Bootstrapper, registryPor
 			}
 			return filtered
 		}),
+		libp2p.ChainOptions(
+			libp2p.NoTransports,
+			libp2p.Transport(tcp.NewTCPTransport),
+		),
 	}
 	if cfg.DataDir != "" {
 		peerKey, err := loadOrCreatePrivateKey(ctx, cfg.DataDir)

--- a/test/integration/kubernetes/kubernetes_test.go
+++ b/test/integration/kubernetes/kubernetes_test.go
@@ -290,6 +290,7 @@ func TestKubernetes(t *testing.T) {
 
 			t.Log("Upgrading Spegel from latest release to dev build")
 			installSpegel(t, actionCfg, k8sClient, k8sDynClient, kindNodes, "")
+			time.Sleep(3 * time.Second)
 			installSpegel(t, actionCfg, k8sClient, k8sDynClient, kindNodes, imageDigest)
 			uninstallSpegel(t, actionCfg, kindNodes)
 


### PR DESCRIPTION
This removes QUIC from protocols as it is causing backoff failures for some reason. A new issue will be created to investigate this further.

Fixes #1373 