### PR TITLE
Move oci filter into Containerd

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,6 +182,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		return err
 	}
 
+	// OCI Filters.
 	filters := []oci.Filter{}
 	regFilter, err := oci.FilterForMirroredRegistries(args.MirroredRegistries)
 	if err != nil {
@@ -194,14 +195,14 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		filters = append(filters, oci.RegexFilter{Regex: r})
 	}
 
-	// OCI Store
-	ociStore, err := containerd.NewContainerd(ctx, args.ContainerdSock, args.ContainerdNamespace, containerd.WithContentPath(args.ContainerdContentPath))
+	// Containerd store.
+	ctrd, err := containerd.NewContainerd(ctx, args.ContainerdSock, args.ContainerdNamespace, containerd.WithContentPath(args.ContainerdContentPath), containerd.WithFilters(filters))
 	if err != nil {
 		return err
 	}
-	defer ociStore.Close()
+	defer ctrd.Close()
 
-	// Router
+	// Routing and state tracking.
 	_, registryPort, err := net.SplitHostPort(args.RegistryAddr)
 	if err != nil {
 		return err
@@ -224,17 +225,15 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		}
 		return nil
 	})
-
-	// State tracking
 	group.Go(func(ctx context.Context) error {
-		err := state.Track(ctx, ociStore, router, state.WithRegistryFilters(filters))
+		err := state.Track(ctx, ctrd, router)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return err
 		}
 		return nil
 	})
 
-	// Registry
+	// OCI registry.
 	userinfo, err := httpx.LoadUserinfo("/etc/secrets/basic-auth")
 	if err != nil {
 		return err
@@ -246,7 +245,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 		registry.WithUserinfo(userinfo),
 		registry.WithOCIClient(ociClient),
 	}
-	reg, err := registry.NewRegistry(ociStore, router, registryOpts...)
+	reg, err := registry.NewRegistry(ctrd, router, registryOpts...)
 	if err != nil {
 		return err
 	}
