### PR TITLE
fix: reduce ProviderAddrTTL to match provider record validity

### DIFF
--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -155,7 +155,7 @@ func NewP2PRouter(ctx context.Context, addr string, bs Bootstrapper, registryPor
 		dht.ProtocolPrefix("/spegel"),
 		dht.ProviderManagerOpts(
 			records.ProvideValidity(cfg.AdvertiseTTL+(2*cfg.MaxReprovideDelay)),
-			records.ProviderAddrTTL(1*time.Hour),
+			records.ProviderAddrTTL(cfg.AdvertiseTTL+(2*cfg.MaxReprovideDelay)+(5*time.Minute)),
 		),
 	}
 	kdht, err := dht.New(ctx, host, dhtOpts...)


### PR DESCRIPTION
Reduce `ProviderAddrTTL` from a fixed 1 hour to `AdvertiseTTL + 2*MaxReprovideDelay + 5min` (24 minutes). This ensures dead peer addresses are evicted from the peerstore in a timeframe consistent with provider record expiry.
Stale-IP dials disappear within minutes of a peer going away instead of within an hour.

#1411 