### PR TITLE
Refactor list images to allow tags to same digest

### DIFF
--- a/pkg/oci/containerd/containerd.go
+++ b/pkg/oci/containerd/containerd.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"slices"
 
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/v2/client"
@@ -128,31 +127,34 @@ func (c *Containerd) ListImages(ctx context.Context) ([]oci.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	tagDgsts := map[digest.Digest]string{}
+
+	seen := map[string]any{}
 	imgs := []oci.Image{}
+	dgstImgs := []oci.Image{}
 	for _, cImg := range cImgs {
 		img, err := oci.ParseImage(cImg.Name, oci.WithDigest(cImg.Target.Digest))
 		if err != nil {
-			return nil, err
-		}
-		if img.Tag != "" {
-			tagDgsts[img.Digest] = img.Tag
+			logr.FromContextOrDiscard(ctx).Error(err, "could not parse image name", "name", cImg.Name)
+			continue
 		}
 		if oci.MatchesFilter(img.Reference, c.filters) {
 			continue
 		}
+		if _, ok := img.TagName(); ok {
+			dgstName, _ := img.DigestName()
+			seen[dgstName] = nil
+			imgs = append(imgs, img)
+			continue
+		}
+		dgstImgs = append(dgstImgs, img)
+	}
+	for _, img := range dgstImgs {
+		dgstName, _ := img.DigestName()
+		if _, ok := seen[dgstName]; ok {
+			continue
+		}
 		imgs = append(imgs, img)
 	}
-	// Remove duplicate digest images that already have tags.
-	imgs = slices.DeleteFunc(imgs, func(img oci.Image) bool {
-		if img.Tag != "" {
-			return false
-		}
-		if _, ok := tagDgsts[img.Digest]; ok {
-			return true
-		}
-		return false
-	})
 	return imgs, nil
 }
 

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -45,6 +45,14 @@ func (i Image) TagName() (string, bool) {
 	return fmt.Sprintf("%s/%s:%s", i.Registry, i.Repository, i.Tag), true
 }
 
+// DigestName returns the full tag reference string if digest is set.
+func (i Image) DigestName() (string, bool) {
+	if i.Tag == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s/%s@%s", i.Registry, i.Repository, i.Digest), true
+}
+
 // DistributionPath returns the distribution path for the images top layer.
 func (i Image) DistributionPath(scheme, method string) (DistributionPath, error) {
 	ref := i.Reference


### PR DESCRIPTION
This fixes some issues in list images which would ignore images when different tags are used for the same digest.

Fixes #1495