### PR TITLE
Refactor basic auth to increase test coverage

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,11 +167,11 @@ func versionCommand(_ context.Context, args *VersionCmd) error {
 
 func configurationCommand(ctx context.Context, args *ConfigurationCmd) error {
 	args.MirrorTargets[0] = httpx.EncapsulateIPv6Host(args.MirrorTargets[0])
-	username, password, err := loadBasicAuth()
+	userinfo, err := httpx.LoadUserinfo("/etc/secrets/basic-auth")
 	if err != nil {
 		return err
 	}
-	err = oci.AddMirrorConfiguration(ctx, args.ContainerdRegistryConfigPath, args.MirroredRegistries, args.MirrorTargets, args.ResolveTags, args.PrependExisting, username, password)
+	err = oci.AddMirrorConfiguration(ctx, args.ContainerdRegistryConfigPath, args.MirroredRegistries, args.MirrorTargets, args.ResolveTags, args.PrependExisting, userinfo)
 	if err != nil {
 		return err
 	}
@@ -191,10 +191,6 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		return err
 	}
 
-	username, password, err := loadBasicAuth()
-	if err != nil {
-		return err
-	}
 	ociClient, err := oci.NewClient()
 	if err != nil {
 		return err
@@ -253,10 +249,14 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	})
 
 	// Registry
+	userinfo, err := httpx.LoadUserinfo("/etc/secrets/basic-auth")
+	if err != nil {
+		return err
+	}
 	registryOpts := []registry.RegistryOption{
 		registry.WithRegistryFilters(filters),
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
-		registry.WithBasicAuth(username, password),
+		registry.WithUserinfo(userinfo),
 		registry.WithOCIClient(ociClient),
 	}
 	reg, err := registry.NewRegistry(ociStore, router, registryOpts...)
@@ -365,19 +365,6 @@ func getBootstrapper(cfg BootstrapConfig) (routing.Bootstrapper, error) { //noli
 	default:
 		return nil, fmt.Errorf("unknown bootstrap kind %s", cfg.BootstrapKind)
 	}
-}
-
-func loadBasicAuth() (string, string, error) {
-	dirPath := "/etc/secrets/basic-auth"
-	username, err := os.ReadFile(filepath.Join(dirPath, "username"))
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", "", err
-	}
-	password, err := os.ReadFile(filepath.Join(dirPath, "password"))
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", "", err
-	}
-	return string(username), string(password), nil
 }
 
 func loadHTTPBootstrapperCerts(tlsCAFile, tlsCertFile, tlsKeyFile *string) (tlsCA, tlsCert, tlsKey []byte, err error) {

--- a/pkg/httpx/userinfo.go
+++ b/pkg/httpx/userinfo.go
@@ -1,0 +1,63 @@
+package httpx
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+)
+
+const (
+	UsernameFilename = "username"
+	PasswordFilename = "password"
+)
+
+// LoadUserinfo loads a username and password file from the given base directory.
+func LoadUserinfo(dirPath string) (*url.Userinfo, error) {
+	if dirPath == "" {
+		return nil, errors.New("dir path cannot be empty")
+	}
+	username, err := os.ReadFile(filepath.Join(dirPath, UsernameFilename))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	password, err := os.ReadFile(filepath.Join(dirPath, PasswordFilename))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if len(username) == 0 && len(password) == 0 {
+		return nil, nil
+	}
+	if len(username) != 0 && len(password) == 0 {
+		return url.User(string(username)), nil
+	}
+	return url.UserPassword(string(username), string(password)), nil
+}
+
+// UserinfoHeaderValue returns the authorization header value for basic auth.
+func UserinfoHeaderValue(userinfo url.Userinfo) string {
+	authorization := userinfo.Username() + ":"
+	if password, ok := userinfo.Password(); ok {
+		authorization += password
+	}
+	authorization = base64.StdEncoding.EncodeToString([]byte(authorization))
+	authorization = "Basic " + authorization
+	return authorization
+}
+
+// AuthenticateUserinfo returns true if the username and password from basic auth matches the user info.
+func AuthenticateUserinfo(basicAuthFn func() (string, string, bool), userinfo url.Userinfo) bool {
+	username, password, ok := basicAuthFn()
+	if !ok {
+		return false
+	}
+
+	expectedUsername := userinfo.Username()
+	expectedPassword, _ := userinfo.Password()
+
+	usernameMatch := (subtle.ConstantTimeCompare([]byte(username), []byte(expectedUsername)) == 1)
+	passwordMatch := (subtle.ConstantTimeCompare([]byte(password), []byte(expectedPassword)) == 1)
+	return usernameMatch && passwordMatch
+}

