### PR TITLE
Do not advertise content missing from the content store

### DIFF
--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -249,9 +249,13 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[Image][]digest.Digest, 
 		}
 		contentIdx[cImg.Target.Digest] = refs
 
-		dgsts := []digest.Digest{}
-		for _, ref := range refs {
-			dgsts = append(dgsts, ref.Digest)
+		// The walk does not read leaf content like layers, so their existence has to be
+		// checked before advertising. Lazily pulled images have layers which are missing
+		// from the content store and cannot be served.
+		dgsts, err := c.existingDigests(ctx, refs)
+		if err != nil {
+			log.Error(err, "skipping image that cannot be checked for existing content", "image", img.String())
+			continue
 		}
 		initial[img] = dgsts
 	}
@@ -285,6 +289,22 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[Image][]digest.Digest, 
 		}
 	}()
 	return initial, eventCh, nil
+}
+
+// existingDigests returns the digests of the references which exist in the content store.
+func (c *Containerd) existingDigests(ctx context.Context, refs []Reference) ([]digest.Digest, error) {
+	dgsts := []digest.Digest{}
+	for _, ref := range refs {
+		_, err := c.client.ContentStore().Info(ctx, ref.Digest)
+		if errors.Is(err, errdefs.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		dgsts = append(dgsts, ref.Digest)
+	}
+	return dgsts, nil
 }
 
 func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, contentIdx map[digest.Digest][]Reference) ([]OCIEvent, error) {

--- a/pkg/oci/containerd/containerd.go
+++ b/pkg/oci/containerd/containerd.go
@@ -271,9 +271,13 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[oci.Image][]digest.Dige
 		}
 		contentIdx[cImg.Target.Digest] = refs
 
-		dgsts := []digest.Digest{}
-		for _, ref := range refs {
-			dgsts = append(dgsts, ref.Digest)
+		// The walk does not read leaf content like layers, so their existence has to be
+		// checked before advertising. Lazily pulled images have layers which are missing
+		// from the content store and cannot be served.
+		dgsts, err := c.existingDigests(ctx, refs)
+		if err != nil {
+			log.Error(err, "skipping image that cannot be checked for existing content", "image", img.String())
+			continue
 		}
 		initial[img] = dgsts
 	}
@@ -307,6 +311,22 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[oci.Image][]digest.Dige
 		}
 	}()
 	return initial, eventCh, nil
