### PR TITLE
Remove bootstrap run from bootstrappers

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ type ConfigurationCmd struct {
 type BootstrapConfig struct {
 	BootstrapKind        string   `arg:"--bootstrap-kind,env:BOOTSTRAP_KIND" help:"Kind of bootsrapper to use."`
 	DNSBootstrapDomain   string   `arg:"--dns-bootstrap-domain,env:DNS_BOOTSTRAP_DOMAIN" help:"Domain to use when bootstrapping using DNS."`
-	HTTPBootstrapAddr    string   `arg:"--http-bootstrap-addr,env:HTTP_BOOTSTRAP_ADDR" help:"Address to serve for HTTP bootstrap at /id. Leave it empty to disable serving."`
 	HTTPBootstrapURL     url.URL  `arg:"--http-bootstrap-url,env:HTTP_BOOTSTRAP_URL" help:"Full URL of an HTTP bootstrap endpoint."`
 	HTTPBootstrapCertDir string   `arg:"--http-bootstrap-cert-dir,env:HTTP_BOOTSTRAP_CERT_DIR" help:"Path to directory containing CA and TLS certificate."`
 	StaticBootstrapPeers []string `arg:"--static-bootstrap-peers,env:STATIC_BOOTSTRAP_PEERS" help:"Static list of peers to bootstrap with."`
@@ -344,7 +343,7 @@ func getBootstrapper(cfg BootstrapConfig) (libp2p.Bootstrapper, error) { //nolin
 		if err != nil {
 			return nil, err
 		}
-		return libp2p.NewHTTPBootstrapper(cfg.HTTPBootstrapAddr, cfg.HTTPBootstrapURL, pool, cert)
+		return libp2p.NewHTTPBootstrapper(cfg.HTTPBootstrapURL, pool, cert)
 	case "static":
 		return libp2p.NewStaticBootstrapperFromStrings(cfg.StaticBootstrapPeers)
 	default:

--- a/pkg/routing/libp2p/bootstrap.go
+++ b/pkg/routing/libp2p/bootstrap.go
@@ -13,21 +13,16 @@ import (
 	"net/url"
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
-
-	"github.com/kvick-org/pkg/errgroup"
 
 	"github.com/spegel-org/spegel/pkg/httpx"
 )
 
 // Bootstrapper resolves peers to bootstrap with for the P2P router.
 type Bootstrapper interface {
-	// Run starts the bootstrap process. Should be blocking even if not needed.
-	Run(ctx context.Context, addrInfo peer.AddrInfo) error
 	// Get returns a list of peers that should be used as bootstrap nodes.
 	// If the peer ID is empty it will be resolved.
 	// If the address is missing a port the P2P router port will be used.
@@ -59,11 +54,6 @@ func NewStaticBootstrapper(peers []peer.AddrInfo) *StaticBootstrapper {
 	}
 }
 
-func (b *StaticBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) error {
-	<-ctx.Done()
-	return nil
-}
-
 func (b *StaticBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
 	b.mx.RLock()
 	defer b.mx.RUnlock()
@@ -88,11 +78,6 @@ func NewDNSBootstrapper(host string) *DNSBootstrapper {
 		resolver: &net.Resolver{},
 		host:     host,
 	}
-}
-
-func (b *DNSBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) error {
-	<-ctx.Done()
-	return nil
 }
 
 func (b *DNSBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {
@@ -135,12 +120,11 @@ var _ Bootstrapper = &HTTPBootstrapper{}
 // HTTPBootstrapper resolves bootstrap peers over HTTP.
 type HTTPBootstrapper struct {
 	httpClient *http.Client
-	addr       string
 	endpoint   string
 }
 
 // NewHTTPBootstrapper creates an HTTP bootstrapper.
-func NewHTTPBootstrapper(addr string, bootstrapURL url.URL, pool *x509.CertPool, cert *tls.Certificate) (*HTTPBootstrapper, error) {
+func NewHTTPBootstrapper(bootstrapURL url.URL, pool *x509.CertPool, cert *tls.Certificate) (*HTTPBootstrapper, error) {
 	transport := httpx.BaseTransport()
 	if pool != nil || cert != nil {
 		tlsConfig := &tls.Config{
@@ -157,44 +141,8 @@ func NewHTTPBootstrapper(addr string, bootstrapURL url.URL, pool *x509.CertPool,
 
 	return &HTTPBootstrapper{
 		httpClient: client,
-		addr:       addr,
 		endpoint:   bootstrapURL.String(),
 	}, nil
-}
-
-func (bs *HTTPBootstrapper) Run(ctx context.Context, addrInfo peer.AddrInfo) error {
-	if bs.addr == "" {
-		<-ctx.Done()
-		return nil
-	}
-	b, err := json.Marshal([]peer.AddrInfo{addrInfo})
-	if err != nil {
-		return err
-	}
-	group := errgroup.WithContext(ctx)
-	mux := http.NewServeMux()
-	mux.HandleFunc("/id", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		//nolint:errcheck // ignore
-		w.Write(b)
-	})
-	srv := &http.Server{
-		Addr:    bs.addr,
-		Handler: mux,
-	}
-	group.Go(func(ctx context.Context) error {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return err
-		}
-		return nil
-	})
-	group.Go(func(ctx context.Context) error {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		return srv.Shutdown(shutdownCtx)
-	})
-	return group.Wait()
 }
 
 func (bs *HTTPBootstrapper) Get(ctx context.Context) ([]peer.AddrInfo, error) {

--- a/pkg/routing/libp2p/bootstrap_test.go
+++ b/pkg/routing/libp2p/bootstrap_test.go
@@ -40,27 +40,15 @@ func TestStaticBootstrap(t *testing.T) {
 		},
 	}
 	bs := NewStaticBootstrapper(peers)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	group := errgroup.WithContext(ctx)
-	group.Go(func(ctx context.Context) error {
-		return bs.Run(ctx, peer.AddrInfo{})
-	})
-
 	bsPeers, err := bs.Get(t.Context())
 	require.NoError(t, err)
 	require.ElementsMatch(t, peers, bsPeers)
-
-	cancel()
-	err = group.Wait()
-	require.NoError(t, err)
 }
 
 func TestDNSBootstrap(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(t.Context())
-	group := errgroup.WithContext(ctx)
+	group := errgroup.WithContext(t.Context())
 
 	rr, err := dns.NewRR("example.com. 30 IN A 10.1.2.3")
 	require.NoError(t, err)
@@ -95,67 +83,15 @@ func TestDNSBootstrap(t *testing.T) {
 			return net.Dial("udp", pc.LocalAddr().String())
 		},
 	}
-	group.Go(func(ctx context.Context) error {
-		return bs.Run(ctx, peer.AddrInfo{})
-	})
-	addrInfos, err := bs.Get(ctx)
+	addrInfos, err := bs.Get(t.Context())
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
 	require.Len(t, addrInfos[0].Addrs, 1)
 	require.EqualT(t, "{: [/ip4/10.1.2.3]}", addrInfos[0].String())
-
-	cancel()
-	err = group.Wait()
-	require.NoError(t, err)
 }
 
 func TestHTTPBootstrap(t *testing.T) {
 	t.Parallel()
-
-	//nolint:noctx // Context not important for testing.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	err = ln.Close()
-	require.NoError(t, err)
-	parentAddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
-	require.NoError(t, err)
-	id, err := peer.Decode("12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB")
-	require.NoError(t, err)
-	parentAddrInfo := peer.AddrInfo{
-		ID:    id,
-		Addrs: []ma.Multiaddr{parentAddr},
-	}
-	bootstrapURL, err := url.Parse("http://" + ln.Addr().String() + "/id")
-	require.NoError(t, err)
-	parentBs, err := NewHTTPBootstrapper(ln.Addr().String(), *bootstrapURL, nil, nil)
-	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(t.Context())
-	group := errgroup.WithContext(ctx)
-	group.Go(func(ctx context.Context) error {
-		return parentBs.Run(ctx, parentAddrInfo)
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	childBs, err := NewHTTPBootstrapper("", *bootstrapURL, nil, nil)
-	require.NoError(t, err)
-	addrInfos, err := childBs.Get(t.Context())
-	require.NoError(t, err)
-	require.Len(t, addrInfos, 1)
-	require.Len(t, addrInfos[0].Addrs, 1)
-	require.EqualT(t, parentAddrInfo.ID, addrInfos[0].ID)
-	require.EqualT(t, "{12D3KooWAsvvigG9jqjMNWMmqXph6BvszxTus6Fg6k5UZda2iKDB: [/ip4/127.0.0.1/tcp/4001]}", addrInfos[0].String())
-
-	cancel()
-	err = group.Wait()
-	require.NoError(t, err)
-}
-
-func TestHTTPBootstrapEndpoint(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	group := errgroup.WithContext(ctx)
 
 	now := time.Now()
 
@@ -249,20 +185,12 @@ func TestHTTPBootstrapEndpoint(t *testing.T) {
 
 	srvUrl, err := url.Parse(srv.URL)
 	require.NoError(t, err)
-	bs, err := NewHTTPBootstrapper("", *srvUrl, pool, &clientTLSCert)
+	bs, err := NewHTTPBootstrapper(*srvUrl, pool, &clientTLSCert)
 	require.NoError(t, err)
 
-	group.Go(func(ctx context.Context) error {
-		return bs.Run(ctx, peer.AddrInfo{})
-	})
-
-	addrInfos, err := bs.Get(ctx)
+	addrInfos, err := bs.Get(t.Context())
 	require.NoError(t, err)
 	require.Len(t, addrInfos, 1)
 	require.Len(t, addrInfos[0].Addrs, 1)
 	require.Equal(t, "{: [/ip4/10.1.2.3]}", addrInfos[0].String())
-
-	cancel()
-	err = group.Wait()
-	require.NoError(t, err)
 }

--- a/pkg/routing/libp2p/libp2p.go
+++ b/pkg/routing/libp2p/libp2p.go
@@ -36,8 +36,6 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/kvick-org/pkg/errgroup"
-
 	"github.com/spegel-org/spegel/internal/channel"
 	"github.com/spegel-org/spegel/internal/option"
 	"github.com/spegel-org/spegel/internal/resilient"
@@ -216,15 +214,7 @@ func (r *Router) Run(ctx context.Context) error {
 	log := logr.FromContextOrDiscard(ctx).WithName("p2p")
 	log.Info("starting p2p router", "id", r.host.ID())
 
-	group := errgroup.WithContext(ctx)
-	group.Go(func(ctx context.Context) error {
-		err := r.bootstrapper.Run(ctx, *host.InfoFromHost(r.host))
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	group.Go(func(ctx context.Context) error {
+	err := func() error {
 		for {
 			select {
 			case <-ctx.Done():
@@ -263,10 +253,8 @@ func (r *Router) Run(ctx context.Context) error {
 				}
 			}
 		}
-	})
-
+	}()
 	errs := []error{}
-	err := group.Wait()
 	if err != nil {
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
Bootstrap run was used back when leader election was used for bootstrapping. It was kept mostly for the HTTP bootstrapper. It was a bit verbose for bootstrappers that dont need to run. The only user of HTTP bootstrap doesn't need the self broadcasting so there is no need to keep a feature that is not in use.