--- a/pkg/httpx/userinfo_test.go
+++ b/pkg/httpx/userinfo_test.go
@@ -1,0 +1,122 @@
+package httpx
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestLoadUserinfo(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadUserinfo("")
+	require.EqualError(t, err, "dir path cannot be empty")
+
+	dirPath := t.TempDir()
+
+	userinfo, err := LoadUserinfo(dirPath)
+	require.NoError(t, err)
+	require.Nil(t, userinfo)
+
+	expectedUsername := "helloworld"
+	err = os.WriteFile(filepath.Join(dirPath, UsernameFilename), []byte(expectedUsername), 0o644)
+	require.NoError(t, err)
+	userinfo, err = LoadUserinfo(dirPath)
+	require.NoError(t, err)
+	require.EqualT(t, expectedUsername, userinfo.Username())
+	password, ok := userinfo.Password()
+	require.FalseT(t, ok)
+	require.Empty(t, password)
+
+	expectedPassword := "supersecret"
+	err = os.WriteFile(filepath.Join(dirPath, PasswordFilename), []byte(expectedPassword), 0o644)
+	require.NoError(t, err)
+	userinfo, err = LoadUserinfo(dirPath)
+	require.NoError(t, err)
+	require.EqualT(t, expectedUsername, userinfo.Username())
+	password, ok = userinfo.Password()
+	require.TrueT(t, ok)
+	require.EqualT(t, expectedPassword, password)
+}
+
+func TestBasicAuthHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet // Prioritize readability in tests.
+	tests := []struct {
+		userinfo url.Userinfo
+		expected string
+	}{
+		{
+			userinfo: *url.User("foo"),
+			expected: "Basic Zm9vOg==",
+		},
+		{
+			userinfo: *url.UserPassword("foo", "bar"),
+			expected: "Basic Zm9vOmJhcg==",
+		},
+		{
+			userinfo: *url.UserPassword("foo", ""),
+			expected: "Basic Zm9vOg==",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.userinfo.String(), func(t *testing.T) {
+			t.Parallel()
+
+			v := UserinfoHeaderValue(tt.userinfo)
+			require.EqualT(t, tt.expected, v)
+		})
+	}
+}
+
+func TestAuthenticateUserinfo(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet // Prioritize readability in tests.
+	tests := []struct {
+		userinfo    url.Userinfo
+		basicAuthFn func() (string, string, bool)
+		expected    bool
+	}{
+		{
+			userinfo: *url.User("admin"),
+			basicAuthFn: func() (string, string, bool) {
+				return "admin", "", true
+			},
+			expected: true,
+		},
+		{
+			userinfo: *url.User("admin"),
+			basicAuthFn: func() (string, string, bool) {
+				return "root", "", true
+			},
+			expected: false,
+		},
+		{
+			userinfo: *url.UserPassword("admin", "password!34"),
+			basicAuthFn: func() (string, string, bool) {
+				return "admin", "password!34", true
+			},
+			expected: true,
+		},
+		{
+			userinfo: *url.User("admin"),
+			basicAuthFn: func() (string, string, bool) {
+				return "admin", "test", true
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.userinfo.String(), func(t *testing.T) {
+			t.Parallel()
+
+			ok := AuthenticateUserinfo(tt.basicAuthFn, tt.userinfo)
+			require.EqualT(t, tt.expected, ok)
+		})
+	}
+}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -79,8 +79,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 type CommonConfig struct {
 	Mirror   *url.URL
 	Header   http.Header
-	Username string
-	Password string
+	Userinfo *url.Userinfo
 }
 
 type PullConfig struct {
@@ -104,10 +103,9 @@ func WithPullHeader(header http.Header) PullOption {
 	}
 }
 
-func WithPullBasicAuth(username, password string) PullOption {
+func WithPullUserinfo(userinfo *url.Userinfo) PullOption {
 	return func(cfg *PullConfig) error {
-		cfg.Username = username
-		cfg.Password = password
+		cfg.Userinfo = userinfo
 		return nil
 	}
 }
@@ -138,10 +136,9 @@ func WithFetchHeader(k, v string) FetchOption {
 	}
 }
 
-func WithFetchBasicAuth(username, password string) FetchOption {
+func WithFetchUserinfo(userinfo *url.Userinfo) FetchOption {
 	return func(cfg *CommonConfig) error {
-		cfg.Username = username
-		cfg.Password = password
+		cfg.Userinfo = userinfo
 		return nil
 	}
 }
@@ -164,8 +161,7 @@ func (c *Client) Pull(ctx context.Context, img Image, opts ...PullOption) ([]Pul
 	fetchOpt := func(commonCfg *CommonConfig) error {
 		commonCfg.Mirror = cfg.Mirror
 		commonCfg.Header = cfg.Header
-		commonCfg.Username = cfg.Username
-		commonCfg.Password = cfg.Password
+		commonCfg.Userinfo = cfg.Userinfo
 		return nil
 	}
 
@@ -305,12 +301,14 @@ func (c *Client) Fetch(ctx context.Context, dist DistributionPath, opts ...Fetch
 			return resilient.Unrecoverable(err)
 		}
 		httpx.CopyHeader(req.Header, cfg.Header)
-		req.SetBasicAuth(cfg.Username, cfg.Password)
 		req.Header.Set(httpx.HeaderUserAgent, "spegel")
 		req.Header.Add(httpx.HeaderAccept, ocispec.MediaTypeImageManifest)
 		req.Header.Add(httpx.HeaderAccept, images.MediaTypeDockerSchema2Manifest)
 		req.Header.Add(httpx.HeaderAccept, ocispec.MediaTypeImageIndex)
 		req.Header.Add(httpx.HeaderAccept, images.MediaTypeDockerSchema2ManifestList)
+		if cfg.Userinfo != nil {
+			req.Header.Set(httpx.HeaderAuthorization, httpx.UserinfoHeaderValue(*cfg.Userinfo))
+		}
 		if dist.Range != nil {
 			req.Header.Add(httpx.HeaderRange, dist.Range.String())
 		}

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -3,7 +3,6 @@ package oci
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -424,7 +423,7 @@ func contentLabelsToReferences(l map[string]string, dgst digest.Digest) ([]Refer
 // Refer to containerd registry configuration documentation for more information about required configuration.
 // https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 // https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples
-func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegistries, mirrorTargets []string, resolveTags, prependExisting bool, username, password string) error {
+func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegistries, mirrorTargets []string, resolveTags, prependExisting bool, userinfo *url.Userinfo) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	// Parse and verify mirror urls.
@@ -457,7 +456,7 @@ func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegi
 		capabilities = append(capabilities, "resolve")
 	}
 	for _, mr := range parsedMirroredRegistries {
-		templatedHosts, err := templateHosts(mr, parsedMirrorTargets, capabilities, username, password)
+		templatedHosts, err := templateHosts(mr, parsedMirrorTargets, capabilities, userinfo)
 		if err != nil {
 			return err
 		}
@@ -618,7 +617,7 @@ func clearConfig(configPath string) error {
 	return nil
 }
 
-func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, capabilities []string, username, password string) (string, error) {
+func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, capabilities []string, userinfo *url.Userinfo) (string, error) {
 	server := parsedMirrorRegistry.String()
 	if parsedMirrorRegistry.String() == "https://docker.io" {
 		server = "https://registry-1.docker.io"
@@ -626,12 +625,9 @@ func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, 
 	if parsedMirrorRegistry == wildcardRegistryURL {
 		server = ""
 	}
-
 	authorization := ""
-	if username != "" || password != "" {
-		authorization = username + ":" + password
-		authorization = base64.StdEncoding.EncodeToString([]byte(authorization))
-		authorization = "Basic " + authorization
+	if userinfo != nil {
+		authorization = httpx.UserinfoHeaderValue(*userinfo)
 	}
 
 	hc := struct {

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -104,8 +104,7 @@ func TestMirrorConfiguration(t *testing.T) {
 		existingFiles       map[string]string
 		expectedFiles       map[string]string
 		name                string
-		username            string
-		password            string
+		userinfo            *url.Userinfo
 		mirroredRegistries  []string
 		mirrorTargets       []string
 		resolveTags         bool
@@ -391,8 +390,7 @@ dial_timeout = '200ms'`,
 			mirroredRegistries: []string{"http://foo.bar:5000"},
 			mirrorTargets:      []string{"http://127.0.0.1:5000", "http://127.0.0.1:5001"},
 			prependExisting:    false,
-			username:           "hello",
-			password:           "world",
+			userinfo:           url.UserPassword("hello", "world"),
 			expectedFiles: map[string]string{
 				"foo.bar:5000/hosts.toml": `server = 'http://foo.bar:5000'
 
@@ -426,7 +424,7 @@ Authorization = 'Basic aGVsbG86d29ybGQ='`,
 				err = os.WriteFile(path, []byte(v), 0o644)
 				require.NoError(t, err)
 			}
-			err := AddMirrorConfiguration(t.Context(), registryConfigPath, tt.mirroredRegistries, tt.mirrorTargets, tt.resolveTags, tt.prependExisting, tt.username, tt.password)
+			err := AddMirrorConfiguration(t.Context(), registryConfigPath, tt.mirroredRegistries, tt.mirrorTargets, tt.resolveTags, tt.prependExisting, tt.userinfo)
 			require.NoError(t, err)
 			ok, err := dirExists(filepath.Join(registryConfigPath, "_backup"))
 			require.NoError(t, err)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -33,8 +33,7 @@ const (
 
 type RegistryConfig struct {
 	OCIClient      *oci.Client
-	Username       string
-	Password       string
+	Userinfo       *url.Userinfo
 	Filters        []oci.Filter
 	ResolveTimeout time.Duration
 	ResolveRetries int
@@ -70,10 +69,9 @@ func WithOCIClient(ociClient *oci.Client) RegistryOption {
 	}
 }
 
-func WithBasicAuth(username, password string) RegistryOption {
+func WithUserinfo(userinfo *url.Userinfo) RegistryOption {
 	return func(cfg *RegistryConfig) error {
-		cfg.Username = username
-		cfg.Password = password
+		cfg.Userinfo = userinfo
 		return nil
 	}
 }
@@ -88,8 +86,7 @@ type Registry struct {
 	ociStore       oci.Store
 	ociClient      *oci.Client
 	router         routing.Router
-	username       string
-	password       string
+	userinfo       *url.Userinfo
 	filters        []oci.Filter
 	resolveTimeout time.Duration
 	resolveRetries int
@@ -127,8 +124,7 @@ func NewRegistry(ociStore oci.Store, router routing.Router, opts ...RegistryOpti
 		resolveRetries: cfg.ResolveRetries,
 		filters:        cfg.Filters,
 		resolveTimeout: cfg.ResolveTimeout,
-		username:       cfg.Username,
-		password:       cfg.Password,
+		userinfo:       cfg.Userinfo,
 		bufferPool:     bufferPool,
 		stats:          Statistics{},
 		hedger:         resilient.NewHedger([]float64{80, 85, 90}, 50*time.Millisecond),
@@ -174,13 +170,10 @@ func (r *Registry) registryHandler(rw httpx.ResponseWriter, req *http.Request) {
 	rw.SetAttrs(HandlerAttrKey, "registry")
 
 	// Check basic authentication
-	if r.username != "" || r.password != "" {
-		username, password, _ := req.BasicAuth()
-		if r.username != username || r.password != password {
-			respErr := oci.NewDistributionError(oci.ErrCodeUnauthorized, "invalid credentials", nil)
-			rw.WriteError(http.StatusUnauthorized, respErr)
-			return
-		}
+	if r.userinfo != nil && !httpx.AuthenticateUserinfo(req.BasicAuth, *r.userinfo) {
+		respErr := oci.NewDistributionError(oci.ErrCodeUnauthorized, "invalid credentials", nil)
+		rw.WriteError(http.StatusUnauthorized, respErr)
+		return
 	}
 
 	// Quickly return 200 for /v2 to indicate that registry supports v2.
@@ -413,7 +406,7 @@ func (r *Registry) raceFetch(ctx context.Context, iterator *routing.Iterator, di
 					fetchOpts := []oci.FetchOption{
 						oci.WithFetchHeader(HeaderSpegelMirrored, "true"),
 						oci.WithFetchMirror(mirror),
-						oci.WithFetchBasicAuth(r.username, r.password),
+						oci.WithFetchUserinfo(r.userinfo),
 					}
 					rc, desc, err := r.ociClient.Fetch(ctx, dist, fetchOpts...)
 					if err != nil {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"net/url"
 	"regexp"
 	"testing"
 	"testing/synctest"
@@ -44,7 +45,7 @@ func TestRegistryOptions(t *testing.T) {
 		WithResolveRetries(5),
 		WithRegistryFilters(filters),
 		WithResolveTimeout(10 * time.Minute),
-		WithBasicAuth("foo", "bar"),
+		WithUserinfo(url.UserPassword("foo", "bar")),
 		WithOCIClient(ociClient),
 	}
 	cfg := RegistryConfig{}
@@ -54,8 +55,7 @@ func TestRegistryOptions(t *testing.T) {
 	require.SliceEqualT(t, filters, cfg.Filters)
 	require.EqualT(t, 10*time.Minute, cfg.ResolveTimeout)
 	require.Equal(t, ociClient, cfg.OCIClient)
-	require.EqualT(t, "foo", cfg.Username)
-	require.EqualT(t, "bar", cfg.Password)
+	require.EqualT(t, "foo:bar", cfg.Userinfo.String())
 }
 
 func TestProbeHandlers(t *testing.T) {
@@ -98,8 +98,7 @@ func TestBasicAuth(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		username    string
-		password    string
+		userinfo    *url.Userinfo
 		reqUsername string
 		reqPassword string
 		expected    int
@@ -116,38 +115,33 @@ func TestBasicAuth(t *testing.T) {
 		},
 		{
 			name:        "correct authentication",
-			username:    "foo",
-			password:    "bar",
+			userinfo:    url.UserPassword("foo", "bar"),
 			reqUsername: "foo",
 			reqPassword: "bar",
 			expected:    http.StatusOK,
 		},
 		{
 			name:        "invalid username",
-			username:    "foo",
-			password:    "bar",
+			userinfo:    url.UserPassword("foo", "bar"),
 			reqUsername: "wrong",
 			reqPassword: "bar",
 			expected:    http.StatusUnauthorized,
 		},
 		{
 			name:        "invalid password",
-			username:    "foo",
-			password:    "bar",
+			userinfo:    url.UserPassword("foo", "bar"),
 			reqUsername: "foo",
 			reqPassword: "wrong",
 			expected:    http.StatusUnauthorized,
 		},
 		{
 			name:     "missing authentication",
-			username: "foo",
-			password: "bar",
+			userinfo: url.UserPassword("foo", "bar"),
 			expected: http.StatusUnauthorized,
 		},
 		{
 			name:     "missing authentication",
-			username: "foo",
-			password: "bar",
+			userinfo: url.UserPassword("foo", "bar"),
 			expected: http.StatusUnauthorized,
 		},
 	}
@@ -155,7 +149,7 @@ func TestBasicAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			reg, err := NewRegistry(nil, nil, WithBasicAuth(tt.username, tt.password))
+			reg, err := NewRegistry(nil, nil, WithUserinfo(tt.userinfo))
 			require.NoError(t, err)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost/v2/", nil)


### PR DESCRIPTION
Switches passing of basic credentials to a userinfo and also moves the loading from file to a package to allow for testing.