+}
+
+// existingDigests returns the digests of the references which exist in the content store.
+func (c *Containerd) existingDigests(ctx context.Context, refs []oci.Reference) ([]digest.Digest, error) {
+	dgsts := []digest.Digest{}
+	for _, ref := range refs {
+		_, err := c.client.ContentStore().Info(ctx, ref.Digest)
+		if errors.Is(err, errdefs.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		dgsts = append(dgsts, ref.Digest)
+	}
+	return dgsts, nil
 }
 
 func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, contentIdx map[digest.Digest][]oci.Reference) ([]oci.OCIEvent, error) {

--- a/test/integration/containerd/containerd_test.go
+++ b/test/integration/containerd/containerd_test.go
@@ -10,11 +10,13 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	ctrdclient "github.com/containerd/containerd/v2/client"
 	"github.com/go-openapi/testify/v2/assert"
 	"github.com/go-openapi/testify/v2/require"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -179,6 +181,36 @@ func TestContainerdPull(t *testing.T) {
 				require.NoError(t, err)
 				ensureEvents(t, eventCh, expectedDeleteEvents)
 			}
+
+			t.Log("Checking that content missing from the content store is not advertised")
+			_, err = imageClient.PullImage(t.Context(), &runtimeapi.PullImageRequest{Image: &runtimeapi.ImageSpec{Image: imgs[0]}})
+			require.NoError(t, err)
+			// Drain the create events for the tag reference and the seven content digests.
+			for range 8 {
+				<-eventCh
+			}
+			// Remove a layer blob from the content store to replicate the state left behind
+			// by remote snapshotters, which lazy pull images without writing layer blobs to
+			// the content store.
+			ctrdClient, err := ctrdclient.New(socketPath, ctrdclient.WithDefaultNamespace("k8s.io"))
+			require.NoError(t, err)
+			missingDgst := digest.Digest("sha256:99ea62d595b5a3e1d01639af2781f97730eca4086f5308be58f68b18c244adc9")
+			err = ctrdClient.ContentStore().Delete(t.Context(), missingDgst)
+			require.NoError(t, err)
+			err = ctrdClient.Close()
+			require.NoError(t, err)
+
+			missingStore, err := oci.NewContainerd(t.Context(), socketPath, "k8s.io")
+			require.NoError(t, err)
+			missingInitial, _, err := missingStore.Subscribe(t.Context())
+			require.NoError(t, err)
+			require.NotEmpty(t, missingInitial)
+			for _, dgsts := range missingInitial {
+				require.Len(t, dgsts, 6)
+				require.NotContains(t, dgsts, missingDgst)
+			}
+			err = missingStore.Close()
+			require.NoError(t, err)
 
 			t.Log("Closing Containerd store")
 			err = connClient.Close()

--- a/test/integration/containerd/containerd_test.go
+++ b/test/integration/containerd/containerd_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 	"time"
 
+	ctrdclient "github.com/containerd/containerd/v2/client"
 	"github.com/go-openapi/testify/v2/assert"
 	"github.com/go-openapi/testify/v2/require"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
@@ -188,6 +190,37 @@ func TestContainerdPull(t *testing.T) {
 				require.NoError(t, err)
 				testutil.EnsureEvents(t, eventCh, expectedDeleteEvents)
 			}
+
+			t.Log("Checking that content missing from the content store is not advertised")
+			_, err = imageClient.PullImage(t.Context(), &runtimeapi.PullImageRequest{Image: &runtimeapi.ImageSpec{Image: imgs[0]}})
+			require.NoError(t, err)
+			// Drain the create events for the tag reference and the seven content digests.
+			for range 8 {
+				<-eventCh
+			}
+			// Remove a layer blob from the content store to replicate the state left behind
+			// by remote snapshotters, which lazy pull images without writing layer blobs to
+			// the content store.
+			ctrdClient, err := ctrdclient.New(socketPath, ctrdclient.WithDefaultNamespace("k8s.io"))
+			require.NoError(t, err)
+			missingDgst := digest.Digest("sha256:99ea62d595b5a3e1d01639af2781f97730eca4086f5308be58f68b18c244adc9")
+			err = ctrdClient.ContentStore().Delete(t.Context(), missingDgst)
+			require.NoError(t, err)
+			err = ctrdClient.Close()
+			require.NoError(t, err)
+
+			missingStore, err := containerd.NewContainerd(t.Context(), socketPath, "k8s.io")
+			require.NoError(t, err)
+			missingInitial, missingEventCh, err := missingStore.Subscribe(t.Context())
+			require.NoError(t, err)
+			require.NotEmpty(t, missingInitial)
+			for _, dgsts := range missingInitial {
+				require.Len(t, dgsts, 6)
+				require.NotContains(t, dgsts, missingDgst)
+			}
+			err = missingStore.Close()
+			require.NoError(t, err)
+			testutil.WaitForClose(t, missingEventCh)
 
 			t.Log("Closing subscription")
 			subCancel()

--- a/test/integration/containerd/go.mod
+++ b/test/integration/containerd/go.mod
@@ -5,9 +5,11 @@ go 1.26.3
 replace github.com/spegel-org/spegel => ../../../
 
 require (
+	github.com/containerd/containerd/v2 v2.3.1
 	github.com/go-openapi/testify/v2 v2.5.1
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/spegel-org/spegel v0.0.0-00010101000000-000000000000
 	golang.org/x/sync v0.20.0
@@ -23,7 +25,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/cgroups/v3 v3.1.3 // indirect
 	github.com/containerd/containerd/api v1.11.1 // indirect
-	github.com/containerd/containerd/v2 v2.3.1 // indirect
 	github.com/containerd/continuity v0.5.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -50,7 +51,6 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/test/integration/containerd/go.mod
+++ b/test/integration/containerd/go.mod
@@ -7,10 +7,12 @@ toolchain go1.26.5
 replace github.com/spegel-org/spegel => ../../../
 
 require (
+	github.com/containerd/containerd/v2 v2.3.3
 	github.com/go-openapi/testify/v2 v2.6.0
 	github.com/kvick-org/pkg/errgroup v0.0.0-20260714201549-203456789dd7
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/spegel-org/spegel v0.0.0-00010101000000-000000000000
 	go.uber.org/goleak v1.3.0
@@ -26,7 +28,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/cgroups/v3 v3.1.3 // indirect
 	github.com/containerd/containerd/api v1.11.1 // indirect
-	github.com/containerd/containerd/v2 v2.3.3 // indirect
 	github.com/containerd/continuity v0.5.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -53,7 +54,6 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect


### PR DESCRIPTION
Lazily pulled images have image records but no layer blobs in the content store, yet the [initial advertisement](https://github.com/spegel-org/spegel/blob/d1e7da21966cdf579913c8c3c6bf61b61900cb84/pkg/oci/containerd.go#L228-L257) announces every digest referenced by the manifest without checking that the blob exists. Peers resolving those layers get a 404.

The initial advertisement now only includes digests whose blobs are present in the content store. The check is only needed there: everything advertised after startup comes from [content create events](https://github.com/spegel-org/spegel/blob/d1e7da21966cdf579913c8c3c6bf61b61900cb84/pkg/oci/containerd.go#L299-L319), which fire when a blob is written and can never reference missing content.

The added integration test reproduces the lazy pull state by deleting a layer blob and fails without the fix.

Initial step toward supporting the stargz snapshotter, see #510.