### PR TITLE
Move Containerd specific code to its own package

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/spegel-org/spegel/internal/channel"
 	"github.com/spegel-org/spegel/pkg/httpx"
-	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/oci/containerd"
 )
 
 func Run(ctx context.Context, addr, configPath string) error {
 	log := logr.FromContextOrDiscard(ctx)
 
-	err := oci.CleanupMirrorConfiguration(ctx, configPath)
+	err := containerd.CleanupMirrorConfiguration(ctx, configPath)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/metrics"
 	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/oci/containerd"
 	"github.com/spegel-org/spegel/pkg/registry"
 	"github.com/spegel-org/spegel/pkg/routing"
 	"github.com/spegel-org/spegel/pkg/state"
@@ -167,7 +168,7 @@ func configurationCommand(ctx context.Context, args *ConfigurationCmd) error {
 	if err != nil {
 		return err
 	}
-	err = oci.AddMirrorConfiguration(ctx, args.ContainerdRegistryConfigPath, args.MirroredRegistries, args.MirrorTargets, args.ResolveTags, args.PrependExisting, userinfo)
+	err = containerd.AddMirrorConfiguration(ctx, args.ContainerdRegistryConfigPath, args.MirroredRegistries, args.MirrorTargets, args.ResolveTags, args.PrependExisting, userinfo)
 	if err != nil {
 		return err
 	}
@@ -205,7 +206,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	}
 
 	// OCI Store
-	ociStore, err := oci.NewContainerd(ctx, args.ContainerdSock, args.ContainerdNamespace, oci.WithContentPath(args.ContainerdContentPath))
+	ociStore, err := containerd.NewContainerd(ctx, args.ContainerdSock, args.ContainerdNamespace, containerd.WithContentPath(args.ContainerdContentPath))
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/containerd/containerd.go
+++ b/pkg/oci/containerd/containerd.go
@@ -1,20 +1,15 @@
-package oci
+package containerd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"net"
-	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
-	"text/template"
 	"time"
 
 	eventtypes "github.com/containerd/containerd/api/events"
@@ -29,17 +24,15 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pelletier/go-toml/v2"
-	tomlu "github.com/pelletier/go-toml/v2/unstable"
 	"google.golang.org/grpc"
 
 	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/internal/resilient"
 	"github.com/spegel-org/spegel/pkg/httpx"
+	"github.com/spegel-org/spegel/pkg/oci"
 )
 
 const (
-	backupDir       = "_backup"
 	listImageFilter = `name~="^.+/"`
 )
 
@@ -64,7 +57,7 @@ func WithConnection(conn net.Conn) ContainerdOption {
 	}
 }
 