@@ -284,13 +283,12 @@ func registryCommand(ctx context.Context, args *RegistryCmd) error {
 	if args.DebugWebEnabled {
 		webOpts := []web.WebOption{
 			web.WithOCIClient(ociClient),
-			web.WithRegistryFilters(filters),
 		}
 		mirror := &url.URL{
 			Scheme: "http",
 			Host:   args.RegistryAddr,
 		}
-		web, err := web.NewWeb(router, ociStore, reg, mirror, webOpts...)
+		web, err := web.NewWeb(router, ctrd, reg, mirror, webOpts...)
 		if err != nil {
 			return err
 		}

--- a/pkg/oci/containerd/containerd.go
+++ b/pkg/oci/containerd/containerd.go
@@ -42,20 +42,28 @@ var _ oci.ImageLister = &Containerd{}
 type ContainerdConfig struct {
 	Conn        net.Conn
 	ContentPath string
+	Filters     []oci.Filter
 }
 
 type ContainerdOption = option.Option[ContainerdConfig]
 
 func WithContentPath(path string) ContainerdOption {
-	return func(c *ContainerdConfig) error {
-		c.ContentPath = path
+	return func(cfg *ContainerdConfig) error {
+		cfg.ContentPath = path
 		return nil
 	}
 }
 
 func WithConnection(conn net.Conn) ContainerdOption {
-	return func(c *ContainerdConfig) error {
-		c.Conn = conn
+	return func(cfg *ContainerdConfig) error {
+		cfg.Conn = conn
+		return nil
+	}
+}
+
+func WithFilters(filters []oci.Filter) ContainerdOption {
+	return func(cfg *ContainerdConfig) error {
+		cfg.Filters = filters
 		return nil
 	}
 }
@@ -64,6 +72,7 @@ type Containerd struct {
 	client       *client.Client
 	mediaTypeIdx *lru.Cache[digest.Digest, string]
 	contentPath  string
+	filters      []oci.Filter
 }
 
 func NewContainerd(ctx context.Context, socketPath, namespace string, opts ...ContainerdOption) (*Containerd, error) {
@@ -134,6 +143,9 @@ func (c *Containerd) ListImages(ctx context.Context) ([]oci.Image, error) {
 		}
 		if img.Tag != "" {
 			tagDgsts[img.Digest] = img.Tag
+		}
+		if oci.MatchesFilter(img.Reference, c.filters) {
+			continue
 		}
 		imgs = append(imgs, img)
 	}
@@ -248,6 +260,10 @@ func (c *Containerd) Subscribe(ctx context.Context) (map[oci.Image][]digest.Dige
 			log.Error(err, "skipping image that cannot be parsed", "image", img.String())
 			continue
 		}
+		if oci.MatchesFilter(img.Reference, c.filters) {
+			continue
+		}
+
 		refs := []oci.Reference{}
 		handler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			children, err := images.ChildrenHandler(c.client.ContentStore()).Handle(ctx, desc)
@@ -365,6 +381,9 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 		if err != nil {
 			return nil, err
 		}
+		if oci.MatchesFilter(img.Reference, c.filters) {
+			return nil, nil
+		}
 		// Just advertise the image if it is a tag reference.
 		if img.Digest == "" {
 			return []oci.OCIEvent{{Type: oci.CreateEvent, Reference: img.Reference}}, nil
@@ -401,6 +420,9 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 		img, err := oci.ParseImage(e.GetName(), oci.AllowTagOnly())
 		if err != nil {
 			return nil, err
+		}
+		if oci.MatchesFilter(img.Reference, c.filters) {
+			return nil, nil
 		}
 		// Just advertise the image if it is a tag reference.
 		if img.Digest == "" {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -7,32 +7,12 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/pkg/metrics"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/routing"
 )
 
-type TrackerConfig struct {
-	Filters []oci.Filter
-}
-
-type TrackerOption = option.Option[TrackerConfig]
-
-func WithRegistryFilters(filters []oci.Filter) TrackerOption {
-	return func(cfg *TrackerConfig) error {
-		cfg.Filters = filters
-		return nil
-	}
-}
-
-func Track(ctx context.Context, ociStore oci.Store, router routing.Router, opts ...TrackerOption) error {
-	cfg := TrackerConfig{}
-	err := option.Apply(&cfg, opts...)
-	if err != nil {
-		return err
-	}
-
+func Track(ctx context.Context, ociStore oci.Store, router routing.Router) error {
 	initial, eventCh, err := ociStore.Subscribe(ctx)
 	if err != nil {
 		return err
@@ -41,13 +21,13 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, opts 
 	// Initial advertisement of all content.
 	keys := []string{}
 	for img, dgsts := range initial {
-		if !oci.MatchesFilter(img.Reference, cfg.Filters) {
-			tagName, ok := img.TagName()
-			if ok {
-				metrics.AdvertisedImageTags.WithLabelValues(img.Registry).Inc()
-				keys = append(keys, tagName)
-			}
+		// if !oci.MatchesFilter(img.Reference, cfg.Filters) {
+		tagName, ok := img.TagName()
+		if ok {
+			metrics.AdvertisedImageTags.WithLabelValues(img.Registry).Inc()
+			keys = append(keys, tagName)
 		}
+		// }
 		metrics.AdvertisedImageDigests.WithLabelValues(img.Registry).Inc()
 		for _, dgst := range dgsts {
 			metrics.AdvertisedContentDigests.WithLabelValues(img.Registry).Inc()
@@ -69,7 +49,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, opts 
 			if !ok {
 				return errors.New("event channel closed")
 			}
-			err := handleEvent(ctx, router, event, cfg.Filters)
+			err := handleEvent(ctx, router, event)
 			if err != nil {
 				logr.FromContextOrDiscard(ctx).Error(err, "could not handle event")
 				continue
@@ -78,10 +58,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, opts 
 	}
 }
 
-func handleEvent(ctx context.Context, router routing.Router, event oci.OCIEvent, filters []oci.Filter) error {
-	if oci.MatchesFilter(event.Reference, filters) {
-		return nil
-	}
+func handleEvent(ctx context.Context, router routing.Router, event oci.OCIEvent) error {
 	logr.FromContextOrDiscard(ctx).Info("OCI event", "ref", event.Reference.String(), "type", event.Type)
 	switch event.Type {
 	case oci.CreateEvent:

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"math/rand/v2"
 	"net/netip"
-	"regexp"
 	"slices"
 	"strconv"
 	"testing"
@@ -62,80 +61,49 @@ func TestTrack(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	tests := []struct {
-		name            string
-		registryFilters []oci.Filter
-		expectedImages  []string
-	}{
-		{
-			name:            "no filters",
-			registryFilters: []oci.Filter{},
-			expectedImages:  []string{"docker.io/library/ubuntu:latest", "ghcr.io/spegel-org/spegel:v0.0.9", "quay.io/namespace/repo:latest", "localhost:5000/test:latest"},
-		},
-		{
-			name:            "filter docker.io only",
-			registryFilters: []oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`^docker\.io/`)}},
-			expectedImages:  []string{"ghcr.io/spegel-org/spegel:v0.0.9", "quay.io/namespace/repo:latest", "localhost:5000/test:latest"},
-		},
-		{
-			name:            "filter multiple registries",
-			registryFilters: []oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`^docker\.io/`)}, oci.RegexFilter{Regex: regexp.MustCompile(`^ghcr\.io/`)}},
-			expectedImages:  []string{"quay.io/namespace/repo:latest", "localhost:5000/test:latest"},
-		},
-		{
-			name:            "filter latest tags",
-			registryFilters: []oci.Filter{oci.RegexFilter{Regex: regexp.MustCompile(`:latest$`)}},
-			expectedImages:  []string{"ghcr.io/spegel-org/spegel:v0.0.9"},
+	log := tlog.NewTestLogger(t)
+	ctx := logr.NewContext(t.Context(), log)
+	ctx, cancel := context.WithCancel(ctx)
+
+	self := routing.Peer{
+		Host:      "test",
+		Addresses: []netip.Addr{netip.MustParseAddr("127.0.0.1")},
+		Metadata: routing.PeerMetadata{
+			RegistryPort: 5000,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	router := routing.NewMemoryRouter(map[string][]routing.Peer{}, self)
+	group := errgroup.WithContext(ctx)
+	group.Go(func(ctx context.Context) error {
+		return Track(ctx, ociStore, router)
+	})
+	time.Sleep(100 * time.Millisecond)
 
-			log := tlog.NewTestLogger(t)
-			ctx := logr.NewContext(t.Context(), log)
-			ctx, cancel := context.WithCancel(ctx)
-
-			self := routing.Peer{
-				Host:      "test",
-				Addresses: []netip.Addr{netip.MustParseAddr("127.0.0.1")},
-				Metadata: routing.PeerMetadata{
-					RegistryPort: 5000,
-				},
-			}
-			router := routing.NewMemoryRouter(map[string][]routing.Peer{}, self)
-			group := errgroup.WithContext(ctx)
-			group.Go(func(ctx context.Context) error {
-				return Track(ctx, ociStore, router, WithRegistryFilters(tt.registryFilters))
-			})
-			time.Sleep(100 * time.Millisecond)
-
-			// Check that all images are advertised by digest (this should always happen)
-			for _, img := range imgs {
-				peers, ok := router.Get(img.Digest.String())
-				require.TrueT(t, ok, "Image digest %s should be advertised", img.Digest.String())
-				require.Len(t, peers, 1)
-			}
-
-			// Check that images have been filtered
-			for _, img := range imgs {
-				tagName, ok := img.TagName()
-				if !ok {
-					continue
-				}
-				peers, ok := router.Get(tagName)
-				shouldBeAdvertised := slices.Contains(tt.expectedImages, tagName)
-				if shouldBeAdvertised {
-					require.TrueT(t, ok, "Image %s should be advertised", tagName)
-					require.Len(t, peers, 1)
-				} else {
-					require.FalseT(t, ok, "Image %s should NOT be advertised", tagName)
-				}
-			}
-
-			cancel()
-			err := group.Wait()
-			require.ErrorIs(t, err, context.Canceled)
-		})
+	// Check that all images are advertised by digest (this should always happen)
+	for _, img := range imgs {
+		peers, ok := router.Get(img.Digest.String())
+		require.TrueT(t, ok, "Image digest %s should be advertised", img.Digest.String())
+		require.Len(t, peers, 1)
 	}
+
+	// Check that images have been filtered
+	for _, img := range imgs {
+		tagName, ok := img.TagName()
+		if !ok {
+			continue
+		}
+		peers, ok := router.Get(tagName)
+		expectedImages := []string{"docker.io/library/ubuntu:latest", "ghcr.io/spegel-org/spegel:v0.0.9", "quay.io/namespace/repo:latest", "localhost:5000/test:latest"}
+		shouldBeAdvertised := slices.Contains(expectedImages, tagName)
+		if shouldBeAdvertised {
+			require.TrueT(t, ok, "Image %s should be advertised", tagName)
+			require.Len(t, peers, 1)
+		} else {
+			require.FalseT(t, ok, "Image %s should NOT be advertised", tagName)
+		}
+	}
+
+	cancel()
+	err := group.Wait()
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -25,7 +25,6 @@ var templatesFS embed.FS
 
 type WebConfig struct {
 	OCIClient *oci.Client
-	Filters   []oci.Filter
 }
 
 type WebOption = option.Option[WebConfig]
@@ -37,13 +36,6 @@ func WithOCIClient(ociClient *oci.Client) WebOption {
 	}
 }
 
-func WithRegistryFilters(filters []oci.Filter) WebOption {
-	return func(cfg *WebConfig) error {
-		cfg.Filters = filters
-		return nil
-	}
-}
-
 type Web struct {
 	mirror    *url.URL
 	router    *routing.P2PRouter
@@ -51,7 +43,6 @@ type Web struct {
 	imgLister oci.ImageLister
 	tmpls     *template.Template
 	reg       *registry.Registry
-	filters   []oci.Filter
 }
 
 func NewWeb(router *routing.P2PRouter, imgLister oci.ImageLister, reg *registry.Registry, mirror *url.URL, opts ...WebOption) (*Web, error) {
@@ -81,7 +72,6 @@ func NewWeb(router *routing.P2PRouter, imgLister oci.ImageLister, reg *registry.
 		router:    router,
 		ociClient: cfg.OCIClient,
 		imgLister: imgLister,
-		filters:   cfg.Filters,
 		tmpls:     tmpls,
 		reg:       reg,
 		mirror:    mirror,
@@ -138,17 +128,12 @@ type statsData struct {
 func (w *Web) statsHandler(rw httpx.ResponseWriter, req *http.Request) {
 	data := statsData{}
 
-	images, err := w.imgLister.ListImages(req.Context())
+	imgs, err := w.imgLister.ListImages(req.Context())
 	if err != nil {
 		rw.WriteError(http.StatusInternalServerError, err)
 		return
 	}
-	for _, img := range images {
-		if oci.MatchesFilter(img.Reference, w.filters) {
-			continue
-		}
-		data.Images = append(data.Images, img)
-	}
+	data.Images = imgs
 
 	stats := w.reg.Stats()
 	mirrorLastSuccess := stats.MirrorLastSuccess.Load()


### PR DESCRIPTION
With refactoring that is being done we need to move oci specific filters into Containerd rather than where it is called. The filter is per instance and should be applied to all functions.