### PR TITLE
Revert temporary 1.33 compatibility fix.

### DIFF
--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -46,7 +46,6 @@ Read the [getting started](https://spegel.dev/docs/getting-started/) guide to de
 | service.metrics.annotations | object | `{}` | Annotations to add to the metrics service |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |
 | service.registry.annotations | object | `{}` | Annotations to add to the registry service |
-| service.registry.internalTrafficLocal | bool | `false` | Enable internalTrafficPolicy: Local. This is only for 1.33 clusters compatibility instead of PreferSameNode. |
 | service.registry.nodeIp | string | `""` | Override the NODE_ID environment variable. It defaults to the field status.hostIP |
 | service.registry.nodePort | int | `30020` | Node port to expose the registry via the service. |
 | service.registry.port | int | `5000` | Port to expose the registry via the service. |

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -33,11 +33,7 @@ metadata:
   {{- end }}
 spec:
   type: NodePort
-  {{- if .Values.service.registry.internalTrafficLocal }}
-  internalTrafficPolicy: Local
-  {{- else }}
   trafficDistribution: PreferSameNode
-  {{- end }}
   selector:
     app.kubernetes.io/component: spegel
     {{- include "spegel.selectorLabels" . | nindent 4 }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -51,8 +51,6 @@ service:
     nodePort: 30020
     # -- Annotations to add to the registry service
     annotations: {}
-    # -- Enable internalTrafficPolicy: Local. This is only for 1.33 clusters compatibility instead of PreferSameNode.
-    internalTrafficLocal: false
 
   router:
     # -- Port to expose the router via the service.


### PR DESCRIPTION
Kubernetes 1.37 has been released which means that supporting 1.33 isn't something we can do anymore. Changes in #1374 were added thinking that a release of Spegel would happen before 1.37 which didn't. So we are removing it before the next release.