-var _ Store = &Containerd{}
+var _ oci.Store = &Containerd{}
 
 type Containerd struct {
 	client       *client.Client
@@ -126,15 +119,15 @@ func (c *Containerd) Name() string {
 	return "containerd"
 }
 
-func (c *Containerd) ListImages(ctx context.Context) ([]Image, error) {
+func (c *Containerd) ListImages(ctx context.Context) ([]oci.Image, error) {
 	cImgs, err := c.client.ImageService().List(ctx, listImageFilter)
 	if err != nil {
 		return nil, err
 	}
 	tagDgsts := map[digest.Digest]string{}
-	imgs := []Image{}
+	imgs := []oci.Image{}
 	for _, cImg := range cImgs {
-		img, err := ParseImage(cImg.Name, WithDigest(cImg.Target.Digest))
+		img, err := oci.ParseImage(cImg.Name, oci.WithDigest(cImg.Target.Digest))
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +137,7 @@ func (c *Containerd) ListImages(ctx context.Context) ([]Image, error) {
 		imgs = append(imgs, img)
 	}
 	// Remove duplicate digest images that already have tags.
-	imgs = slices.DeleteFunc(imgs, func(img Image) bool {
+	imgs = slices.DeleteFunc(imgs, func(img oci.Image) bool {
 		if img.Tag != "" {
 			return false
 		}
@@ -167,7 +160,7 @@ func (c *Containerd) Resolve(ctx context.Context, ref string) (digest.Digest, er
 func (c *Containerd) Descriptor(ctx context.Context, dgst digest.Digest) (ocispec.Descriptor, error) {
 	info, err := c.client.ContentStore().Info(ctx, dgst)
 	if errors.Is(err, errdefs.ErrNotFound) {
-		return ocispec.Descriptor{}, errors.Join(ErrNotFound, err)
+		return ocispec.Descriptor{}, errors.Join(oci.ErrNotFound, err)
 	}
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -176,7 +169,7 @@ func (c *Containerd) Descriptor(ctx context.Context, dgst digest.Digest) (ocispe
 	mt, ok := c.mediaTypeIdx.Get(dgst)
 	if !ok {
 		mt, err = func() (string, error) {
-			if info.Size > ManifestMaxSize {
+			if info.Size > oci.ManifestMaxSize {
 				return httpx.ContentTypeBinary, nil
 			}
 			rc, err := c.Open(ctx, dgst)
@@ -184,7 +177,7 @@ func (c *Containerd) Descriptor(ctx context.Context, dgst digest.Digest) (ocispe
 				return "", err
 			}
 			defer rc.Close()
-			mt, err := FingerprintMediaType(rc)
+			mt, err := oci.FingerprintMediaType(rc)
 			if err != nil {
 				return "", err
 			}
@@ -209,7 +202,7 @@ func (c *Containerd) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekC
 		path := filepath.Join(c.contentPath, "blobs", dgst.Algorithm().String(), dgst.Encoded())
 		file, err := os.Open(path)
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, errors.Join(ErrNotFound, err)
+			return nil, errors.Join(oci.ErrNotFound, err)
 		}
 		if err != nil {
 			return nil, err
@@ -218,7 +211,7 @@ func (c *Containerd) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekC
 	}
 	ra, err := c.client.ContentStore().ReaderAt(ctx, ocispec.Descriptor{Digest: dgst})
 	if errors.Is(err, errdefs.ErrNotFound) {
-		return nil, errors.Join(ErrNotFound, err)
+		return nil, errors.Join(oci.ErrNotFound, err)
 	}
 	if err != nil {
 		return nil, err
@@ -232,29 +225,29 @@ func (c *Containerd) Open(ctx context.Context, dgst digest.Digest) (io.ReadSeekC
 	}, nil
 }
 
-func (c *Containerd) Subscribe(ctx context.Context) (map[Image][]digest.Digest, <-chan OCIEvent, error) {
+func (c *Containerd) Subscribe(ctx context.Context) (map[oci.Image][]digest.Digest, <-chan oci.OCIEvent, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	eventCh := make(chan OCIEvent)
+	eventCh := make(chan oci.OCIEvent)
 	subCtx, subCancel := context.WithCancel(ctx)
 	eventFilters := []string{`topic~="/images/create|/images/delete",event.name~="^.+/"`, `topic~="/content/create"`}
 	envelopeCh, cErrCh := c.client.EventService().Subscribe(subCtx, eventFilters...)
 
 	// Populate the content index.
-	initial := map[Image][]digest.Digest{}
-	contentIdx := map[digest.Digest][]Reference{}
+	initial := map[oci.Image][]digest.Digest{}
+	contentIdx := map[digest.Digest][]oci.Reference{}
 	cImgs, err := c.client.ImageService().List(ctx, listImageFilter)
 	if err != nil {
 		subCancel()
 		return nil, nil, err
 	}
 	for _, cImg := range cImgs {
-		img, err := ParseImage(cImg.Name, WithDigest(cImg.Target.Digest))
+		img, err := oci.ParseImage(cImg.Name, oci.WithDigest(cImg.Target.Digest))
 		if err != nil {
 			log.Error(err, "skipping image that cannot be parsed", "image", img.String())
 			continue
 		}
-		refs := []Reference{}
+		refs := []oci.Reference{}
 		handler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			children, err := images.ChildrenHandler(c.client.ContentStore()).Handle(ctx, desc)
 			if errors.Is(err, errdefs.ErrNotFound) {
@@ -263,7 +256,7 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[Image][]digest.Digest, 
 			if err != nil {
 				return nil, err
 			}
-			ref := Reference{
+			ref := oci.Reference{
 				Registry:   img.Registry,
 				Repository: img.Repository,
 				Digest:     desc.Digest,
@@ -316,7 +309,7 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[Image][]digest.Digest, 
 	return initial, eventCh, nil
 }
 
-func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, contentIdx map[digest.Digest][]Reference) ([]OCIEvent, error) {
+func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, contentIdx map[digest.Digest][]oci.Reference) ([]oci.OCIEvent, error) {
 	if envelope.Event == nil {
 		return nil, errors.New("envelope event cannot be nil")
 	}
@@ -327,7 +320,7 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 	switch e := evt.(type) {
 	case *eventtypes.ContentCreate:
 		dgst := digest.Digest(e.GetDigest())
-		refs, err := resilient.RetryValue(ctx, 10, resilient.BackoffDelay(10*time.Millisecond, 100*time.Millisecond), func(ctx context.Context) ([]Reference, error) {
+		refs, err := resilient.RetryValue(ctx, 10, resilient.BackoffDelay(10*time.Millisecond, 100*time.Millisecond), func(ctx context.Context) ([]oci.Reference, error) {
 			info, err := c.client.ContentStore().Info(ctx, dgst)
 			if err != nil {
 				return nil, resilient.Unrecoverable(err)
@@ -341,26 +334,26 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 		if err != nil {
 			return nil, err
 		}
-		events := []OCIEvent{}
+		events := []oci.OCIEvent{}
 		for _, ref := range refs {
-			events = append(events, OCIEvent{Type: CreateEvent, Reference: ref})
+			events = append(events, oci.OCIEvent{Type: oci.CreateEvent, Reference: ref})
 		}
 		return events, nil
 	case *eventtypes.ImageCreate:
-		img, err := ParseImage(e.GetName(), AllowTagOnly())
+		img, err := oci.ParseImage(e.GetName(), oci.AllowTagOnly())
 		if err != nil {
 			return nil, err
 		}
 		// Just advertise the image if it is a tag reference.
 		if img.Digest == "" {
-			return []OCIEvent{{Type: CreateEvent, Reference: img.Reference}}, nil
+			return []oci.OCIEvent{{Type: oci.CreateEvent, Reference: img.Reference}}, nil
 		}
 		// Walk the image to index its content.
 		cImg, err := c.client.ImageService().Get(ctx, img.String())
 		if err != nil {
 			return nil, err
 		}
-		refs := []Reference{}
+		refs := []oci.Reference{}
 		handler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			children, err := images.ChildrenHandler(c.client.ContentStore()).Handle(ctx, desc)
 			if errors.Is(err, errdefs.ErrNotFound) {
@@ -369,7 +362,7 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 			if err != nil {
 				return nil, err
 			}
-			ref := Reference{
+			ref := oci.Reference{
 				Registry:   img.Registry,
 				Repository: img.Repository,
 				Digest:     desc.Digest,
@@ -384,19 +377,19 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 		contentIdx[img.Digest] = refs
 		return nil, nil
 	case *eventtypes.ImageDelete:
-		img, err := ParseImage(e.GetName(), AllowTagOnly())
+		img, err := oci.ParseImage(e.GetName(), oci.AllowTagOnly())
 		if err != nil {
 			return nil, err
 		}
 		// Just advertise the image if it is a tag reference.
 		if img.Digest == "" {
-			return []OCIEvent{{Type: DeleteEvent, Reference: img.Reference}}, nil
+			return []oci.OCIEvent{{Type: oci.DeleteEvent, Reference: img.Reference}}, nil
 		}
 		// Advertise deletion of images content if it no longer exists.
 		refs, ok := contentIdx[img.Digest]
 		if !ok {
 			logr.FromContextOrDiscard(ctx).Info("delete event with missing content index entry")
-			return []OCIEvent{{Type: DeleteEvent, Reference: img.Reference}}, nil
+			return []oci.OCIEvent{{Type: oci.DeleteEvent, Reference: img.Reference}}, nil
 		}
 		delete(contentIdx, img.Digest)
 		// Delete events are sent before garbage collection is run.
@@ -414,7 +407,7 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 			return nil, fmt.Errorf("image manifest has not been deleted: %w", err)
 		}
 		// Create delete events for contents that has been removed.
-		events := []OCIEvent{}
+		events := []oci.OCIEvent{}
 		for _, ref := range refs {
 			_, err := c.client.ContentStore().Info(ctx, ref.Digest)
 			if err == nil {
@@ -423,7 +416,7 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 			if !errors.Is(err, errdefs.ErrNotFound) {
 				return nil, err
 			}
-			events = append(events, OCIEvent{Type: DeleteEvent, Reference: ref})
+			events = append(events, oci.OCIEvent{Type: oci.DeleteEvent, Reference: ref})
 		}
 		return events, nil
 	default:
@@ -431,13 +424,13 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 	}
 }
 
-func contentLabelsToReferences(l map[string]string, dgst digest.Digest) ([]Reference, error) {
-	refs := []Reference{}
+func contentLabelsToReferences(l map[string]string, dgst digest.Digest) ([]oci.Reference, error) {
+	refs := []oci.Reference{}
 	for k, v := range l {
 		if !strings.HasPrefix(k, labels.LabelDistributionSource) {
 			continue
 		}
-		ref := Reference{
+		ref := oci.Reference{
 			Registry:   strings.TrimPrefix(k, labels.LabelDistributionSource+"."),
 			Repository: v,
 			Digest:     dgst,
@@ -469,316 +462,4 @@ func getContentPath(ctx context.Context, client *client.Client) (string, error) 
 		return "", nil
 	}
 	return root, nil
-}
-
-// Refer to containerd registry configuration documentation for more information about required configuration.
-// https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
-// https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples
-func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegistries, mirrorTargets []string, resolveTags, prependExisting bool, userinfo *url.Userinfo) error {
-	log := logr.FromContextOrDiscard(ctx)
-
-	// Parse and verify mirror urls.
-	parsedMirroredRegistries, err := parseRegistries(mirroredRegistries, true)
-	if err != nil {
-		return err
-	}
-	parsedMirrorTargets, err := parseRegistries(mirrorTargets, false)
-	if err != nil {
-		return err
-	}
-
-	// Backup and clear configgurrationn.
-	err = os.MkdirAll(configPath, 0o755)
-	if err != nil {
-		return err
-	}
-	err = backupConfig(log, configPath)
-	if err != nil {
-		return err
-	}
-	err = clearConfig(configPath)
-	if err != nil {
-		return err
-	}
-
-	// Write mirror configuration
-	capabilities := []string{"pull"}
-	if resolveTags {
-		capabilities = append(capabilities, "resolve")
-	}
-	for _, mr := range parsedMirroredRegistries {
-		templatedHosts, err := templateHosts(mr, parsedMirrorTargets, capabilities, userinfo)
-		if err != nil {
-			return err
-		}
-		if prependExisting {
-			existingHosts, err := existingHosts(configPath, mr)
-			if err != nil {
-				return err
-			}
-			if existingHosts != "" {
-				// If we are prepending we also want to keep files like certificates that may be referenced.
-				backupRegDir := path.Join(configPath, backupDir, mr.Host)
-				err = filepath.WalkDir(backupRegDir, func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						return err
-					}
-					if d.IsDir() {
-						return nil
-					}
-					if d.Name() == "hosts.toml" {
-						return nil
-					}
-					src, err := os.Open(path)
-					if err != nil {
-						return err
-					}
-					defer src.Close()
-					relPath, err := filepath.Rel(backupRegDir, path)
-					if err != nil {
-						return err
-					}
-					dstPath := filepath.Join(configPath, mr.Host, relPath)
-					err = os.MkdirAll(filepath.Dir(dstPath), 0o755)
-					if err != nil {
-						return err
-					}
-					dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-					if err != nil {
-						return err
-					}
-					defer dst.Close()
-					_, err = io.Copy(dst, src)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-				if err != nil {
-					return err
-				}
-
-				templatedHosts = templatedHosts + "\n\n" + existingHosts
-				log.Info("prepending to existing containerd mirror configuration", "registry", mr.String())
-			}
-
-		}
-		fp := path.Join(configPath, mr.Host, "hosts.toml")
-		err = os.MkdirAll(filepath.Dir(fp), 0o755)
-		if err != nil {
-			return err
-		}
-		err = os.WriteFile(fp, []byte(templatedHosts), 0o644)
-		if err != nil {
-			return err
-		}
-		log.Info("added containerd mirror configuration", "registry", mr.String(), "path", fp)
-	}
-	return nil
-}
-
-func CleanupMirrorConfiguration(ctx context.Context, configPath string) error {
-	log := logr.FromContextOrDiscard(ctx)
-
-	// If backup directory does not exist it means mirrors was never configured or cleanup has already run.
-	backupDirPath := path.Join(configPath, backupDir)
-	ok, err := dirExists(backupDirPath)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		log.Info("skipping cleanup because backup directory does not exist")
-		return nil
-	}
-
-	// Remove everything except _backup
-	err = clearConfig(configPath)
-	if err != nil {
-		return err
-	}
-
-	// Move content from backup directory
-	files, err := os.ReadDir(backupDirPath)
-	if err != nil {
-		return err
-	}
-	for _, fi := range files {
-		oldPath := path.Join(backupDirPath, fi.Name())
-		newPath := path.Join(configPath, fi.Name())
-		err := os.Rename(oldPath, newPath)
-		if err != nil {
-			return err
-		}
-		log.Info("recovering containerd host configuration", "path", oldPath)
-	}
-
-	// Remove backup directory to indicate that cleanup has been run.
-	err = os.RemoveAll(backupDirPath)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func backupConfig(log logr.Logger, configPath string) error {
-	backupDirPath := path.Join(configPath, backupDir)
-	ok, err := dirExists(backupDirPath)
-	if err != nil {
-		return err
-	}
-	if ok {
-		return nil
-	}
-	files, err := os.ReadDir(configPath)
-	if err != nil {
-		return err
-	}
-	err = os.MkdirAll(backupDirPath, 0o755)
-	if err != nil {
-		return err
-	}
-	for _, fi := range files {
-		oldPath := path.Join(configPath, fi.Name())
-		newPath := path.Join(backupDirPath, fi.Name())
-		err := os.Rename(oldPath, newPath)
-		if err != nil {
-			return err
-		}
-		log.Info("backing up containerd host configuration", "path", oldPath)
-	}
-	return nil
-}
-
-func clearConfig(configPath string) error {
-	files, err := os.ReadDir(configPath)
-	if err != nil {
-		return err
-	}
-	for _, fi := range files {
-		if fi.Name() == backupDir {
-			continue
-		}
-		filePath := path.Join(configPath, fi.Name())
-		err := os.RemoveAll(filePath)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, capabilities []string, userinfo *url.Userinfo) (string, error) {
-	server := parsedMirrorRegistry.String()
-	if parsedMirrorRegistry.String() == "https://docker.io" {
-		server = "https://registry-1.docker.io"
-	}
-	if parsedMirrorRegistry == wildcardRegistryURL {
-		server = ""
-	}
-	authorization := ""
-	if userinfo != nil {
-		authorization = httpx.UserinfoHeaderValue(*userinfo)
-	}
-
-	hc := struct {
-		Authorization string
-		Server        string
-		Capabilities  string
-		MirrorTargets []url.URL
-	}{
-		Server:        server,
-		Capabilities:  fmt.Sprintf("['%s']", strings.Join(capabilities, "', '")),
-		MirrorTargets: parsedMirrorTargets,
-		Authorization: authorization,
-	}
-	tmpl, err := template.New("").Parse(`{{- with .Server }}server = '{{ . }}'{{ end }}
-{{- $authorization := .Authorization }}
-{{ range .MirrorTargets }}
-[host.'{{ .String }}']
-capabilities = {{ $.Capabilities }}
-dial_timeout = '200ms'
-{{- if $authorization }}
-[host.'{{ .String }}'.header]
-Authorization = '{{ $authorization }}'
-{{- end }}
-{{ end }}`)
-	if err != nil {
-		return "", err
-	}
-	buf := bytes.NewBuffer(nil)
-	err = tmpl.Execute(buf, hc)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(buf.String()), nil
-}
-
-func existingHosts(configPath string, parsedMirrorRegistry url.URL) (string, error) {
-	fp := path.Join(configPath, backupDir, parsedMirrorRegistry.Host, "hosts.toml")
-	b, err := os.ReadFile(fp)
-	if errors.Is(err, os.ErrNotExist) {
-		return "", nil
-	}
-	if err != nil {
-		return "", err
-	}
-
-	type hostFile struct {
-		Hosts map[string]any `toml:"host"`
-	}
-
-	var hf hostFile
-	err = toml.Unmarshal(b, &hf)
-	if err != nil {
-		return "", err
-	}
-	if len(hf.Hosts) == 0 {
-		return "", nil
-	}
-
-	hosts := []string{}
-	parser := tomlu.Parser{}
-	parser.Reset(b)
-	for parser.NextExpression() {
-		err := parser.Error()
-		if err != nil {
-			return "", err
-		}
-		e := parser.Expression()
-		if e.Kind != tomlu.Table {
-			continue
-		}
-		ki := e.Key()
-		if ki.Next() && string(ki.Node().Data) == "host" && ki.Next() && ki.IsLast() {
-			hosts = append(hosts, string(ki.Node().Data))
-		}
-	}
-
-	ehs := []string{}
-	for _, h := range hosts {
-		data := hostFile{
-			Hosts: map[string]any{
-				h: hf.Hosts[h],
-			},
-		}
-		b, err := toml.Marshal(data)
-		if err != nil {
-			return "", err
-		}
-		eh := strings.TrimPrefix(string(b), "[host]\n")
-		ehs = append(ehs, eh)
-	}
-	return strings.TrimSpace(strings.Join(ehs, "\n")), nil
-}
-
-func dirExists(path string) (bool, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return info.IsDir(), nil
 }

--- a/pkg/oci/containerd/containerd_test.go
+++ b/pkg/oci/containerd/containerd_test.go
@@ -1,0 +1,66 @@
+package containerd
+
+import (
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+	"github.com/opencontainers/go-digest"
+
+	"github.com/spegel-org/spegel/pkg/oci"
+)
+
+func TestContentLabelsToReferences(t *testing.T) {
+	t.Parallel()
+
+	dgst := digest.Digest("foo")
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected []oci.Reference
+	}{
+		{
+			name: "one matching",
+			labels: map[string]string{
+				"containerd.io/distribution.source.docker.io": "library/alpine",
+			},
+			expected: []oci.Reference{
+				{
+					Registry:   "docker.io",
+					Repository: "library/alpine",
+					Digest:     dgst,
+				},
+			},
+		},
+		{
+			name: "multiple matching",
+			labels: map[string]string{
+				"containerd.io/distribution.source.example.com": "foo",
+				"containerd.io/distribution.source.ghcr.io":     "spegel-org/spegel",
+			},
+			expected: []oci.Reference{
+				{
+					Registry:   "ghcr.io",
+					Repository: "spegel-org/spegel",
+					Digest:     dgst,
+				},
+				{
+					Registry:   "example.com",
+					Repository: "foo",
+					Digest:     dgst,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(t.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			refs, err := contentLabelsToReferences(tt.labels, dgst)
+			require.NoError(t, err)
+			require.ElementsMatchT(t, tt.expected, refs)
+		})
+	}
+
+	_, err := contentLabelsToReferences(map[string]string{}, dgst)
+	require.EqualError(t, err, "no distribution source labels found for foo")
+}

--- a/pkg/oci/containerd/mirror.go
+++ b/pkg/oci/containerd/mirror.go
@@ -1,0 +1,339 @@
+package containerd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/go-logr/logr"
+	"github.com/pelletier/go-toml/v2"
+	tomlu "github.com/pelletier/go-toml/v2/unstable"
+
+	"github.com/spegel-org/spegel/pkg/httpx"
+	"github.com/spegel-org/spegel/pkg/oci"
+)
+
+const (
+	backupDir = "_backup"
+)
+
+// Refer to containerd registry configuration documentation for more information about required configuration.
+// https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+// https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples
+func AddMirrorConfiguration(ctx context.Context, configPath string, mirroredRegistries, mirrorTargets []string, resolveTags, prependExisting bool, userinfo *url.Userinfo) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	// Parse and verify mirror urls.
+	parsedMirroredRegistries, err := oci.ParseRegistries(mirroredRegistries, true)
+	if err != nil {
+		return err
+	}
+	parsedMirrorTargets, err := oci.ParseRegistries(mirrorTargets, false)
+	if err != nil {
+		return err
+	}
+
+	// Backup and clear configgurrationn.
+	err = os.MkdirAll(configPath, 0o755)
+	if err != nil {
+		return err
+	}
+	err = backupConfig(log, configPath)
+	if err != nil {
+		return err
+	}
+	err = clearConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	// Write mirror configuration
+	capabilities := []string{"pull"}
+	if resolveTags {
+		capabilities = append(capabilities, "resolve")
+	}
+	for _, mr := range parsedMirroredRegistries {
+		templatedHosts, err := templateHosts(mr, parsedMirrorTargets, capabilities, userinfo)
+		if err != nil {
+			return err
+		}
+		if prependExisting {
+			existingHosts, err := existingHosts(configPath, mr)
+			if err != nil {
+				return err
+			}
+			if existingHosts != "" {
+				// If we are prepending we also want to keep files like certificates that may be referenced.
+				backupRegDir := path.Join(configPath, backupDir, mr.Host)
+				err = filepath.WalkDir(backupRegDir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+					if d.IsDir() {
+						return nil
+					}
+					if d.Name() == "hosts.toml" {
+						return nil
+					}
+					src, err := os.Open(path)
+					if err != nil {
+						return err
+					}
+					defer src.Close()
+					relPath, err := filepath.Rel(backupRegDir, path)
+					if err != nil {
+						return err
+					}
+					dstPath := filepath.Join(configPath, mr.Host, relPath)
+					err = os.MkdirAll(filepath.Dir(dstPath), 0o755)
+					if err != nil {
+						return err
+					}
+					dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+					if err != nil {
+						return err
+					}
+					defer dst.Close()
+					_, err = io.Copy(dst, src)
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+
+				templatedHosts = templatedHosts + "\n\n" + existingHosts
+				log.Info("prepending to existing containerd mirror configuration", "registry", mr.String())
+			}
+
+		}
+		fp := path.Join(configPath, mr.Host, "hosts.toml")
+		err = os.MkdirAll(filepath.Dir(fp), 0o755)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(fp, []byte(templatedHosts), 0o644)
+		if err != nil {
+			return err
+		}
+		log.Info("added containerd mirror configuration", "registry", mr.String(), "path", fp)
+	}
+	return nil
+}
+
+func CleanupMirrorConfiguration(ctx context.Context, configPath string) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	// If backup directory does not exist it means mirrors was never configured or cleanup has already run.
+	backupDirPath := path.Join(configPath, backupDir)
+	ok, err := dirExists(backupDirPath)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		log.Info("skipping cleanup because backup directory does not exist")
+		return nil
+	}
+
+	// Remove everything except _backup
+	err = clearConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	// Move content from backup directory
+	files, err := os.ReadDir(backupDirPath)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		oldPath := path.Join(backupDirPath, fi.Name())
+		newPath := path.Join(configPath, fi.Name())
+		err := os.Rename(oldPath, newPath)
+		if err != nil {
+			return err
+		}
+		log.Info("recovering containerd host configuration", "path", oldPath)
+	}
+
+	// Remove backup directory to indicate that cleanup has been run.
+	err = os.RemoveAll(backupDirPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func backupConfig(log logr.Logger, configPath string) error {
+	backupDirPath := path.Join(configPath, backupDir)
+	ok, err := dirExists(backupDirPath)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	files, err := os.ReadDir(configPath)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(backupDirPath, 0o755)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		oldPath := path.Join(configPath, fi.Name())
+		newPath := path.Join(backupDirPath, fi.Name())
+		err := os.Rename(oldPath, newPath)
+		if err != nil {
+			return err
+		}
+		log.Info("backing up containerd host configuration", "path", oldPath)
+	}
+	return nil
+}
+
+func clearConfig(configPath string) error {
+	files, err := os.ReadDir(configPath)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		if fi.Name() == backupDir {
+			continue
+		}
+		filePath := path.Join(configPath, fi.Name())
+		err := os.RemoveAll(filePath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func templateHosts(parsedMirrorRegistry url.URL, parsedMirrorTargets []url.URL, capabilities []string, userinfo *url.Userinfo) (string, error) {
+	server := parsedMirrorRegistry.String()
+	if parsedMirrorRegistry.String() == "https://docker.io" {
+		server = "https://registry-1.docker.io"
+	}
+	if parsedMirrorRegistry == oci.WildcardRegistryURL {
+		server = ""
+	}
+	authorization := ""
+	if userinfo != nil {
+		authorization = httpx.UserinfoHeaderValue(*userinfo)
+	}
+
+	hc := struct {
+		Authorization string
+		Server        string
+		Capabilities  string
+		MirrorTargets []url.URL
+	}{
+		Server:        server,
+		Capabilities:  fmt.Sprintf("['%s']", strings.Join(capabilities, "', '")),
+		MirrorTargets: parsedMirrorTargets,
+		Authorization: authorization,
+	}
+	tmpl, err := template.New("").Parse(`{{- with .Server }}server = '{{ . }}'{{ end }}
+{{- $authorization := .Authorization }}
+{{ range .MirrorTargets }}
+[host.'{{ .String }}']
+capabilities = {{ $.Capabilities }}
+dial_timeout = '200ms'
+{{- if $authorization }}
+[host.'{{ .String }}'.header]
+Authorization = '{{ $authorization }}'
+{{- end }}
+{{ end }}`)
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = tmpl.Execute(buf, hc)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func existingHosts(configPath string, parsedMirrorRegistry url.URL) (string, error) {
+	fp := path.Join(configPath, backupDir, parsedMirrorRegistry.Host, "hosts.toml")
+	b, err := os.ReadFile(fp)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	type hostFile struct {
+		Hosts map[string]any `toml:"host"`
+	}
+
+	var hf hostFile
+	err = toml.Unmarshal(b, &hf)
+	if err != nil {
+		return "", err
+	}
+	if len(hf.Hosts) == 0 {
+		return "", nil
+	}
+
+	hosts := []string{}
+	parser := tomlu.Parser{}
+	parser.Reset(b)
+	for parser.NextExpression() {
+		err := parser.Error()
+		if err != nil {
+			return "", err
+		}
+		e := parser.Expression()
+		if e.Kind != tomlu.Table {
+			continue
+		}
+		ki := e.Key()
+		if ki.Next() && string(ki.Node().Data) == "host" && ki.Next() && ki.IsLast() {
+			hosts = append(hosts, string(ki.Node().Data))
+		}
+	}
+
+	ehs := []string{}
+	for _, h := range hosts {
+		data := hostFile{
+			Hosts: map[string]any{
+				h: hf.Hosts[h],
+			},
+		}
+		b, err := toml.Marshal(data)
+		if err != nil {
+			return "", err
+		}
+		eh := strings.TrimPrefix(string(b), "[host]\n")
+		ehs = append(ehs, eh)
+	}
+	return strings.TrimSpace(strings.Join(ehs, "\n")), nil
+}
+
+func dirExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.IsDir(), nil
+}

--- a/pkg/oci/containerd/mirror_test.go
+++ b/pkg/oci/containerd/mirror_test.go
@@ -1,4 +1,4 @@
-package oci
+package containerd
 
 import (
 	iofs "io/fs"
@@ -10,7 +10,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-openapi/testify/v2/require"
-	"github.com/opencontainers/go-digest"
+
+	"github.com/spegel-org/spegel/pkg/oci"
 )
 
 func TestBackupConfig(t *testing.T) {
@@ -39,62 +40,6 @@ func TestBackupConfig(t *testing.T) {
 	files, err = os.ReadDir(filepath.Join(configPath, "_backup"))
 	require.NoError(t, err)
 	require.Len(t, files, 1)
-}
-
-func TestContentLabelsToReferences(t *testing.T) {
-	t.Parallel()
-
-	dgst := digest.Digest("foo")
-	tests := []struct {
-		name     string
-		labels   map[string]string
-		expected []Reference
-	}{
-		{
-			name: "one matching",
-			labels: map[string]string{
-				"containerd.io/distribution.source.docker.io": "library/alpine",
-			},
-			expected: []Reference{
-				{
-					Registry:   "docker.io",
-					Repository: "library/alpine",
-					Digest:     dgst,
-				},
-			},
-		},
-		{
-			name: "multiple matching",
-			labels: map[string]string{
-				"containerd.io/distribution.source.example.com": "foo",
-				"containerd.io/distribution.source.ghcr.io":     "spegel-org/spegel",
-			},
-			expected: []Reference{
-				{
-					Registry:   "ghcr.io",
-					Repository: "spegel-org/spegel",
-					Digest:     dgst,
-				},
-				{
-					Registry:   "example.com",
-					Repository: "foo",
-					Digest:     dgst,
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(t.Name(), func(t *testing.T) {
-			t.Parallel()
-
-			refs, err := contentLabelsToReferences(tt.labels, dgst)
-			require.NoError(t, err)
-			require.ElementsMatchT(t, tt.expected, refs)
-		})
-	}
-
-	_, err := contentLabelsToReferences(map[string]string{}, dgst)
-	require.EqualError(t, err, "no distribution source labels found for foo")
 }
 
 func TestMirrorConfiguration(t *testing.T) {
@@ -148,7 +93,7 @@ dial_timeout = '200ms'`,
 		{
 			name:               "default is explicitly set",
 			resolveTags:        true,
-			mirroredRegistries: []string{wildcardRegistries[0]},
+			mirroredRegistries: []string{oci.WildcardRegistries[0]},
 			mirrorTargets:      []string{"http://127.0.0.1:5000"},
 			prependExisting:    false,
 			expectedFiles: map[string]string{
@@ -449,7 +394,6 @@ Authorization = 'Basic aGVsbG86d29ybGQ='`,
 		})
 	}
 }
-
 func TestExistingHosts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/oci/filter.go
+++ b/pkg/oci/filter.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	wildcardRegistries  = []string{"_default", "*"}
-	wildcardRegistryURL = url.URL{Host: wildcardRegistries[0]}
+	WildcardRegistries  = []string{"_default", "*"}
+	WildcardRegistryURL = url.URL{Host: WildcardRegistries[0]}
 )
 
 type Filter interface {
@@ -59,14 +59,14 @@ func FilterForMirroredRegistries(mirroredRegistries []string) (*RegistryWhitelis
 	if len(mirroredRegistries) == 0 {
 		return nil, nil
 	}
-	rus, err := parseRegistries(mirroredRegistries, true)
+	rus, err := ParseRegistries(mirroredRegistries, true)
 	if err != nil {
 		return nil, err
 	}
 	registryHosts := []string{}
 	for _, ru := range rus {
 		// No registry filter when wildcard is part of mirrored registries.
-		if ru == wildcardRegistryURL {
+		if ru == WildcardRegistryURL {
 			return nil, nil
 		}
 		registryHosts = append(registryHosts, ru.Host)
@@ -74,14 +74,14 @@ func FilterForMirroredRegistries(mirroredRegistries []string) (*RegistryWhitelis
 	return &RegistryWhitelistFilter{Whitelist: registryHosts}, nil
 }
 
-func parseRegistries(registries []string, allowWildcard bool) ([]url.URL, error) {
+func ParseRegistries(registries []string, allowWildcard bool) ([]url.URL, error) {
 	if len(registries) == 0 && allowWildcard {
-		return []url.URL{wildcardRegistryURL}, nil
+		return []url.URL{WildcardRegistryURL}, nil
 	}
 	rus := []url.URL{}
 	hasWildcard := false
 	for _, s := range registries {
-		if slices.Contains(wildcardRegistries, s) {
+		if slices.Contains(WildcardRegistries, s) {
 			if !allowWildcard {
 				return nil, errors.New("wildcard registries are not allowed")
 			}
@@ -89,7 +89,7 @@ func parseRegistries(registries []string, allowWildcard bool) ([]url.URL, error)
 				return nil, errors.New("registries should not contain two wildcards")
 			}
 			hasWildcard = true
-			rus = append(rus, wildcardRegistryURL)
+			rus = append(rus, WildcardRegistryURL)
 			continue
 		}
 		u, err := url.Parse(s)

--- a/pkg/oci/filter_test.go
+++ b/pkg/oci/filter_test.go
@@ -116,7 +116,7 @@ func TestParseRegistries(t *testing.T) {
 	t.Parallel()
 
 	registries := []string{"https://docker.io", "_default", "http://localhost:9090"}
-	rus, err := parseRegistries(registries, true)
+	rus, err := ParseRegistries(registries, true)
 	require.NoError(t, err)
 	strs := []string{}
 	for _, ru := range rus {
@@ -149,7 +149,7 @@ func TestParseRegistries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := parseRegistries(tt.registries, tt.allowWildcard)
+			_, err := ParseRegistries(tt.registries, tt.allowWildcard)
 			require.EqualError(t, err, tt.expected)
 		})
 	}

--- a/test/integration/containerd/containerd_test.go
+++ b/test/integration/containerd/containerd_test.go
@@ -21,6 +21,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/oci/containerd"
 )
 
 var (
@@ -116,7 +117,7 @@ func TestContainerdPull(t *testing.T) {
 			require.NoError(t, err)
 			imageClient := runtimeapi.NewImageServiceClient(connClient)
 
-			containerdStore, err := oci.NewContainerd(t.Context(), socketPath, "k8s.io")
+			containerdStore, err := containerd.NewContainerd(t.Context(), socketPath, "k8s.io")
 			require.NoError(t, err)
 			name := containerdStore.Name()
 			require.EqualT(t, "containerd", name)


### PR DESCRIPTION
With the possible introduction of CRI-O support we need to move Containerd into its own package. This way the logic is kept separate and stops anyone importing the OCI package from having to import both CRI-O and Containerd dependencies.

Related to #1119