### PR TITLE
Wire --mirror-resolve-retries flag to registry

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,6 +251,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	}
 	registryOpts := []registry.RegistryOption{
 		registry.WithRegistryFilters(filters),
+		registry.WithResolveRetries(args.MirrorResolveRetries),
 		registry.WithResolveTimeout(args.MirrorResolveTimeout),
 		registry.WithUserinfo(userinfo),
 		registry.WithOCIClient(ociClient),


### PR DESCRIPTION
The `--mirror-resolve-retries` CLI flag is parsed but never passed to `NewRegistry`. The registry always uses the hardcoded default of 3, regardless of what the user configures via the Helm chart or CLI.

Fixes #1409 