### PR TITLE
Refactor event handling to not miss advertised content

### DIFF
--- a/pkg/oci/containerd/containerd.go
+++ b/pkg/oci/containerd/containerd.go
@@ -9,14 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
-	"time"
 
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/events"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
@@ -27,7 +24,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/spegel-org/spegel/internal/option"
-	"github.com/spegel-org/spegel/internal/resilient"
 	"github.com/spegel-org/spegel/pkg/httpx"
 	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/store"
@@ -244,11 +240,16 @@ func (c *Containerd) Watch(ctx context.Context) ([]store.Event, <-chan store.Eve
 
 	eventCh := make(chan store.Event)
 	subCtx, subCancel := context.WithCancel(ctx)
-	eventFilters := []string{`topic~="/images/create|/images/delete",event.name~="^.+/"`, `topic~="/content/create"`}
+	eventFilters := []string{
+		fmt.Sprintf(`namespace==%q,topic~="/images/create|/images/update",event.name~="^.+/"`, c.client.DefaultNamespace()),
+		fmt.Sprintf(`namespace==%q,topic~="/images/delete"`, c.client.DefaultNamespace()),
+		fmt.Sprintf(`namespace==%q,topic~="/content/create"`, c.client.DefaultNamespace()),
+		fmt.Sprintf(`namespace==%q,topic~="/snapshot/remove"`, c.client.DefaultNamespace()),
+	}
 	envelopeCh, cErrCh := c.client.EventService().Subscribe(subCtx, eventFilters...)
 
 	// Populate the content index.
-	contentIdx := map[digest.Digest][]oci.Reference{}
+	idx := NewIndex()
 	initial := []store.Event{}
 
 	imgs, err := c.ListImages(ctx)
@@ -257,19 +258,15 @@ func (c *Containerd) Watch(ctx context.Context) ([]store.Event, <-chan store.Eve
 		return nil, nil, err
 	}
 	for _, img := range imgs {
-		refs, err := walkImage(ctx, c.client, img)
-		if err != nil {
-			subCancel()
-			return nil, nil, err
-		}
-		contentIdx[img.Digest] = refs
-		for i, ref := range refs {
-			event := store.Event{Type: store.CreateEvent, Digest: ref.Digest}
-			if tagName, ok := img.TagName(); ok && i == 0 {
-				event.Reference = tagName
-			}
-			initial = append(initial, event)
-		}
+		initial = append(initial, idx.AddImage(img)...)
+	}
+	err = c.client.ContentStore().Walk(ctx, func(info content.Info) error {
+		initial = append(initial, idx.AddContent(info.Digest)...)
+		return nil
+	})
+	if err != nil {
+		subCancel()
+		return nil, nil, err
 	}
 
 	go func() {
@@ -279,7 +276,7 @@ func (c *Containerd) Watch(ctx context.Context) ([]store.Event, <-chan store.Eve
 			case <-subCtx.Done():
 				return
 			case envelope := <-envelopeCh:
-				events, err := c.handleEvent(subCtx, *envelope, contentIdx)
+				events, err := c.handleEvent(subCtx, *envelope, idx)
 				if err != nil {
 					log.Error(err, "error when handling containerd event")
 					continue
@@ -305,7 +302,7 @@ func (c *Containerd) Watch(ctx context.Context) ([]store.Event, <-chan store.Eve
 	return initial, eventCh, nil
 }
 
-func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, contentIdx map[digest.Digest][]oci.Reference) ([]store.Event, error) {
+func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, idx *Index) ([]store.Event, error) {
 	if envelope.Event == nil {
 		return nil, errors.New("envelope event cannot be nil")
 	}
@@ -316,145 +313,69 @@ func (c *Containerd) handleEvent(ctx context.Context, envelope events.Envelope, 
 
 	switch e := evt.(type) {
 	case *eventtypes.ContentCreate:
-		dgst := digest.Digest(e.GetDigest())
-		refs, err := resilient.RetryValue(ctx, 10, resilient.BackoffDelay(10*time.Millisecond, 100*time.Millisecond), func(ctx context.Context) ([]oci.Reference, error) {
-			info, err := c.client.ContentStore().Info(ctx, dgst)
-			if err != nil {
-				return nil, resilient.Unrecoverable(err)
-			}
-			refs, err := contentLabelsToReferences(info.Labels, dgst)
+		dgst, err := digest.Parse(e.GetDigest())
+		if err != nil {
+			return nil, err
+		}
+		return idx.AddContent(dgst), nil
+	case *eventtypes.ImageCreate:
+		cImg, err := c.client.ImageService().Get(ctx, e.GetName())
+		if err != nil {
+			return nil, err
+		}
+		if cImg.UpdatedAt.After(envelope.Timestamp) {
+			logr.FromContextOrDiscard(ctx).Info("skipping image that was updated after create event")
+			return nil, nil
+		}
+		img, err := oci.ParseImage(e.GetName(), oci.WithDigest(cImg.Target.Digest))
+		if err != nil {
+			return nil, err
+		}
+		return idx.AddImage(img), nil
+	case *eventtypes.ImageUpdate:
+		cImg, err := c.client.ImageService().Get(ctx, e.GetName())
+		if err != nil {
+			return nil, err
+		}
+		if cImg.UpdatedAt.After(envelope.Timestamp) {
+			logr.FromContextOrDiscard(ctx).Info("skipping image that was updated after update event")
+			return nil, nil
+		}
+		img, err := oci.ParseImage(e.GetName(), oci.WithDigest(cImg.Target.Digest))
+		if err != nil {
+			return nil, err
+		}
+		return idx.AddImage(img), nil
+	case *eventtypes.ImageDelete:
+		if _, err := digest.Parse(e.GetName()); err == nil {
+			dgsts := []digest.Digest{}
+			err = c.client.ContentStore().Walk(ctx, func(info content.Info) error {
+				dgsts = append(dgsts, info.Digest)
+				return nil
+			})
 			if err != nil {
 				return nil, err
 			}
-			return refs, nil
+			return idx.DiffContent(dgsts), nil
+		}
+		img, err := oci.ParseImage(e.GetName(), oci.AllowTagOnly())
+		if err != nil {
+			return nil, err
+		}
+		return idx.RemoveImage(img), nil
+	case *eventtypes.SnapshotRemove:
+		dgsts := []digest.Digest{}
+		err = c.client.ContentStore().Walk(ctx, func(info content.Info) error {
+			dgsts = append(dgsts, info.Digest)
+			return nil
 		})
 		if err != nil {
 			return nil, err
 		}
-		events := []store.Event{}
-		for _, ref := range refs {
-			events = append(events, store.Event{Type: store.CreateEvent, Digest: ref.Digest})
-		}
-		return events, nil
-	case *eventtypes.ImageCreate:
-		img, err := oci.ParseImage(e.GetName(), oci.AllowTagOnly())
-		if err != nil {
-			return nil, err
-		}
-		if oci.MatchesFilter(img.Reference, c.filters) {
-			return nil, nil
-		}
-		// Just advertise the image if it is a tag reference.
-		if tagName, ok := img.TagName(); ok {
-			return []store.Event{{Type: store.CreateEvent, Reference: tagName}}, nil
-		}
-		// Walk the image to index its content.
-		refs, err := walkImage(ctx, c.client, img)
-		if err != nil {
-			return nil, err
-		}
-		contentIdx[img.Digest] = refs
-		return nil, nil
-	case *eventtypes.ImageDelete:
-		img, err := oci.ParseImage(e.GetName(), oci.AllowTagOnly())
-		if err != nil {
-			return nil, err
-		}
-		if oci.MatchesFilter(img.Reference, c.filters) {
-			return nil, nil
-		}
-		// Just advertise the image if it is a tag reference.
-		if tagName, ok := img.TagName(); ok {
-			return []store.Event{{Type: store.DeleteEvent, Reference: tagName}}, nil
-		}
-		// Advertise deletion of images content if it no longer exists.
-		refs, ok := contentIdx[img.Digest]
-		if !ok {
-			logr.FromContextOrDiscard(ctx).Info("delete event with missing content index entry")
-			return []store.Event{{Type: store.DeleteEvent, Digest: img.Digest}}, nil
-		}
-		delete(contentIdx, img.Digest)
-		// Delete events are sent before garbage collection is run.
-		err = resilient.Retry(ctx, 10, resilient.BackoffDelay(10*time.Millisecond, 100*time.Millisecond), func(ctx context.Context) error {
-			_, err := c.client.ContentStore().Info(ctx, img.Digest)
-			if errors.Is(err, errdefs.ErrNotFound) {
-				return nil
-			}
-			if err != nil {
-				return resilient.Unrecoverable(err)
-			}
-			return fmt.Errorf("manifest with digest %s still exists", img.Digest.String())
-		}, resilient.WithLastErrorOnly())
-		if err != nil {
-			return nil, fmt.Errorf("image manifest has not been deleted: %w", err)
-		}
-		// Create delete events for contents that has been removed.
-		events := []store.Event{}
-		for _, ref := range refs {
-			_, err := c.client.ContentStore().Info(ctx, ref.Digest)
-			if err == nil {
-				continue
-			}
-			if !errors.Is(err, errdefs.ErrNotFound) {
-				return nil, err
-			}
-			events = append(events, store.Event{Type: store.DeleteEvent, Digest: ref.Digest})
-		}
-		return events, nil
+		return idx.DiffContent(dgsts), nil
 	default:
 		return nil, fmt.Errorf("unsupported event type %T", evt)
 	}
-}
-
-func walkImage(ctx context.Context, client *client.Client, img oci.Image) ([]oci.Reference, error) {
-	cImgs, err := client.ImageService().List(ctx, fmt.Sprintf(`target.digest==%q`, img.Digest.String()))
-	if err != nil {
-		return nil, err
-	}
-	if len(cImgs) == 0 {
-		return nil, fmt.Errorf("image %s not found", img.String())
-	}
-	refs := []oci.Reference{}
-	handler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		_, err := client.ContentStore().Info(ctx, desc.Digest)
-		if errors.Is(err, errdefs.ErrNotFound) {
-			return nil, images.ErrSkipDesc
-		}
-		if err != nil {
-			return nil, err
-		}
-		ref := oci.Reference{
-			Registry:   img.Registry,
-			Repository: img.Repository,
-			Digest:     desc.Digest,
-		}
-		refs = append(refs, ref)
-		return nil, nil
-	})
-	err = images.Walk(ctx, images.Handlers(handler, images.ChildrenHandler(client.ContentStore())), cImgs[0].Target)
-	if err != nil {
-		return nil, err
-	}
-	return refs, nil
-}
-
-func contentLabelsToReferences(l map[string]string, dgst digest.Digest) ([]oci.Reference, error) {
-	refs := []oci.Reference{}
-	for k, v := range l {
-		if !strings.HasPrefix(k, labels.LabelDistributionSource) {
-			continue
-		}
-		ref := oci.Reference{
-			Registry:   strings.TrimPrefix(k, labels.LabelDistributionSource+"."),
-			Repository: v,
-			Digest:     dgst,
-		}
-		refs = append(refs, ref)
-	}
-	if len(refs) == 0 {
-		return nil, fmt.Errorf("no distribution source labels found for %s", dgst)
-	}
-	return refs, nil
 }
 
 func getContentPath(ctx context.Context, client *client.Client) (string, error) {

--- a/pkg/oci/containerd/containerd_test.go
+++ b/pkg/oci/containerd/containerd_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-openapi/testify/v2/require"
 	"github.com/opencontainers/go-digest"
 
-	"github.com/spegel-org/spegel/pkg/oci"
 	"github.com/spegel-org/spegel/pkg/store"
 )
 
@@ -60,60 +59,4 @@ func TestHandleEvent(t *testing.T) {
 	storeEvts, err = ctrd.handleEvent(t.Context(), events.Envelope{Event: event}, nil)
 	require.EqualError(t, err, "unsupported event type *events.ContainerCreate")
 	require.Empty(t, storeEvts)
-}
-
-func TestContentLabelsToReferences(t *testing.T) {
-	t.Parallel()
-
-	dgst := digest.Digest("foo")
-	tests := []struct {
-		name     string
-		labels   map[string]string
-		expected []oci.Reference
-	}{
-		{
-			name: "one matching",
-			labels: map[string]string{
-				"containerd.io/distribution.source.docker.io": "library/alpine",
-			},
-			expected: []oci.Reference{
-				{
-					Registry:   "docker.io",
-					Repository: "library/alpine",
-					Digest:     dgst,
-				},
-			},
-		},
-		{
-			name: "multiple matching",
-			labels: map[string]string{
-				"containerd.io/distribution.source.example.com": "foo",
-				"containerd.io/distribution.source.ghcr.io":     "spegel-org/spegel",
-			},
-			expected: []oci.Reference{
-				{
-					Registry:   "ghcr.io",
-					Repository: "spegel-org/spegel",
-					Digest:     dgst,
-				},
-				{
-					Registry:   "example.com",
-					Repository: "foo",
-					Digest:     dgst,
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(t.Name(), func(t *testing.T) {
-			t.Parallel()
-
-			refs, err := contentLabelsToReferences(tt.labels, dgst)
-			require.NoError(t, err)
-			require.ElementsMatchT(t, tt.expected, refs)
-		})
-	}
-
-	_, err := contentLabelsToReferences(map[string]string{}, dgst)
-	require.EqualError(t, err, "no distribution source labels found for foo")
 }

--- a/pkg/oci/containerd/index.go
+++ b/pkg/oci/containerd/index.go
@@ -1,0 +1,73 @@
+package containerd
+
+import (
+	"maps"
+
+	"github.com/opencontainers/go-digest"
+
+	"github.com/spegel-org/spegel/pkg/oci"
+	"github.com/spegel-org/spegel/pkg/store"
+)
+
+type Index struct {
+	tagNames map[string]digest.Digest
+	contents map[digest.Digest]any
+}
+
+func NewIndex() *Index {
+	return &Index{
+		tagNames: map[string]digest.Digest{},
+		contents: map[digest.Digest]any{},
+	}
+}
+
+func (idx *Index) AddImage(img oci.Image) []store.Event {
+	tagName, ok := img.TagName()
+	if !ok {
+		return nil
+	}
+	dgst, ok := idx.tagNames[tagName]
+	if dgst != img.Digest {
+		idx.tagNames[tagName] = img.Digest
+	}
+	if ok {
+		return nil
+	}
+	return []store.Event{{Type: store.CreateEvent, Reference: tagName}}
+}
+
+func (idx *Index) RemoveImage(img oci.Image) []store.Event {
+	tagName, ok := img.TagName()
+	if !ok {
+		return nil
+	}
+	if _, ok := idx.tagNames[tagName]; !ok {
+		return nil
+	}
+	delete(idx.tagNames, tagName)
+	return []store.Event{{Type: store.DeleteEvent, Reference: tagName}}
+}
+
+func (idx *Index) AddContent(dgst digest.Digest) []store.Event {
+	if _, ok := idx.contents[dgst]; ok {
+		return nil
+	}
+	idx.contents[dgst] = nil
+	return []store.Event{{Type: store.CreateEvent, Digest: dgst}}
+}
+
+func (idx *Index) DiffContent(dgsts []digest.Digest) []store.Event {
+	contents := map[digest.Digest]any{}
+	deleted := maps.Clone(idx.contents)
+	for _, dgst := range dgsts {
+		delete(deleted, dgst)
+		contents[dgst] = nil
+	}
+	idx.contents = contents
+
+	events := []store.Event{}
+	for dgst := range deleted {
+		events = append(events, store.Event{Type: store.DeleteEvent, Digest: dgst})
+	}
+	return events
+}

--- a/pkg/routing/sync.go
+++ b/pkg/routing/sync.go
@@ -44,20 +44,21 @@ func handleEvents(ctx context.Context, router Router, events []store.Event) erro
 	advertise := []string{}
 	withdraw := []string{}
 	for _, event := range events {
-		if event.Digest == "" {
-			return errors.New("received event with empty digest")
-		}
 		switch event.Type {
 		case store.CreateEvent:
 			if event.Reference != "" {
 				advertise = append(advertise, event.Reference)
 			}
-			advertise = append(advertise, event.Digest.String())
+			if event.Digest != "" {
+				advertise = append(advertise, event.Digest.String())
+			}
 		case store.DeleteEvent:
 			if event.Reference != "" {
 				withdraw = append(withdraw, event.Reference)
 			}
-			withdraw = append(withdraw, event.Digest.String())
+			if event.Digest != "" {
+				withdraw = append(withdraw, event.Digest.String())
+			}
 		default:
 			return fmt.Errorf("unhandled event type %s", event.Type)
 		}

--- a/test/integration/containerd/containerd_test.go
+++ b/test/integration/containerd/containerd_test.go
@@ -140,7 +140,8 @@ func TestContainerdPull(t *testing.T) {
 			_, err = imageClient.PullImage(t.Context(), &runtimeapi.PullImageRequest{Image: &runtimeapi.ImageSpec{Image: "ghcr.io/spegel-org/spegel:v0.7.4"}})
 			require.NoError(t, err)
 			expectedInitial := []store.Event{
-				{Type: store.CreateEvent, Reference: "ghcr.io/spegel-org/spegel:v0.7.4", Digest: "sha256:26c60b05e08ac738e8442bc389c5780bff0e1d8153956e45d810a2f1008cf56f"},
+				{Type: store.CreateEvent, Reference: "ghcr.io/spegel-org/spegel:v0.7.4"},
+				{Type: store.CreateEvent, Digest: "sha256:26c60b05e08ac738e8442bc389c5780bff0e1d8153956e45d810a2f1008cf56f"},
 				{Type: store.CreateEvent, Digest: "sha256:cfa0b07068007bc283828f25ee6a128c81052857b9c1efc93c4dc596ed895b6a"},
 				{Type: store.CreateEvent, Digest: "sha256:e7a777e36197ea8d4ce50cb206cfb238986e3462fa5b1f3c28cbbfb5c5128431"},
 				{Type: store.CreateEvent, Digest: "sha256:1eed391ea893e6015bf4ce4ed366909975d2acdbe907670919236a8d18ea6b07"},
@@ -162,10 +163,10 @@ func TestContainerdPull(t *testing.T) {
 			providerCfg := storetest.ProviderConfig{
 				Name:               "containerd",
 				NotFoundRef:        "dummy",
-				ExistingRef:        "ghcr.io/spegel-org/spegel:v0.7.4",
-				ExistingRefDigest:  expectedInitial[0].Digest,
+				ExistingRef:        expectedInitial[0].Reference,
+				ExistingRefDigest:  expectedInitial[1].Digest,
 				NotFoundDigest:     digest.FromBytes(nil),
-				ExistingDescriptor: store.Descriptor{Digest: expectedInitial[0].Digest, Size: 2385, MediaType: ocispec.MediaTypeImageIndex},
+				ExistingDescriptor: store.Descriptor{Digest: expectedInitial[1].Digest, Size: 2385, MediaType: ocispec.MediaTypeImageIndex},
 			}
 			storetest.ProviderConformance(t, ctrd, providerCfg)
 
@@ -219,8 +220,6 @@ func TestContainerdPull(t *testing.T) {
 					require.EqualT(t, imgs[0].Digest, dgst)
 				}
 
-				time.Sleep(1 * time.Second)
-
 				t.Log("Deleting image with CRI", benchmarkImg.String())
 				_, err = imageClient.RemoveImage(t.Context(), &runtimeapi.RemoveImageRequest{Image: &runtimeapi.ImageSpec{Image: benchmarkImg.String()}})
 				require.NoError(t, err)
@@ -245,7 +244,7 @@ func TestContainerdPull(t *testing.T) {
 			missingInitial, missingCh, err := ctrd.Watch(missingCtx)
 			require.NoError(t, err)
 			require.NotEmpty(t, missingInitial)
-			require.Len(t, missingInitial, 6)
+			require.Len(t, missingInitial, 7)
 			require.NotContains(t, missingInitial, store.Event{Type: store.CreateEvent, Digest: missingDgst})
 
 			missingCancel()


### PR DESCRIPTION
This refactors the Containerd event handling to remove the need for image content tracking which was unstable. This comes at the cost of the logic being a bit more dumb and verbose. We handle more events and do a bit more event lookup s but these should be relatively cheap as the client is local and content diffing are single loops.

The reason we need to check over and over again for delete content is because we dont have a properly working delete event. This problem is described in more detail in https://github.com/containerd/containerd/issues/14018. Until this is resolved the additional lookups is a acceptable tradeoff.

The downside of this solution is that we cant determine what registry content belongs to, so we cant do any filtering. The filtering has to instead be completely done at registry level instead. Once we get the needed event information in Containerd we can reconsider this logic.

This should also solve #1096 but we should first add a test before closing the issue.