### PR TITLE
Switch to using new errors as type

### DIFF
--- a/internal/resilient/retry.go
+++ b/internal/resilient/retry.go
@@ -100,8 +100,7 @@ func RetryValue[T any](ctx context.Context, attempts int, delay DelayFunc, fn fu
 		if err == nil {
 			return result, nil
 		}
-		var unrecoverableErr *unrecoverableError
-		if errors.As(err, &unrecoverableErr) {
+		if unrecoverableErr, ok := errors.AsType[*unrecoverableError](err); ok {
 			errs = append(errs, unrecoverableErr.error)
 			break
 		}

--- a/pkg/httpx/response.go
+++ b/pkg/httpx/response.go
@@ -63,8 +63,8 @@ func (r *response) WriteError(statusCode int, err error) {
 	r.error = err
 
 	b, ct, rbErr := func() ([]byte, string, error) {
-		var respErr ResponseError
-		if !errors.As(err, &respErr) {
+		respErr, ok := errors.AsType[ResponseError](err)
+		if !ok {
 			return nil, "", nil
 		}
 		b, ct, err := respErr.ResponseBody()

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -61,8 +61,8 @@ type Store interface {
 func FingerprintMediaType(r io.Reader) (string, error) {
 	dec := json.NewDecoder(r)
 	tok, err := dec.Token()
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
+	//nolint:errcheck // We are only interested in the error type not the error content.
+	if _, ok := errors.AsType[*json.SyntaxError](err); ok {
 		return httpx.ContentTypeBinary, nil
 	}
 	if err != nil {

--- a/pkg/routing/p2p.go
+++ b/pkg/routing/p2p.go
@@ -607,13 +607,13 @@ func bootstrapPeers(ctx context.Context, bs Bootstrapper, kdht *dht.IpfsDHT, pro
 			}
 			addrInfo.ID = id
 			err = kdht.Host().Connect(bootstrapCtx, addrInfo)
-			var mismatchErr sec.ErrPeerIDMismatch
-			if !errors.As(err, &mismatchErr) {
+			mismatchErr, ok := errors.AsType[sec.ErrPeerIDMismatch](err)
+			kdht.Host().Peerstore().ClearAddrs(addrInfo.ID)
+			kdht.Host().Peerstore().RemovePeer(addrInfo.ID)
+			if !ok {
 				errs = append(errs, err)
 				continue
 			}
-			kdht.Host().Peerstore().ClearAddrs(addrInfo.ID)
-			kdht.Host().Peerstore().RemovePeer(addrInfo.ID)
 			addrInfo.ID = mismatchErr.Actual
 		}
 


### PR DESCRIPTION
This change updates error casting to use generics which is faster and type safe.