### PR TITLE
Reject range whose start is at or beyond content size

### DIFF
--- a/pkg/httpx/range.go
+++ b/pkg/httpx/range.go
@@ -142,6 +142,9 @@ func ContentRangeFromRange(rng Range, size int64) (ContentRange, error) {
 
 	// Offset with unknown size.
 	if rng.End == nil {
+		if *rng.Start >= size {
+			return ContentRange{}, fmt.Errorf("start %d is out of bounds for size %d", *rng.Start, size)
+		}
 		crng := ContentRange{
 			Start: *rng.Start,
 			End:   size - 1,
@@ -151,6 +154,9 @@ func ContentRangeFromRange(rng Range, size int64) (ContentRange, error) {
 	}
 
 	// Known start and end range.
+	if *rng.Start >= size {
+		return ContentRange{}, fmt.Errorf("start %d is out of bounds for size %d", *rng.Start, size)
+	}
 	crng := ContentRange{
 		Start: *rng.Start,
 		End:   min(*rng.End, size-1),

--- a/pkg/httpx/range.go
+++ b/pkg/httpx/range.go
@@ -140,11 +140,14 @@ func ContentRangeFromRange(rng Range, size int64) (ContentRange, error) {
 		return crng, nil
 	}
 
+	// A start at or beyond the content size is out of bounds for every
+	// offset form below.
+	if *rng.Start >= size {
+		return ContentRange{}, fmt.Errorf("start %d is out of bounds for size %d", *rng.Start, size)
+	}
+
 	// Offset with unknown size.
 	if rng.End == nil {
-		if *rng.Start >= size {
-			return ContentRange{}, fmt.Errorf("start %d is out of bounds for size %d", *rng.Start, size)
-		}
 		crng := ContentRange{
 			Start: *rng.Start,
 			End:   size - 1,
@@ -154,9 +157,6 @@ func ContentRangeFromRange(rng Range, size int64) (ContentRange, error) {
 	}
 
 	// Known start and end range.
-	if *rng.Start >= size {
-		return ContentRange{}, fmt.Errorf("start %d is out of bounds for size %d", *rng.Start, size)
-	}
 	crng := ContentRange{
 		Start: *rng.Start,
 		End:   min(*rng.End, size-1),

--- a/pkg/httpx/range_test.go
+++ b/pkg/httpx/range_test.go
@@ -213,6 +213,15 @@ func TestContentRange(t *testing.T) {
 
 	_, err = ContentRangeFromRange(Range{Start: nil, End: nil}, 100)
 	require.EqualError(t, err, "start and end range cannot both be empty")
+
+	start := int64(1000)
+	_, err = ContentRangeFromRange(Range{Start: &start}, 1000)
+	require.EqualError(t, err, "start 1000 is out of bounds for size 1000")
+
+	start = int64(1500)
+	end := int64(2000)
+	_, err = ContentRangeFromRange(Range{Start: &start, End: &end}, 1000)
+	require.EqualError(t, err, "start 1500 is out of bounds for size 1000")
 }
 
 func TestRangeClone(t *testing.T) {


### PR DESCRIPTION
A range like bytes=1000- against a 1000 byte blob passed validation and produced a content range with End set to one below the size, so Length() returned a negative Content-Length, while bytes=1500-2000 gave a zero length. RFC 9110 treats a start offset at or past the representation size as unsatisfiable, so ContentRangeFromRange now returns an error which the registry already maps to 416.