### PR TITLE
Add optional NetworkPolicy for the libp2p router to Helm chart

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -32,6 +32,8 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | livenessProbe.enabled | bool | `false` | When enabled a liveness probe will be added to the registry. |
 | nameOverride | string | `""` | Overrides the name of the chart. |
 | namespaceOverride | string | `""` | Overrides the namespace where spegel resources are installed. |
+| networkPolicy.additionalRouterPeers | list | `[]` | Extra peers allowed to reach the libp2p router port, appended to the in-namespace Spegel selector. |
+| networkPolicy.enabled | bool | `false` | If true creates a NetworkPolicy that limits libp2p router traffic to Spegel peers in the release namespace. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for pod assignment. |
 | podAnnotations | object | `{}` | Annotations to add to the pod. |
 | podSecurityContext | object | `{}` | Security context for the pod. |

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -32,7 +32,6 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | livenessProbe.enabled | bool | `false` | When enabled a liveness probe will be added to the registry. |
 | nameOverride | string | `""` | Overrides the name of the chart. |
 | namespaceOverride | string | `""` | Overrides the namespace where spegel resources are installed. |
-| networkPolicy.additionalRouterPeers | list | `[]` | Extra peers allowed to reach the libp2p router port, appended to the in-namespace Spegel selector. |
 | networkPolicy.enabled | bool | `false` | If true creates a NetworkPolicy that limits libp2p router traffic to Spegel peers in the release namespace. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for pod assignment. |
 | podAnnotations | object | `{}` | Annotations to add to the pod. |

--- a/charts/spegel/templates/networkpolicy.yaml
+++ b/charts/spegel/templates/networkpolicy.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
+  labels:
+    {{- include "spegel.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "spegel.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # The libp2p router runs the DHT and peer mesh. Only other Spegel peers in
+    # this namespace need to reach it, so keep it closed to everything else.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "spegel.selectorLabels" . | nindent 14 }}
+        {{- with .Values.networkPolicy.additionalRouterPeers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.service.router.port }}
+          protocol: TCP
+        - port: {{ .Values.service.router.port }}
+          protocol: UDP
+    # The registry and metrics ports stay open so image pulls and scraping keep
+    # working as before.
+    - ports:
+        - port: {{ .Values.service.registry.port }}
+          protocol: TCP
+        - port: {{ .Values.service.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/charts/spegel/templates/networkpolicy.yaml
+++ b/charts/spegel/templates/networkpolicy.yaml
@@ -13,22 +13,15 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # The libp2p router runs the DHT and peer mesh. Only other Spegel peers in
-    # this namespace need to reach it, so keep it closed to everything else.
     - from:
         - podSelector:
             matchLabels:
               {{- include "spegel.selectorLabels" . | nindent 14 }}
-        {{- with .Values.networkPolicy.additionalRouterPeers }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
       ports:
         - port: {{ .Values.service.router.port }}
           protocol: TCP
         - port: {{ .Values.service.router.port }}
           protocol: UDP
-    # The registry and metrics ports stay open so image pulls and scraping keep
-    # working as before.
     - ports:
         - port: {{ .Values.service.registry.port }}
           protocol: TCP

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -143,6 +143,12 @@ grafanaDashboard:
     matchLabels: {}
       # dashboards: grafana
 
+networkPolicy:
+  # -- If true creates a NetworkPolicy that limits libp2p router traffic to Spegel peers in the release namespace.
+  enabled: false
+  # -- Extra peers allowed to reach the libp2p router port, appended to the in-namespace Spegel selector.
+  additionalRouterPeers: []
+
 # -- Priority class name to use for the pod.
 priorityClassName: system-node-critical
 

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -146,8 +146,6 @@ grafanaDashboard:
 networkPolicy:
   # -- If true creates a NetworkPolicy that limits libp2p router traffic to Spegel peers in the release namespace.
   enabled: false
-  # -- Extra peers allowed to reach the libp2p router port, appended to the in-namespace Spegel selector.
-  additionalRouterPeers: []
 
 # -- Priority class name to use for the pod.
 priorityClassName: system-node-critical


### PR DESCRIPTION
This adds an optional NetworkPolicy to the chart that keeps inbound libp2p router traffic to Spegel peers within the release namespace.

The router (`--router-addr`, port 5001) runs the DHT and the peer mesh. Right now anything that can reach that port can join the mesh, which is more reach than it really needs, since the only things that legitimately talk to it are the other Spegel pods in the same namespace. This follows on from #562 where shipping a network policy example came up.

It is off by default (`networkPolicy.enabled: false`), so existing installs are untouched, and because policy behaviour still differs between CNIs. When enabled it leaves the registry and metrics ports open so image pulls and scraping keep working as before, and only constrains the router port. There is an `additionalRouterPeers` value for anyone who needs to let extra peers reach the router:

```yaml
networkPolicy:
  enabled: true
  additionalRouterPeers:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: monitoring
```

Ran `helm lint` and `helm template` with the policy on and off. Kubelet probes and other host-to-pod traffic follow the usual per-CNI behaviour.
