### PR TITLE
Add extraInitContainers even if containerdMirrorAdd is false

### DIFF
--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -39,11 +39,12 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       priorityClassName: {{ .Values.priorityClassName }}
-      {{- if .Values.spegel.containerdMirrorAdd }}
+      {{- if or .Values.spegel.containerdMirrorAdd .Values.extraInitContainers }}
       initContainers:
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.spegel.containerdMirrorAdd }}
       - name: configuration
         image: "{{ include "spegel.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -81,6 +82,7 @@ spec:
             mountPath: "/etc/secrets/basic-auth"
             readOnly: true
           {{- end }}
+      {{- end }}
       {{- end }}
       containers:
       - name: registry


### PR DESCRIPTION
Fixes https://github.com/spegel-org/spegel/issues/1304, i.e., any extra init containers not being included if `.spegel.containerdMirrorAdd` is `false`.